### PR TITLE
CMS-356: Add README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,45 @@
-# parks-staff-portal
+# BC Parks Staff Portal
+
+Expanding and modernizing the BC Parks Dates of Operation tool.
+
+## Structure
+
+This project consists of a REST API server in `backend/` and a React JS frontend in `frontend/`. For more details, refer to the specific [backend README](./backend/README.md) and [frontend README](./frontend/README.md) files.
+
+## Requirements
+
+This project is intended to be developed in VS Code Dev Containers. You will need VS Code and Docker installed on your host machine.
+
+When you open this workspace, VS Code should prompt you to install the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) if you don't already have it.
+
+All necessary dependencies are included in the Dev Containers. However, if you plan to edit the configuration files in the project root on your host machine, it's recommended to have Prettier, ESLint, and EditorConfig installed. See `/.vscode/extensions.json` for details.
+
+If you plan to run the project locally, outside of Docker, you'll need Node.js installed. Check the `engines` field in each `package.json` file for the required version.
+
+## Dev Containers
+
+When you open the project's root directory in VS Code, you should be prompted to open the project in a Dev Container. You can choose to open the `frontend` or `backend` container.
+
+The containers are managed by `/docker-compose.dev.yml`, so opening one container will start all of them.
+
+Use the command palette (`F1` or `CTRL+SHIFT+P`) in VS Code to work with the containers. The Dev Containers extension also adds a menu button to the bottom-left corner of the status bar.
+
+### Recommended Dev Containers workflow
+
+The servers do not automatically start in the containers, so you'll need to start them manually.
+
+1. Open the project root locally in VS Code.
+2. **Dev Containers: Reopen in Container** - then select `backend`.
+3. **New Window** - Open a new VS Code window and reopen the project root.
+4. **Dev Containers: Reopen in Container** - then select `frontend`.
+
+Now you'll have two VS Code windows open, each with a Dev Container for a different part of the app. Refer to the [backend README](./backend/README.md) and [frontend README](./frontend/README.md) for details on starting the dev servers (e.g., `npm run dev` in the integrated terminal).
+
+The Dev Containers will not shut down automatically. This is so the containers don't stop when you close one window. You can manually stop them in Docker Desktop by clicking the Stop button in the Actions column.
+
+Alternatively, you can stop the project's containers from the command line with `docker compose`:
+
+```sh
+# Stop the dev containers
+docker compose -f docker-compose.dev.yml stop
+```

--- a/backend/README.md
+++ b/backend/README.md
@@ -34,3 +34,7 @@ npm run dev
 ```
 
 To manually restart the `nodemon` process, type `rs<enter>` in the terminal. (Or stop it with `CTRL+C` and run `npm run dev` again.)
+
+### Code formatting
+
+The Dev Container is configured with Prettier and ESLint. Code will be automatically formatted on save.

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,36 @@
+# Backend - REST API server
+
+This directory contains the code for the backend REST API server built with Express.
+
+## Project structure
+
+- `index.js`: The entry point of the server.
+- `routes/`: Directory containing endpoint route handlers.
+- `db/`: Directory for Sequelize models and database interactions.
+
+## Setup
+
+### Development environment
+
+This workspace is set up to open in a Dev Container. All necessary dependencies, including Node.js, are pre-installed in the container. See the [README in root workspace](../README.md) for details about the Dev Containers workflow.
+
+### Installation
+
+Inside the dev container, install the project dependencies with `npm`:
+
+```sh
+npm install
+```
+
+### Running the server
+
+#### Development
+
+The Express server runs in development mode with `nodemon`. The server will automatically restart when you save a file.
+
+```sh
+# Start the server with nodemon
+npm run dev
+```
+
+To manually restart the `nodemon` process, type `rs<enter>` in the terminal. (Or stop it with `CTRL+C` and run `npm run dev` again.)

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "backend-placeholder",
+  "name": "staff-portal-backend",
   "version": "1.0.0",
   "description": "placeholder code for the eventual node REST API",
   "main": "index.js",

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,8 +1,34 @@
-# React + Vite
+# Frontend - React application
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+This directory contains the code for the frontend Staff Portal web application, built with React.
 
-Currently, two official plugins are available:
+## Project structure
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react/README.md) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+- `src/`: Directory containing the main application code.
+- `public/`: Directory for static assets.
+- `vite.config.js`: Configuration file for Vite, the build tool.
+
+## Setup
+
+### Development environment
+
+This workspace is set up to open in a Dev Container. All necessary dependencies, including Node.js, are pre-installed in the container. See the [README in root workspace](../README.md) for details about the Dev Containers workflow.
+
+### Installation
+
+Inside the dev container, install the project dependencies with `npm`:
+
+```sh
+npm install
+```
+
+### Running the app
+
+#### Development
+
+The React app runs in development mode with `Vite`. The app will automatically update with Hot Module Replacement when you save a file.
+
+```sh
+# Start the dev server with HMR
+npm run dev
+```

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -32,3 +32,7 @@ The React app runs in development mode with `Vite`. The app will automatically u
 # Start the dev server with HMR
 npm run dev
 ```
+
+### Code formatting
+
+The Dev Container is configured with Prettier and ESLint. Code will be automatically formatted on save.


### PR DESCRIPTION
### Jira Ticket

CMS-356

### Description
<!-- What did you change, and why? -->

This adds README files to the root directory and the frontend and backend dev container directories, which are the three workspaces you'd open up for this project. The three files link back and forth between each other (hopefully).

I set the project up piece-by-piece but it would be very helpful to hear from you about anything that might be missing or unclear in the documentation for someone who has just cloned the repo. 🙏  Let me know!