### PR TITLE
CMS-416: Clear session storage on log out

### DIFF
--- a/frontend-legacy/src/components/page/home/Home.js
+++ b/frontend-legacy/src/components/page/home/Home.js
@@ -14,6 +14,14 @@ export default function Home({ page: { setError } }) {
   useEffect(() => {
     if (initialized && keycloak.authenticated) {
       setToDashboard(true);
+    } else {
+      // If the user is logged out,
+      // Remove keycloak tokens from session storage (used by the v2 staff portal).
+      Object.keys(sessionStorage).forEach((key) => {
+        if (key.startsWith("oidc.")) {
+          sessionStorage.removeItem(key);
+        }
+      });
     }
   }, [initialized, keycloak]);
 


### PR DESCRIPTION
### Jira Ticket

CMS-416

### Description
<!-- What did you change, and why? -->

Now that the new app is running alongside the old Staff Portal sections on the same domain, we noticed that logging out of the old portal won't log you out of the new one. (The new one uses SessionStorage and the old one uses cookies and possibly LocalStorage). This branch is a quick fix to clear SessionStorage on the home page when you're logged out. 

A more comprehensive solution would be to make both sections use the same auth provider, and share the same storage location and tokens. TBD, but this might be worth doing to avoid possible hassles down the road.