### PR TITLE
CMS-321: Protect entire routes with Keycloak

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -39,9 +39,11 @@ const limiter = RateLimit({
 
 app.use(limiter);
 
-// add routes
+// Public routes
 app.use("/", homeRoutes); // example stuff for testing
-app.use("/nested-path-example/", ormTestRoutes); // example stuff for testing
+
+// Routes with JWT check middleware
+app.use("/nested-path-example/", checkJwt, ormTestRoutes); // example stuff for testing
 app.use("/nested-path-example/", checkJwt, helloRoute); // example stuff for testing
 
 // error handling middleware

--- a/backend/routes/nested-path-example/orm.js
+++ b/backend/routes/nested-path-example/orm.js
@@ -1,41 +1,8 @@
 import DbRow from "../../db/models/DbRow.js";
 import { Router } from "express";
 import asyncHandler from "express-async-handler";
-import checkJwt from "../../middleware/checkJwt.js";
 
 const router = Router();
-
-const routeHandler = asyncHandler(async (req, res) => {
-  const { rowId } = req.params;
-
-  const allRows = await DbRow.findAll();
-  const specificRow = await DbRow.findByPk(rowId);
-
-  if (!specificRow) {
-    throw new Error(`Requested row does not exist: ${rowId}`);
-  }
-
-  res.json({ rowId, specificRow, numRows: allRows.length });
-});
-
-// example with Sequelize ORM 🔒 protected by Keycloak
-// http://0.0.0.0:8100/nested-path-example/orm-2
-router.get(
-  "/orm-2",
-
-  // protect this route with JWT authentication
-  checkJwt,
-
-  // manually set the URL parameter to 2 since this hardcoded example route doesn't use a parameter
-  (req, res, next) => {
-    req.params.rowId = 2;
-    next();
-  },
-
-  // wrap in asyncHandler so thrown errors are caught and handled by Express
-  // without needing to manually try/catch and call next(err)
-  routeHandler,
-);
 
 // example with Sequelize ORM
 // http://0.0.0.0:8100/nested-path-example/orm-1
@@ -44,7 +11,18 @@ router.get(
   "/orm-:rowId",
   // wrap in asyncHandler so thrown errors are caught and handled by Express
   // without needing to manually try/catch and call next(err)
-  routeHandler,
+  asyncHandler(async (req, res) => {
+    const { rowId } = req.params;
+
+    const allRows = await DbRow.findAll();
+    const specificRow = await DbRow.findByPk(rowId);
+
+    if (!specificRow) {
+      throw new Error(`Requested row does not exist: ${rowId}`);
+    }
+
+    res.json({ rowId, specificRow, numRows: allRows.length });
+  }),
 );
 
 export default router;

--- a/frontend/src/config/keycloak.js
+++ b/frontend/src/config/keycloak.js
@@ -7,9 +7,7 @@ export default {
   // Automatically renew the access token before it expires
   automaticSilentRenew: true,
 
-  onSigninCallback(user) {
-    console.log("onSigninCallback", user);
-
+  onSigninCallback() {
     window.history.replaceState({}, document.title, window.location.pathname);
   },
 };

--- a/frontend/src/router/ProtectedRoute.jsx
+++ b/frontend/src/router/ProtectedRoute.jsx
@@ -1,0 +1,24 @@
+import { withAuthenticationRequired } from "react-oidc-context";
+import PropTypes from "prop-types";
+
+// Higher-order component that wraps a route component for authentication
+// Wrap a "layout" component in this component to protect all of its children
+export default function ProtectedRoute({
+  component: Component,
+  ...otherProps
+}) {
+  if (!Component) {
+    throw new Error("Component prop is required");
+  }
+
+  const ComponentWithAuth = withAuthenticationRequired(Component, {
+    onRedirecting: () => <div>Redirecting you to log in...</div>,
+  });
+
+  return <ComponentWithAuth {...otherProps} />;
+}
+
+// Define prop types for ProtectedRoute
+ProtectedRoute.propTypes = {
+  component: PropTypes.elementType.isRequired,
+};

--- a/frontend/src/router/index.jsx
+++ b/frontend/src/router/index.jsx
@@ -4,11 +4,13 @@ import MainLayout from "./layouts/MainLayout";
 import ErrorPage from "./pages/Error";
 import Foo from "./pages/Foo";
 import Bar from "./pages/Bar";
+import ProtectedRoute from "./ProtectedRoute";
 
 const RouterConfig = createBrowserRouter([
   {
     path: "/",
-    element: <MainLayout />,
+    // Protect the entire app with the AuthProvider
+    element: <ProtectedRoute component={MainLayout} />,
     errorElement: <ErrorPage />,
     children: [
       {

--- a/frontend/src/router/layouts/MainLayout.jsx
+++ b/frontend/src/router/layouts/MainLayout.jsx
@@ -34,10 +34,10 @@ export default function MainLayout() {
                 <Link to={`/`}>Home page</Link>
               </li>
               <li>
-                <Link to={`/foo/A`}>🔒 Foo page A</Link>
+                <Link to={`/foo/A`}>Foo page A</Link>
               </li>
               <li>
-                <Link to={`/foo/B`}>🔒 Foo page B</Link>
+                <Link to={`/foo/B`}>Foo page B</Link>
               </li>
               <li>
                 <Link to={`/bar`}>Bar page</Link>

--- a/frontend/src/router/pages/Foo.jsx
+++ b/frontend/src/router/pages/Foo.jsx
@@ -25,16 +25,12 @@ function AuthTest() {
     return (
       <div>
         Hello, {auth.user?.profile.name} <br />
-        You&rsquo;re logged in and your keycloak ID is {
-          auth.user?.profile.sub
-        }{" "}
-        <br />
-        <button onClick={() => void auth.signoutRedirect()}>Log out</button>
+        You&rsquo;re logged in and your keycloak ID is {auth.user?.profile.sub}
       </div>
     );
   }
 
-  return <button onClick={() => void auth.signinRedirect()}>Log in</button>;
+  return <div>Protected content</div>;
 }
 
 export default function FooPage() {


### PR DESCRIPTION
### Jira Ticket

CMS-321

### Description
<!-- What did you change, and why? -->

Expanding on #9 , this changes the page-specific and section-specific auth to protect the entire frontend app, and all the endpoints on the backend (except`/` and the `/time` testing endpoint in the root).

On the frontend, there's no explicit log in/out buttons. If you're not logged in, it will forward you to Keycloak instead of showing anything.

On the backend, it will continue rejecting requests with `401` if you don't send a valid token.