### PR TITLE
CMS-438: Use Fontawesome pro kit

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# this file is automatically parsed by docker-compose
+# specific variables are included in docker-compose.dev.yml
+
+# fontawesome NPM auth token
+FONTAWESOME_PACKAGE_TOKEN=XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -5,6 +5,8 @@ services:
     build:
       context: ./frontend
       dockerfile: Dockerfile.dev
+    environment:
+      FONTAWESOME_PACKAGE_TOKEN: ${FONTAWESOME_PACKAGE_TOKEN}
     ports:
       - "8101:8101"
     volumes:

--- a/frontend/.npmrc
+++ b/frontend/.npmrc
@@ -1,0 +1,3 @@
+@fortawesome:registry=https://npm.fontawesome.com/
+@awesome.me:registry=https://npm.fontawesome.com/
+//npm.fontawesome.com/:_authToken=${FONTAWESOME_PACKAGE_TOKEN}

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -5,11 +5,7 @@ FROM mcr.microsoft.com/devcontainers/javascript-node:1-20
 
 WORKDIR /app
 
-# Install dependencies
-COPY package*.json ./
-RUN npm install
-
-# Copy the rest of the files
+# Copy the files
 COPY . .
 
 EXPOSE 8101

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,11 +8,10 @@
       "name": "staff-portal-frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@awesome.me/kit-c1c3245051": "^1.0.4",
         "@bcgov/design-tokens": "^3.1.1",
         "@digitalspace/bcparks-bootstrap-theme": "^1.4.6",
         "@fortawesome/fontawesome-svg-core": "^6.6.0",
-        "@fortawesome/free-regular-svg-icons": "^6.6.0",
-        "@fortawesome/free-solid-svg-icons": "^6.6.0",
         "@fortawesome/react-fontawesome": "^0.2.2",
         "@reduxjs/toolkit": "^2.2.7",
         "@vitejs/plugin-react-swc": "^3.5.0",
@@ -41,6 +40,18 @@
       },
       "engines": {
         "node": "20.x"
+      }
+    },
+    "node_modules/@awesome.me/kit-c1c3245051": {
+      "version": "1.0.4",
+      "resolved": "https://npm.fontawesome.com/@awesome.me/kit-c1c3245051/-/1.0.4/kit-c1c3245051-1.0.4.tgz",
+      "integrity": "sha512-59a2UkUk4E48pHtDmqKFnqj8KtMG/K7RsAl+q45ZWdkKWlUlwMPB6eB/yimWDsSzlWiR9M7T3PH4tnStxj3Rng==",
+      "license": "UNLICENSED",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "^6.6.0"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -712,30 +723,6 @@
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.6.0.tgz",
       "integrity": "sha512-KHwPkCk6oRT4HADE7smhfsKudt9N/9lm6EJ5BVg0tD1yPA5hht837fB87F8pn15D8JfTqQOjhKTktwmLMiD7Kg==",
       "license": "MIT",
-      "dependencies": {
-        "@fortawesome/fontawesome-common-types": "6.6.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@fortawesome/free-regular-svg-icons": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-6.6.0.tgz",
-      "integrity": "sha512-Yv9hDzL4aI73BEwSEh20clrY8q/uLxawaQ98lekBx6t9dQKDHcDzzV1p2YtBGTtolYtNqcWdniOnhzB+JPnQEQ==",
-      "license": "(CC-BY-4.0 AND MIT)",
-      "dependencies": {
-        "@fortawesome/fontawesome-common-types": "6.6.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@fortawesome/free-solid-svg-icons": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.6.0.tgz",
-      "integrity": "sha512-IYv/2skhEDFc2WGUcqvFJkeK39Q+HyPf5GHUrT/l2pKbtgEIv1al1TKd6qStR5OIwQdN1GZP54ci3y4mroJWjA==",
-      "license": "(CC-BY-4.0 AND MIT)",
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "6.6.0"
       },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,11 +10,10 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@awesome.me/kit-c1c3245051": "^1.0.4",
     "@bcgov/design-tokens": "^3.1.1",
     "@digitalspace/bcparks-bootstrap-theme": "^1.4.6",
     "@fortawesome/fontawesome-svg-core": "^6.6.0",
-    "@fortawesome/free-regular-svg-icons": "^6.6.0",
-    "@fortawesome/free-solid-svg-icons": "^6.6.0",
     "@fortawesome/react-fontawesome": "^0.2.2",
     "@reduxjs/toolkit": "^2.2.7",
     "@vitejs/plugin-react-swc": "^3.5.0",

--- a/frontend/src/components/NavBack.jsx
+++ b/frontend/src/components/NavBack.jsx
@@ -1,6 +1,6 @@
 import { Link } from "react-router-dom";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faArrowLeft } from "@awesome.me/kit-c1c3245051/icons/classic/solid";
+import { faArrowLeft } from "@fa-kit/icons/classic/solid";
 import PropTypes from "prop-types";
 
 import "./NavBack.scss";

--- a/frontend/src/components/NavBack.jsx
+++ b/frontend/src/components/NavBack.jsx
@@ -1,5 +1,6 @@
 import { Link } from "react-router-dom";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faArrowLeft } from "@awesome.me/kit-c1c3245051/icons/classic/solid";
 import PropTypes from "prop-types";
 
 import "./NavBack.scss";
