### PR TITLE
CMS-425: Add Publish and Export pages

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
         "@bcgov/design-tokens": "^3.1.1",
         "@digitalspace/bcparks-bootstrap-theme": "^1.4.6",
         "@fortawesome/fontawesome-svg-core": "^6.6.0",
+        "@fortawesome/free-regular-svg-icons": "^6.6.0",
         "@fortawesome/free-solid-svg-icons": "^6.6.0",
         "@fortawesome/react-fontawesome": "^0.2.2",
         "@reduxjs/toolkit": "^2.2.7",
@@ -711,6 +712,18 @@
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.6.0.tgz",
       "integrity": "sha512-KHwPkCk6oRT4HADE7smhfsKudt9N/9lm6EJ5BVg0tD1yPA5hht837fB87F8pn15D8JfTqQOjhKTktwmLMiD7Kg==",
       "license": "MIT",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.6.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-regular-svg-icons": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-6.6.0.tgz",
+      "integrity": "sha512-Yv9hDzL4aI73BEwSEh20clrY8q/uLxawaQ98lekBx6t9dQKDHcDzzV1p2YtBGTtolYtNqcWdniOnhzB+JPnQEQ==",
+      "license": "(CC-BY-4.0 AND MIT)",
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "6.6.0"
       },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "@bcgov/design-tokens": "^3.1.1",
     "@digitalspace/bcparks-bootstrap-theme": "^1.4.6",
     "@fortawesome/fontawesome-svg-core": "^6.6.0",
+    "@fortawesome/free-regular-svg-icons": "^6.6.0",
     "@fortawesome/free-solid-svg-icons": "^6.6.0",
     "@fortawesome/react-fontawesome": "^0.2.2",
     "@reduxjs/toolkit": "^2.2.7",

--- a/frontend/src/global.scss
+++ b/frontend/src/global.scss
@@ -8,16 +8,9 @@
 
 // Custom styles
 header.page-header {
-  background-color: var(--surface-color-background-light-blue);
-  padding-inline: var(--layout-padding-large);
   padding-block: var(--layout-padding-medium);
   margin-bottom: var(--layout-padding-xlarge);
-
-  &.internal {
-    background: none;
-    padding-inline: 0;
-    border-bottom: 1px solid var(--surface-color-border-default);
-  }
+  border-bottom: 1px solid var(--surface-color-border-default);
 }
 
 // append search icon appended
@@ -29,11 +22,24 @@ header.page-header {
     padding-right: calc(1.5em + 0.75rem);
   }
 
+  select {
+    // remove the arrow icon added by bootstrap
+    background-image: none;
+  }
+
   .append-content {
     position: absolute;
     right: 0.75rem;
     top: 0.75rem;
     pointer-events: none;
+  }
+}
+
+// required field label
+.append-required {
+  &::after {
+    content: "*";
+    color: var(--typography-color-danger);
   }
 }
 

--- a/frontend/src/global.scss
+++ b/frontend/src/global.scss
@@ -63,3 +63,8 @@ header.page-header {
   color: var(--theme-primary-blue);
   border-color: var(--surface-color-border-active);
 }