@@ -9,10 +10,7 @@ export default function NavBack({ routePath, children }) {
   return (
     <div className="nav-back mb-4">
       <Link to={routePath}>
-        <FontAwesomeIcon
-          className="icon-back me-2"
-          icon="fa-solid fa-arrow-left"
-        />
+        <FontAwesomeIcon className="icon-back me-2" icon={faArrowLeft} />
         <span>{children}</span>
       </Link>
     </div>

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -5,16 +5,10 @@ import router from "./router";
 import store from "./store";
 import { Provider as StoreProvider } from "react-redux";
 import { AuthProvider } from "react-oidc-context";
-import { library } from "@fortawesome/fontawesome-svg-core";
-import { fas } from "@fortawesome/free-solid-svg-icons";
-import { far } from "@fortawesome/free-regular-svg-icons";
 import oidcConfig from "./config/keycloak.js";
 
 // include global styles
 import "./global.scss";
-
-// include fontawesome icons globally
-library.add(fas, far);
 
 createRoot(document.getElementById("root")).render(
   <StrictMode>

--- a/frontend/src/router/pages/EditAndReview.jsx
+++ b/frontend/src/router/pages/EditAndReview.jsx
@@ -1,4 +1,5 @@
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faMagnifyingGlass } from "@awesome.me/kit-c1c3245051/icons/classic/solid";
 
 function EditAndReview() {
   return (
@@ -18,7 +19,7 @@ function EditAndReview() {
             />
             <FontAwesomeIcon
               className="append-content"
-              icon="fa-solid fa-magnifying-glass"
+              icon={faMagnifyingGlass}
             />
           </div>
         </div>

--- a/frontend/src/router/pages/EditAndReview.jsx
+++ b/frontend/src/router/pages/EditAndReview.jsx
@@ -1,5 +1,5 @@
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faMagnifyingGlass } from "@awesome.me/kit-c1c3245051/icons/classic/solid";
+import { faMagnifyingGlass } from "@fa-kit/icons/classic/solid";
 
 function EditAndReview() {
   return (

--- a/frontend/src/router/pages/ExportPage.jsx
+++ b/frontend/src/router/pages/ExportPage.jsx
@@ -1,3 +1,4 @@
+import { faCalendarCheck } from "@awesome.me/kit-c1c3245051/icons/classic/regular";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 function ExportPage() {
@@ -44,7 +45,7 @@ function ExportPage() {
               <select id="year" className="form-select"></select>
               <FontAwesomeIcon
                 className="append-content"
-                icon="fa-regular fa-calendar-check"
+                icon={faCalendarCheck}
               />
             </div>
           </fieldset>

--- a/frontend/src/router/pages/ExportPage.jsx
+++ b/frontend/src/router/pages/ExportPage.jsx
@@ -1,4 +1,4 @@
-import { faCalendarCheck } from "@awesome.me/kit-c1c3245051/icons/classic/regular";
+import { faCalendarCheck } from "@fa-kit/icons/classic/regular";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 function ExportPage() {

--- a/frontend/src/router/pages/ParkDetails.jsx
+++ b/frontend/src/router/pages/ParkDetails.jsx
@@ -1,4 +1,10 @@
 import { useParams } from "react-router-dom";
+import {
+  faChevronDown,
+  faPen,
+  faChevronUp,
+} from "@awesome.me/kit-c1c3245051/icons/classic/solid";
+import { faCircleExclamation } from "@awesome.me/kit-c1c3245051/icons/classic/regular";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import NavBack from "../../components/NavBack";
 import walkInCamping from "../../assets/icons/walk-in-camping.svg";
@@ -34,7 +40,7 @@ function ParkDetails() {
                 <span>Last updated: Never</span>
                 <FontAwesomeIcon
                   className="append-content ms-2"
-                  icon="fa-solid fa-chevron-down"
+                  icon={faChevronDown}
                 />
               </button>
             </header>
@@ -42,10 +48,7 @@ function ParkDetails() {
 
           <div className="controls">
             <button className="btn btn-text-primary">
-              <FontAwesomeIcon
-                className="append-content me-2"
-                icon="fa-solid fa-pen"
-              />
+              <FontAwesomeIcon className="append-content me-2" icon={faPen} />
               <span>Edit</span>
             </button>
           </div>
@@ -62,7 +65,7 @@ function ParkDetails() {
                 <span>Last updated: Never</span>
                 <FontAwesomeIcon
                   className="append-content ms-2"
-                  icon="fa-solid fa-chevron-up"
+                  icon={faChevronUp}
                 />
               </button>
             </header>
@@ -108,10 +111,7 @@ function ParkDetails() {
 
           <div className="controls">
             <button className="btn btn-text-primary">
-              <FontAwesomeIcon
-                className="append-content me-2"
-                icon="fa-solid fa-pen"
-              />
+              <FontAwesomeIcon className="append-content me-2" icon={faPen} />
               <span>Edit</span>
             </button>
 
@@ -120,7 +120,7 @@ function ParkDetails() {
             <button className="btn btn-text-primary">
               <FontAwesomeIcon
                 className="append-content me-2"
-                icon="fa-solid fa-circle-exclamation"
+                icon={faCircleExclamation}
               />
               <span>Preview</span>
             </button>

--- a/frontend/src/router/pages/ParkDetails.jsx
+++ b/frontend/src/router/pages/ParkDetails.jsx
@@ -1,10 +1,6 @@
 import { useParams } from "react-router-dom";
-import {
-  faChevronDown,
-  faPen,
-  faChevronUp,
-} from "@awesome.me/kit-c1c3245051/icons/classic/solid";
-import { faCircleExclamation } from "@awesome.me/kit-c1c3245051/icons/classic/regular";
+import { faChevronDown, faPen, faChevronUp } from "@fa-kit/icons/classic/solid";
+import { faCircleExclamation } from "@fa-kit/icons/classic/regular";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import NavBack from "../../components/NavBack";
 import walkInCamping from "../../assets/icons/walk-in-camping.svg";

--- a/frontend/src/router/pages/SubmitDates.jsx
+++ b/frontend/src/router/pages/SubmitDates.jsx
@@ -1,4 +1,5 @@
 import { useParams } from "react-router-dom";
+import { faCircleInfo } from "@awesome.me/kit-c1c3245051/icons/classic/regular";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import NavBack from "../../components/NavBack";
 import groupCamping from "../../assets/icons/group-camping.svg";
@@ -19,8 +20,8 @@ function SubmitDates() {
             <p>
               Operating dates{" "}
               <FontAwesomeIcon
-                className="append-content"
-                icon="fa-solid fa-circle-info"
+                className="append-content ms-1"
+                icon={faCircleInfo}
               />
             </p>
 
@@ -105,8 +106,8 @@ function SubmitDates() {
             <p>
               Reservation dates{" "}
               <FontAwesomeIcon
-                className="append-content"
-                icon="fa-solid fa-circle-info"
+                className="append-content ms-1"
+                icon={faCircleInfo}
               />
             </p>
 

--- a/frontend/src/router/pages/SubmitDates.jsx
+++ b/frontend/src/router/pages/SubmitDates.jsx
@@ -1,5 +1,5 @@
 import { useParams } from "react-router-dom";
-import { faCircleInfo } from "@awesome.me/kit-c1c3245051/icons/classic/regular";
+import { faCircleInfo } from "@fa-kit/icons/classic/regular";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import NavBack from "../../components/NavBack";
 import groupCamping from "../../assets/icons/group-camping.svg";

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -11,4 +11,10 @@ export default defineConfig({
     host: true,
     port: 8101,
   },
+
+  resolve: {
+    alias: {
+      "@fa-kit": "@awesome.me/kit-c1c3245051",
+    },
+  },
 });

--- a/helm/deployment/templates/frontend/frontend-deployment.yaml
+++ b/helm/deployment/templates/frontend/frontend-deployment.yaml
@@ -57,6 +57,9 @@ spec:
               value: {{ .Values.frontend.env.externalUrl }}/v2/
             - name: VITE_OIDC_LOGOUT_REDIRECT
               value: {{ .Values.frontend.env.externalUrl }}
+          envFrom:
+            - secretRef:
+                name: {{ .Release.Name }}-fontawesome-secret
           readinessProbe:
             httpGet:
               path: /

--- a/helm/deployment/templates/secrets/adminjs-secret.yaml
+++ b/helm/deployment/templates/secrets/adminjs-secret.yaml
@@ -6,7 +6,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   labels:
-    component: adminjs
+    component: {{ .Values.backend.componentName }}
     release: {{ .Release.Name }}
     chart: {{ .Chart.Name }}
     heritage: {{ .Release.Service }}

--- a/helm/deployment/templates/secrets/fontawesome-secret.yaml
+++ b/helm/deployment/templates/secrets/fontawesome-secret.yaml
@@ -1,0 +1,17 @@
+{{- if not (lookup "v1" "Secret" .Release.Namespace (printf "%s-fontawesome-secret" .Release.Name)) -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    component: {{ .Values.frontend.componentName }}
+    release: {{ .Release.Name }}
+    chart: {{ .Chart.Name }}
+    heritage: {{ .Release.Service }}
+  name: {{ .Release.Name }}-fontawesome-secret
+  annotations:
+    "helm.sh/hook": "pre-install"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+    "helm.sh/hook-weight": "0"
+stringData:
+  FONTAWESOME_PACKAGE_TOKEN: {{ .Values.fontawesomeToken | quote }}
+{{- end -}}


### PR DESCRIPTION
### Jira Ticket

CMS-438

### Description
<!-- What did you change, and why? -->

This branch implements a Fontawesome "Pro Kit" instead of the free icon packs we were manually importing. The kit includes all* of the icons we'll need for the project.

Except: *It doesn't include the custom icons, because adding them to the kit would be more trouble than it's worth. I discussed it with the Drive BC devs who had the same experience. It's no trouble to leave the custom icons separate and use an `<img>` tag for those. 

*Note* that this adds a new environment variable to the backend dev container, and hopefully fixes the secrets templates in the Helm charts. You'll need to rebuild your backend dev container.