+
+// override bootstrap theme styles: don't shrink radio/checkbox labels
+label.form-check-label {
+  font-size: var(--typography-regular-body) !important;
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -7,13 +7,14 @@ import { Provider as StoreProvider } from "react-redux";
 import { AuthProvider } from "react-oidc-context";
 import { library } from "@fortawesome/fontawesome-svg-core";
 import { fas } from "@fortawesome/free-solid-svg-icons";
+import { far } from "@fortawesome/free-regular-svg-icons";
 import oidcConfig from "./config/keycloak.js";
 
 // include global styles
 import "./global.scss";
 
 // include fontawesome icons globally
-library.add(fas);
+library.add(fas, far);
 
 createRoot(document.getElementById("root")).render(
   <StrictMode>

--- a/frontend/src/router/index.jsx
+++ b/frontend/src/router/index.jsx
@@ -1,9 +1,12 @@
 import { createBrowserRouter } from "react-router-dom";
 import ApiTest from "./pages/ApiTest";
-import DatesManagement from "./pages/DatesManagement";
+import EditAndReview from "./pages/EditAndReview";
+import PublishPage from "./pages/PublishPage";
+import ExportPage from "./pages/ExportPage";
 import PageDetails from "./pages/PageDetails";
 import SubmitDates from "./pages/SubmitDates";
 import MainLayout from "./layouts/MainLayout";
+import LandingPageTabs from "./layouts/LandingPageTabs";
 import ErrorPage from "./pages/Error";
 import ProtectedRoute from "./ProtectedRoute";
 
@@ -15,10 +18,27 @@ const RouterConfig = createBrowserRouter(
       element: <ProtectedRoute component={MainLayout} />,
       errorElement: <ErrorPage />,
       children: [
-        // dates management table / landing page
         {
           path: "/",
-          element: <DatesManagement />,
+          // Tabbed navigation for the landing page
+          element: <LandingPageTabs />,
+          children: [
+            // Edit & Review table / landing page
+            {
+              path: "",
+              element: <EditAndReview />,
+            },
+            // Export
+            {
+              path: "export",
+              element: <ExportPage />,
+            },
+            // Publish
+            {
+              path: "publish",
+              element: <PublishPage />,
+            },
+          ],
         },
 
         // API endpoint test page
@@ -43,18 +63,6 @@ const RouterConfig = createBrowserRouter(
         {
           path: "/park/:parkId/edit/:seasonId/review",
           element: <div>Review changes page</div>,
-        },
-
-        // publish
-        {
-          path: "/publish",
-          element: <div>Publish page</div>,
-        },
-
-        // export
-        {
-          path: "/export",
-          element: <div>Export page</div>,
         },
       ],
     },

--- a/frontend/src/router/layouts/LandingPageTabs.jsx
+++ b/frontend/src/router/layouts/LandingPageTabs.jsx
@@ -14,14 +14,13 @@ export default function LandingPageTabs() {
             </NavLink>
           </li>
           <li className="nav-item">
-            <NavLink className="nav-link" to="/export">
-              Export
-            </NavLink>
-          </li>
-          <li className="nav-item"></li>
-          <li className="nav-item">
             <NavLink className="nav-link" to="/publish">
               Publish
+            </NavLink>
+          </li>
+          <li className="nav-item">
+            <NavLink className="nav-link" to="/export">
+              Export
             </NavLink>
           </li>
         </ul>

--- a/frontend/src/router/layouts/LandingPageTabs.jsx
+++ b/frontend/src/router/layouts/LandingPageTabs.jsx
@@ -1,0 +1,34 @@
+import { Outlet, NavLink } from "react-router-dom";
+import "./LandingPageTabs.scss";
+
+export default function LandingPageTabs() {
+  return (
+    <div className="layout landing-page-tabs">
+      <header className="section-tabs d-flex flex-column">
+        <h1 className="m-3 mb-4">Dates management</h1>
+
+        <ul className="nav nav-tabs px-2">
+          <li className="nav-item">
+            <NavLink className="nav-link" to="/">
+              Edit and Review
+            </NavLink>
+          </li>
+          <li className="nav-item">
+            <NavLink className="nav-link" to="/export">
+              Export
+            </NavLink>
+          </li>
+          <li className="nav-item"></li>
+          <li className="nav-item">
+            <NavLink className="nav-link" to="/publish">
+              Publish
+            </NavLink>
+          </li>
+        </ul>
+      </header>
+      <div className="my-3">
+        <Outlet />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/router/layouts/LandingPageTabs.scss
+++ b/frontend/src/router/layouts/LandingPageTabs.scss
@@ -1,0 +1,6 @@
+.layout.landing-page-tabs {
+  header.section-tabs {
+    background-color: var(--surface-color-background-light-blue);
+    border-bottom-width: 12px;
+  }
+}

--- a/frontend/src/router/pages/EditAndReview.jsx
+++ b/frontend/src/router/pages/EditAndReview.jsx
@@ -1,12 +1,8 @@
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
-function DatesManagement() {
+function EditAndReview() {
   return (
     <div className="page dates-management">
-      <header className="page-header">
-        <h1>Dates management</h1>
-      </header>
-
       <div className="table-filters row mb-4">
         <div className="col-lg-3 col-md-6 col-12">
           <label htmlFor="parkName" className="form-label">
@@ -53,7 +49,7 @@ function DatesManagement() {
       </div>
 
       <div className="table-responsive">
-        <table className="table table-striped table-hover">
+        <table className="table table-striped">
           <thead>
             <tr>
               <th scope="col">Park name</th>
@@ -97,4 +93,4 @@ function DatesManagement() {
   );
 }
 
-export default DatesManagement;
+export default EditAndReview;

--- a/frontend/src/router/pages/ExportPage.jsx
+++ b/frontend/src/router/pages/ExportPage.jsx
@@ -1,0 +1,161 @@
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+
+function ExportPage() {
+  return (
+    <div className="page export">
+      <p>Select the format of your export:</p>
+
+      <div className="row">
+        <div className="col-md-6 col-lg-5">
+          <fieldset className="mb-3">
+            <legend className="append-required">Export type</legend>
+
+            <div className="form-check">
+              <input
+                className="form-check-input"
+                type="radio"
+                name="type"
+                id="type-all-dates"
+                value="all-dates"
+              />
+              <label className="form-check-label" htmlFor="type-all-dates">
+                All dates
+              </label>
+            </div>
+
+            <div className="form-check">
+              <input
+                className="form-check-input"
+                type="radio"
+                name="type"
+                id="type-bcp-only"
+                value="bcp-only"
+              />
+              <label className="form-check-label" htmlFor="type-bcp-only">
+                BCP reservations only
+              </label>
+            </div>
+          </fieldset>
+
+          <fieldset className="mb-3">
+            <legend className="append-required">Year</legend>
+
+            <div className="input-with-append">
+              <select id="year" className="form-select"></select>
+              <FontAwesomeIcon
+                className="append-content"
+                icon="fa-solid fa-magnifying-glass"
+              />
+            </div>
+          </fieldset>
+
+          <fieldset className="mb-3">
+            <legend className="append-required">Park features</legend>
+
+            <div className="form-check">
+              <input
+                className="form-check-input"
+                type="checkbox"
+                name="features"
+                id="features-backcountry-camping"
+                value="Backcountry camping"
+              />
+              <label
+                className="form-check-label"
+                htmlFor="features-backcountry-camping"
+              >
+                Backcountry camping
+              </label>
+            </div>
+
+            <div className="form-check">
+              <input
+                className="form-check-input"
+                type="checkbox"
+                name="features"
+                id="features-cabins-huts"
+                value="Cabins and huts"
+              />
+              <label
+                className="form-check-label"
+                htmlFor="features-cabins-huts"
+              >
+                Cabins and huts
+              </label>
+            </div>
+
+            <div className="form-check">
+              <input
+                className="form-check-input"
+                type="checkbox"
+                name="features"
+                id="features-frontcountry-camping"
+                value="Frontcountry camping"
+              />
+              <label
+                className="form-check-label"
+                htmlFor="features-frontcountry-camping"
+              >
+                Frontcountry camping
+              </label>
+            </div>
+
+            <div className="form-check">
+              <input
+                className="form-check-input"
+                type="checkbox"
+                name="features"
+                id="features-group-camping"
+                value="Group camping"
+              />
+              <label
+                className="form-check-label"
+                htmlFor="features-group-camping"
+              >
+                Group camping
+              </label>
+            </div>
+
+            <div className="form-check">
+              <input
+                className="form-check-input"
+                type="checkbox"
+                name="features"
+                id="features-picnic-areas"
+                value="Picnic areas"
+              />
+              <label
+                className="form-check-label"
+                htmlFor="features-picnic-areas"
+              >
+                Picnic areas
+              </label>
+            </div>
+
+            <div className="form-check">
+              <input
+                className="form-check-input"
+                type="checkbox"
+                name="features"
+                id="features-walk-in-camping"
+                value="Walk-in camping"
+              />
+              <label
+                className="form-check-label"
+                htmlFor="features-walk-in-camping"
+              >
+                Walk-in camping
+              </label>
+            </div>
+          </fieldset>
+
+          <fieldset>
+            <button className="btn btn-primary">Export report</button>
+          </fieldset>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default ExportPage;

--- a/frontend/src/router/pages/ExportPage.jsx
+++ b/frontend/src/router/pages/ExportPage.jsx
@@ -44,7 +44,7 @@ function ExportPage() {
               <select id="year" className="form-select"></select>
               <FontAwesomeIcon
                 className="append-content"
-                icon="fa-solid fa-magnifying-glass"
+                icon="fa-regular fa-calendar-check"
               />
             </div>
           </fieldset>

--- a/frontend/src/router/pages/PageDetails.jsx
+++ b/frontend/src/router/pages/PageDetails.jsx
@@ -67,7 +67,7 @@ function PageDetails() {
             <div className="details-content">
               <h4>Alouette Campground</h4>
 
-              <table className="table table-striped table-hover sub-area-dates">
+              <table className="table table-striped sub-area-dates">
                 <tbody>
                   <tr>
                     <th scope="row">Operating dates</th>
@@ -85,7 +85,7 @@ function PageDetails() {
 
               <h4>Gold Creek Campground</h4>
 
-              <table className="table table-striped table-hover sub-area-dates">
+              <table className="table table-striped sub-area-dates">
                 <tbody>
                   <tr>
                     <th scope="row">Operating dates</th>

--- a/frontend/src/router/pages/PublishPage.jsx
+++ b/frontend/src/router/pages/PublishPage.jsx
@@ -1,0 +1,36 @@
+function PublishPage() {
+  return (
+    <div className="page publish">
+      <div className="d-flex justify-content-end mb-2">
+        <button className="btn btn-primary">Publish to API</button>
+      </div>
+
+      <div className="table-responsive">
+        <table className="table table-striped">
+          <thead>
+            <tr>
+              <th scope="col">Park name</th>
+              <th scope="col">Feature</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Golden Ears</td>
+              <td className="fw-bold">Alouette Campground</td>
+            </tr>
+            <tr>
+              <td>Golden Ears</td>
+              <td className="fw-bold">Gold Creek Campground</td>
+            </tr>
+            <tr>
+              <td>Golden Ears</td>
+              <td className="fw-bold">North Beach Campground</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+export default PublishPage;


### PR DESCRIPTION
### Jira Ticket

CMS-425

### Description
<!-- What did you change, and why? -->

This branch builds out the elements for the "Publish" and "Export" pages. I moved them in the router config so they're children of the "/" landing page route (and they'll share a tabbed navigation with the "Dates management" table page).

I also removed the table row hover styles from all tables. It's not in the wireframes and I don't want to suggest the row is clickable when it's not.

The layout still uses the built-in Bootstrap container class, even though the wireframes are full width for large screens. I'll discuss with design and see what the final decision is for the responsive layout in another ticket.