### PR TITLE
CMS-452: Build Park Details components

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -23,6 +23,7 @@
         "express-session": "^1.18.0",
         "helmet": "^7.1.0",
         "jwks-rsa": "^3.1.0",
+        "lodash": "^4.17.21",
         "morgan": "^1.10.0",
         "pg": "^8.12.0",
         "pg-hstore": "^2.3.4",

--- a/backend/package.json
+++ b/backend/package.json
@@ -38,6 +38,7 @@
     "express-session": "^1.18.0",
     "helmet": "^7.1.0",
     "jwks-rsa": "^3.1.0",
+    "lodash": "^4.17.21",
     "morgan": "^1.10.0",
     "pg": "^8.12.0",
     "pg-hstore": "^2.3.4",

--- a/backend/routes/api/parks.js
+++ b/backend/routes/api/parks.js
@@ -1,4 +1,5 @@
 import { Router } from "express";
+import _ from "lodash";
 import { Park, Season, FeatureType, Feature } from "../../models/index.js";
 import asyncHandler from "express-async-handler";
 
@@ -104,9 +105,17 @@ router.get(
       throw error;
     }
 
-    const output = park.toJSON();
+    const parkJson = park.toJSON();
 
-    res.json(output);
+    const subAreas = _.mapValues(
+      // group seasons by feature type
+      _.groupBy(parkJson.seasons, (s) => s.featureType.name),
+
+      // sort by year
+      (group) => _.orderBy(group, ["operatingYear"], ["desc"]),
+    );
+
+    res.json({ ...parkJson, subAreas });
   }),
 );
 

--- a/backend/routes/api/parks.js
+++ b/backend/routes/api/parks.js
@@ -115,6 +115,9 @@ router.get(
       (group) => _.orderBy(group, ["operatingYear"], ["desc"]),
     );
 
+    // remove unused season key
+    delete parkJson.seasons;
+
     res.json({ ...parkJson, subAreas });
   }),
 );

--- a/backend/routes/api/seasons.js
+++ b/backend/routes/api/seasons.js
@@ -15,6 +15,213 @@ const router = Router();
 router.get(
   "/seasons/:seasonId",
   asyncHandler(async (req, res) => {
+    if (!req.params.sendRealData) {
+      const data = {
+        id: 3,
+        operatingYear: 2025,
+        status: "not started",
+        featureType: {
+          id: 1,
+          name: "Frontcountry Camping",
+        },
+        park: {
+          id: 1,
+          name: "Golen Ears",
+          orcs: "1",
+        },
+        dateTypes: {
+          Reservation: {
+            id: 2,
+            name: "Reservation",
+          },
+          Operation: {
+            id: 1,
+            name: "Operation",
+          },
+        },
+        campgrounds: [
+          {
+            id: 1,
+            name: "Alouette Campground",
+            features: [
+              {
+                id: 1,
+                name: "Campsites 1-15",
+                hasReservations: true,
+                campground: {
+                  id: 1,
+                  name: "Alouette Campground",
+                },
+                dateable: {
+                  id: 1,
+                  currentSeasonDates: [
+                    {
+                      id: 4,
+                      seasonId: 3,
+                      startDate: "2022-05-01",
+                      endDate: "2022-09-30",
+                      dateType: {
+                        id: 2,
+                        name: "Reservation",
+                      },
+                    },
+                    {
+                      id: 3,
+                      seasonId: 3,
+                      startDate: "2022-05-01",
+                      endDate: "2022-09-30",
+                      dateType: {
+                        id: 1,
+                        name: "Operation",
+                      },
+                    },
+                  ],
+                  previousSeasonDates: [
+                    {
+                      id: 2,
+                      seasonId: 1,
+                      startDate: "2022-05-01",
+                      endDate: "2022-09-30",
+                      dateType: {
+                        id: 2,
+                        name: "Reservation",
+                      },
+                    },
+                    {
+                      id: 1,
+                      seasonId: 1,
+                      startDate: "2022-04-01",
+                      endDate: "2022-09-30",
+                      dateType: {
+                        id: 1,
+                        name: "Operation",
+                      },
+                    },
+                  ],
+                },
+              },
+              {
+                id: 2,
+                name: "Campsites 16-30",
+                hasReservations: true,
+                campground: {
+                  id: 1,
+                  name: "Alouette Campground",
+                },
+                dateable: {
+                  id: 2,
+                  currentSeasonDates: [
+                    {
+                      id: 8,
+                      seasonId: 3,
+                      startDate: "2022-05-01",
+                      endDate: "2022-09-30",
+                      dateType: {
+                        id: 2,
+                        name: "Reservation",
+                      },
+                    },
+                    {
+                      id: 7,
+                      seasonId: 3,
+                      startDate: "2022-05-01",
+                      endDate: "2022-09-30",
+                      dateType: {
+                        id: 1,
+                        name: "Operation",
+                      },
+                    },
+                  ],
+                  previousSeasonDates: [
+                    {
+                      id: 5,
+                      seasonId: 1,
+                      startDate: "2022-05-01",
+                      endDate: "2022-09-30",
+                      dateType: {
+                        id: 1,
+                        name: "Operation",
+                      },
+                    },
+                    {
+                      id: 6,
+                      seasonId: 1,
+                      startDate: "2022-05-01",
+                      endDate: "2022-09-30",
+                      dateType: {
+                        id: 2,
+                        name: "Reservation",
+                      },
+                    },
+                  ],
+                },
+              },
+              {
+                id: 3,
+                name: "Campsites 31-45",
+                hasReservations: true,
+                campground: {
+                  id: 1,
+                  name: "Alouette Campground",
+                },
+                dateable: {
+                  id: 3,
+                  currentSeasonDates: [
+                    {
+                      id: 11,
+                      seasonId: 3,
+                      startDate: "2022-05-01",
+                      endDate: "2022-09-30",
+                      dateType: {
+                        id: 1,
+                        name: "Operation",
+                      },
+                    },
+                    {
+                      id: 12,
+                      seasonId: 3,
+                      startDate: "2022-05-01",
+                      endDate: "2022-09-30",
+                      dateType: {
+                        id: 2,
+                        name: "Reservation",
+                      },
+                    },
+                  ],
+                  previousSeasonDates: [
+                    {
+                      id: 9,
+                      seasonId: 1,
+                      startDate: "2022-05-01",
+                      endDate: "2022-09-30",
+                      dateType: {
+                        id: 1,
+                        name: "Operation",
+                      },
+                    },
+                    {
+                      id: 10,
+                      seasonId: 1,
+                      startDate: "2022-05-01",
+                      endDate: "2022-09-30",
+                      dateType: {
+                        id: 2,
+                        name: "Reservation",
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        ],
+        features: [],
+      };
+
+      res.json(data);
+      return;
+    }
+
     const { seasonId } = req.params;
 
     const seasonModel = await Season.findByPk(seasonId, {

--- a/backend/routes/api/seasons.js
+++ b/backend/routes/api/seasons.js
@@ -66,6 +66,26 @@ router.get(
                       },
                     },
                     {
+                      id: 104,
+                      seasonId: 3,
+                      startDate: "2022-11-01",
+                      endDate: "2022-11-30",
+                      dateType: {
+                        id: 2,
+                        name: "Reservation",
+                      },
+                    },
+                    {
+                      id: 105,
+                      seasonId: 3,
+                      startDate: "2022-12-05",
+                      endDate: "2022-12-15",
+                      dateType: {
+                        id: 2,
+                        name: "Reservation",
+                      },
+                    },
+                    {
                       id: 3,
                       seasonId: 3,
                       startDate: "2022-05-01",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,6 +17,7 @@
         "@vitejs/plugin-react-swc": "^3.5.0",
         "axios": "^1.7.5",
         "classnames": "^2.5.1",
+        "date-fns": "^4.1.0",
         "lodash": "^4.17.21",
         "oidc-client-ts": "^3.0.1",
         "prop-types": "^15.8.1",
@@ -1939,6 +1940,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
     "@vitejs/plugin-react-swc": "^3.5.0",
     "axios": "^1.7.5",
     "classnames": "^2.5.1",
+    "date-fns": "^4.1.0",
     "lodash": "^4.17.21",
     "oidc-client-ts": "^3.0.1",
     "prop-types": "^15.8.1",

--- a/frontend/src/components/DateRange.jsx
+++ b/frontend/src/components/DateRange.jsx
@@ -1,0 +1,33 @@
+import PropTypes from "prop-types";
+import useDate from "../hooks/useDate";
+import { useMemo } from "react";
+
+import "./DateRange.scss";
+
+// Displays a date range in a table cell
+export default function DateRange({ start, end }) {
+  const { formatted: startFormatted, FORMAT_SHORT } = useDate(start);
+  const startDate = useMemo(
+    () => startFormatted(FORMAT_SHORT),
+    [startFormatted, FORMAT_SHORT],
+  );
+
+  const { formatted: endFormatted } = useDate(end);
+  const endDate = useMemo(
+    () => endFormatted(FORMAT_SHORT),
+    [endFormatted, FORMAT_SHORT],
+  );
+
+  return (
+    <div className="date-range">
+      <span className="date">{startDate}</span>
+      <span className="separator">–</span>
+      <span className="date">{endDate}</span>
+    </div>
+  );
+}
+
+DateRange.propTypes = {
+  start: PropTypes.string.isRequired,
+  end: PropTypes.string.isRequired,
+};

--- a/frontend/src/components/DateRange.scss
+++ b/frontend/src/components/DateRange.scss
@@ -1,0 +1,16 @@
+.date-range {
+  display: flex;
+  justify-content: space-between;
+  width: fit-content;
+
+  .date {
+    @media (min-width: 576px) {
+      min-width: 6em;
+    }
+    max-width: fit-content;
+  }
+
+  .separator {
+    margin-inline: 1em;
+  }
+}

--- a/frontend/src/components/EditAndReviewTable.jsx
+++ b/frontend/src/components/EditAndReviewTable.jsx
@@ -8,6 +8,7 @@ import {
   faChevronRight,
 } from "@fa-kit/icons/classic/solid";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import StatusBadge from "@/components/StatusBadge";
 
 function TableRow(park) {
   const navigate = useNavigate();
@@ -25,10 +26,7 @@ function TableRow(park) {
     <tr onClick={navigateToPark} role="button">
       <th scope="row">{park.name}</th>
       <td>
-        {/* TODO: status pill component */}
-        <span className={`badge rounded-pill text-bg-warning`}>
-          {park.status}
-        </span>
+        <StatusBadge status={park.status} />
       </td>
       <td className="text-end">
         <Link to={getParkLink()} aria-label={`View ${park.name} park details`}>

--- a/frontend/src/components/ParkDetailsSeason.jsx
+++ b/frontend/src/components/ParkDetailsSeason.jsx
@@ -7,12 +7,24 @@ import PropTypes from "prop-types";
 import { useNavigate, useParams } from "react-router-dom";
 import StatusBadge from "@/components/StatusBadge";
 import useDate from "@/hooks/useDate";
+import { useApiGet } from "@/hooks/useApi";
+import LoadingBar from "@/components/LoadingBar";
+import SeasonDates from "@/components/ParkDetailsSeasonDates";
 
 export default function ParkSeason({ season }) {
   const { parkId } = useParams();
   const navigate = useNavigate();
 
   const [expanded, setExpanded] = useState(false);
+
+  const {
+    data: datesData,
+    loading,
+    error,
+    fetchData,
+  } = useApiGet(`/seasons/${season.id}`, {
+    instant: false,
+  });
 
   // Returns a chevron icon based on the expansion state
   function getExpandIcon() {
@@ -21,51 +33,30 @@ export default function ParkSeason({ season }) {
 
   // @TODO: get real details data from the API
   function expandableContent() {
-    if (!expanded) return <div></div>;
+    if (!expanded) return null;
 
-    return (
-      <div className="details-content">
-        {/* TODO: render real data when available */}
-        <h4>TODO: Alouette Campground</h4>
+    if (loading)
+      return (
+        <div className="p-3 pt-0">
+          <LoadingBar />
+        </div>
+      );
 
-        <table className="table table-striped sub-area-dates">
-          <tbody>
-            <tr>
-              <th scope="row">Operating dates</th>
-              <td>Mon, Mar 28 - Wed, Oct 15</td>
-            </tr>
-            <tr>
-              <th scope="row">Reservation dates</th>
-              <td>
-                Tue, Mar 28 - Wed, Apr 1<br />
-                Mon, May 1 - Wed, Oct 14
-              </td>
-            </tr>
-          </tbody>
-        </table>
+    if (error)
+      return <p className="px-3">Error loading dates: {error.message}</p>;
 
-        <h4>Gold Creek Campground</h4>
-
-        <table className="table table-striped sub-area-dates">
-          <tbody>
-            <tr>
-              <th scope="row">Operating dates</th>
-              <td>Mon, Mar 28 - Wed, Oct 15</td>
-            </tr>
-            <tr>
-              <th scope="row">Reservation dates</th>
-              <td>
-                Tue, Mar 28 - Wed, Apr 1<br />
-                Mon, May 1 - Wed, Oct 14
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-    );
+    return <SeasonDates data={datesData} />;
   }
 
-  function toggleExpand() {
+  function toggleExpand(event) {
+    // Prevent button click events from bubbling up to the clickable parent
+    event.stopPropagation();
+
+    // If the panel is about to expand, fetch the data
+    if (!expanded && datesData === null) {
+      fetchData();
+    }
+
     setExpanded(!expanded);
   }
 

--- a/frontend/src/components/ParkDetailsSeason.jsx
+++ b/frontend/src/components/ParkDetailsSeason.jsx
@@ -1,0 +1,153 @@
+import { useState } from "react";
+import classNames from "classnames";
+import { faChevronDown, faPen, faChevronUp } from "@fa-kit/icons/classic/solid";
+import { faCircleExclamation } from "@fa-kit/icons/classic/regular";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import PropTypes from "prop-types";
+import { useNavigate, useParams } from "react-router-dom";
+import StatusBadge from "@/components/StatusBadge";
+import useDate from "@/hooks/useDate";
+
+export default function ParkSeason({ season }) {
+  const { parkId } = useParams();
+  const navigate = useNavigate();
+
+  const [expanded, setExpanded] = useState(false);
+
+  // Returns a chevron icon based on the expansion state
+  function getExpandIcon() {
+    return expanded ? faChevronUp : faChevronDown;
+  }
+
+  // @TODO: get real details data from the API
+  function expandableContent() {
+    if (!expanded) return <div></div>;
+
+    return (
+      <div className="details-content">
+        {/* TODO: render real data when available */}
+        <h4>TODO: Alouette Campground</h4>
+
+        <table className="table table-striped sub-area-dates">
+          <tbody>
+            <tr>
+              <th scope="row">Operating dates</th>
+              <td>Mon, Mar 28 - Wed, Oct 15</td>
+            </tr>
+            <tr>
+              <th scope="row">Reservation dates</th>
+              <td>
+                Tue, Mar 28 - Wed, Apr 1<br />
+                Mon, May 1 - Wed, Oct 14
+              </td>
+            </tr>
+          </tbody>
+        </table>
+
+        <h4>Gold Creek Campground</h4>
+
+        <table className="table table-striped sub-area-dates">
+          <tbody>
+            <tr>
+              <th scope="row">Operating dates</th>
+              <td>Mon, Mar 28 - Wed, Oct 15</td>
+            </tr>
+            <tr>
+              <th scope="row">Reservation dates</th>
+              <td>
+                Tue, Mar 28 - Wed, Apr 1<br />
+                Mon, May 1 - Wed, Oct 14
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    );
+  }
+
+  function toggleExpand() {
+    setExpanded(!expanded);
+  }
+
+  const seasonClasses = classNames({
+    season: true,
+    expanded,
+  });
+
+  const detailsClasses = classNames({
+    details: true,
+    expanded,
+  });
+
+  // @TODO: implement logic to show/hide preview button
+  const showPreviewButton = true;
+
+  const updateDate = useDate(season.updatedAt);
+
+  function navigateToEdit() {
+    navigate(`/park/${parkId}/edit/${season.id}`);
+  }
+
+  function navigateToPreview() {
+    navigate(`/park/${parkId}/edit/${season.id}/review`);
+  }
+
+  return (
+    <div className={seasonClasses}>
+      <div className={detailsClasses}>
+        <header role="button" onClick={toggleExpand}>
+          <h3>{season.operatingYear} season</h3>
+
+          <StatusBadge status={season.status} />
+
+          <button
+            onClick={toggleExpand}
+            className="btn btn-text-primary expand-toggle"
+          >
+            <span>Last updated: {updateDate.formatted()}</span>
+            <FontAwesomeIcon
+              className="append-content ms-2"
+              icon={getExpandIcon()}
+            />
+          </button>
+        </header>
+
+        {expandableContent()}
+      </div>
+
+      <div className="controls">
+        <button onClick={navigateToEdit} className="btn btn-text-primary">
+          <FontAwesomeIcon className="append-content me-2" icon={faPen} />
+          <span>Edit</span>
+        </button>
+
+        {showPreviewButton && (
+          <>
+            <div className="divider"></div>
+
+            <button
+              onClick={navigateToPreview}
+              className="btn btn-text-primary"
+            >
+              <FontAwesomeIcon
+                className="append-content me-2"
+                icon={faCircleExclamation}
+              />
+              <span>Preview</span>
+            </button>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// prop validation
+ParkSeason.propTypes = {
+  season: PropTypes.shape({
+    id: PropTypes.number.isRequired,
+    operatingYear: PropTypes.number.isRequired,
+    status: PropTypes.string.isRequired,
+    updatedAt: PropTypes.string.isRequired,
+  }),
+};

--- a/frontend/src/components/ParkDetailsSeasonDates.jsx
+++ b/frontend/src/components/ParkDetailsSeasonDates.jsx
@@ -1,16 +1,15 @@
-import PropTypes from "prop-types";
-import { useEffect, useMemo } from "react";
-import useDate from "@/hooks/useDate";
+import groupBy from "lodash/groupBy";
 import DateRange from "@/components/DateRange";
+import PropTypes from "prop-types";
 
-function DateTypeRow({ dateType }) {
-  console.log("dateType", dateType);
-
+function DateTypeRow({ dateTypeName, dateRanges }) {
   return (
     <tr>
-      <td>{dateType.dateType.name} dates</td>
+      <td>{dateTypeName} dates</td>
       <td>
-        <DateRange start={dateType.startDate} end={dateType.endDate} />
+        {dateRanges.map((date) => (
+          <DateRange key={date.id} start={date.startDate} end={date.endDate} />
+        ))}
       </td>
     </tr>
   );
@@ -18,14 +17,28 @@ function DateTypeRow({ dateType }) {
 
 // "Dateable" features: Campsite groupings, etc.
 function CampGroundFeature({ feature }) {
+  const currentSeasonDates = feature?.dateable?.currentSeasonDates;
+
+  if (!currentSeasonDates) return null;
+
+  // Group current season dates by date type
+  const groupedDates = groupBy(
+    currentSeasonDates,
+    (dateType) => dateType.dateType.name,
+  );
+
   return (
     <div className="feature">
       <h5>{feature.name}</h5>
 
       <table className="table table-striped sub-area-dates mb-0">
         <tbody>
-          {feature?.dateable?.currentSeasonDates?.map((dateType) => (
-            <DateTypeRow key={dateType.id} dateType={dateType} />
+          {Object.entries(groupedDates).map(([dateTypeName, dateRanges]) => (
+            <DateTypeRow
+              key={dateTypeName}
+              dateTypeName={dateTypeName}
+              dateRanges={dateRanges}
+            />
           ))}
         </tbody>
       </table>
@@ -33,7 +46,7 @@ function CampGroundFeature({ feature }) {
   );
 }
 
-// Campground contain one or more dateable features
+// Campgrounds contain one or more dateable features
 function CampGround({ campground }) {
   return (
     <div className="campground">
@@ -55,3 +68,46 @@ export default function SeasonDates({ data }) {
     </div>
   );
 }
+
+// prop validation
+const dateRangePropShape = PropTypes.shape({
+  id: PropTypes.number.isRequired,
+  startDate: PropTypes.string.isRequired,
+  endDate: PropTypes.string.isRequired,
+  dateType: PropTypes.shape({
+    name: PropTypes.string.isRequired,
+  }).isRequired,
+});
+
+const campgroundFeaturePropShape = PropTypes.shape({
+  id: PropTypes.number.isRequired,
+  name: PropTypes.string.isRequired,
+  dateable: PropTypes.shape({
+    currentSeasonDates: PropTypes.arrayOf(dateRangePropShape),
+  }),
+});
+
+const campgroundPropShape = PropTypes.shape({
+  id: PropTypes.number.isRequired,
+  name: PropTypes.string.isRequired,
+  features: PropTypes.arrayOf(campgroundFeaturePropShape),
+});
+
+SeasonDates.propTypes = {
+  data: PropTypes.shape({
+    campgrounds: PropTypes.arrayOf(campgroundPropShape),
+  }),
+};
+
+CampGround.propTypes = {
+  campground: campgroundPropShape,
+};
+
+CampGroundFeature.propTypes = {
+  feature: campgroundFeaturePropShape,
+};
+
+DateTypeRow.propTypes = {
+  dateTypeName: PropTypes.string.isRequired,
+  dateRanges: PropTypes.arrayOf(dateRangePropShape),
+};

--- a/frontend/src/components/ParkDetailsSeasonDates.jsx
+++ b/frontend/src/components/ParkDetailsSeasonDates.jsx
@@ -1,0 +1,57 @@
+import PropTypes from "prop-types";
+import { useEffect, useMemo } from "react";
+import useDate from "@/hooks/useDate";
+import DateRange from "@/components/DateRange";
+
+function DateTypeRow({ dateType }) {
+  console.log("dateType", dateType);
+
+  return (
+    <tr>
+      <td>{dateType.dateType.name} dates</td>
+      <td>
+        <DateRange start={dateType.startDate} end={dateType.endDate} />
+      </td>
+    </tr>
+  );
+}
+
+// "Dateable" features: Campsite groupings, etc.
+function CampGroundFeature({ feature }) {
+  return (
+    <div className="feature">
+      <h5>{feature.name}</h5>
+
+      <table className="table table-striped sub-area-dates mb-0">
+        <tbody>
+          {feature?.dateable?.currentSeasonDates?.map((dateType) => (
+            <DateTypeRow key={dateType.id} dateType={dateType} />
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// Campground contain one or more dateable features
+function CampGround({ campground }) {
+  return (
+    <div className="campground">
+      <h4>{campground.name}</h4>
+
+      {campground.features.map((feature) => (
+        <CampGroundFeature key={feature.id} feature={feature} />
+      ))}
+    </div>
+  );
+}
+
+export default function SeasonDates({ data }) {
+  return (
+    <div className="details-content">
+      {data.campgrounds.map((campground) => (
+        <CampGround key={campground.id} campground={campground} />
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/ParkDetailsSubArea.jsx
+++ b/frontend/src/components/ParkDetailsSubArea.jsx
@@ -1,0 +1,29 @@
+import ParkSeason from "@/components/ParkDetailsSeason";
+// @TODO: map icons to feature types
+import walkInCamping from "@/assets/icons/walk-in-camping.svg";
+import PropTypes from "prop-types";
+
+export default function SubArea({ title, data }) {
+  return (
+    <section className="sub-area">
+      <h2>
+        <img src={walkInCamping} className="sub-area-icon" /> {title}
+      </h2>
+
+      {data.map((season) => (
+        <ParkSeason key={season.id} season={season} />
+      ))}
+    </section>
+  );
+}
+
+SubArea.propTypes = {
+  title: PropTypes.string.isRequired,
+  data: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.number.isRequired,
+      operatingYear: PropTypes.number.isRequired,
+      status: PropTypes.string.isRequired,
+    }),
+  ).isRequired,
+};

--- a/frontend/src/components/StatusBadge.jsx
+++ b/frontend/src/components/StatusBadge.jsx
@@ -1,0 +1,34 @@
+import classNames from "classnames";
+import PropTypes from "prop-types";
+
+export default function StatusBadge({ status }) {
+  let colorClass = "text-bg-dark";
+  let label = status;
+
+  // Don't render anything if the status is null
+  if (!status) {
+    return null;
+  }
+
+  // Map status code to color class and display label
+  const statusMap = new Map([
+    ["published", { cssClass: "text-bg-primary", displayText: "Published" }],
+    ["approved", { cssClass: "text-bg-success", displayText: "Approved" }],
+    ["requested", { cssClass: "text-bg-warning", displayText: "Requested" }],
+  ]);
+
+  if (statusMap.has(status)) {
+    const { cssClass, displayText } = statusMap.get(status);
+
+    colorClass = cssClass;
+    label = displayText;
+  }
+
+  const classes = classNames(["badge", "rounded-pill", colorClass]);
+
+  return <span className={classes}>{label}</span>;
+}
+
+StatusBadge.propTypes = {
+  status: PropTypes.string,
+};

--- a/frontend/src/hooks/useApi.js
+++ b/frontend/src/hooks/useApi.js
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import axios from "axios";
 import getEnv from "../config/getEnv";
 
@@ -7,35 +7,49 @@ const axiosInstance = axios.create({
   baseURL: getEnv("VITE_API_BASE_URL"),
 });
 
-export function useApiGet(endpoint, params = {}) {
+export function useApiGet(endpoint, options = {}) {
   const [data, setData] = useState(null);
-  const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const requestSent = useRef(false);
+
+  // Parse options:
+  // URL parameters
+  const params = options.params ?? {};
+  // Instantly start the request. Set false to call fetchData manually
+  const instant = options.instant ?? true;
+
+  // If instant is true, the request will be sent immediately
+  const [loading, setLoading] = useState(instant);
 
   // Convert the params object to a string to compare changes
   const paramsString = JSON.stringify(params);
 
-  useEffect(() => {
-    async function fetchData() {
-      try {
-        requestSent.current = true;
-        const response = await axiosInstance.get(endpoint, { params });
+  // Define fetchData as a callback so it can be used outside
+  const fetchData = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      requestSent.current = true;
 
-        setData(response.data);
-      } catch (err) {
-        setError(err);
-      } finally {
-        setLoading(false);
-      }
+      const response = await axiosInstance.get(endpoint, { params });
+
+      setData(response.data);
+    } catch (err) {
+      setError(err);
+    } finally {
+      setLoading(false);
     }
 
-    // Prevent sending multiple requests
-    if (!requestSent.current) {
-      fetchData();
-    }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- paramsString is a stringified object
   }, [endpoint, paramsString]);
 
-  return { data, loading, error };
+  useEffect(() => {
+    // Prevent sending multiple requests
+    if (instant && !requestSent.current) {
+      fetchData();
+    }
+  }, [fetchData, instant]);
+
+  // Return fetchData so it can be called externally
+  return { data, loading, error, fetchData };
 }

--- a/frontend/src/hooks/useDate.js
+++ b/frontend/src/hooks/useDate.js
@@ -1,0 +1,18 @@
+import { useState, useCallback } from "react";
+import { format, parseISO } from "date-fns";
+
+const FORMAT_DEFAULT = "MMMM d, yyyy";
+const FORMAT_SHORT = "EEE, MMM d";
+
+// Parses an ISO date string and provides formatting utilities
+export default function useDate(initialDate) {
+  const [date, setDate] = useState(parseISO(initialDate));
+
+  // Returns the formatted date string
+  const formatted = useCallback(
+    (dateFormat = FORMAT_DEFAULT) => format(date, dateFormat),
+    [date],
+  );
+
+  return { date, setDate, formatted, FORMAT_DEFAULT, FORMAT_SHORT };
+}

--- a/frontend/src/router/pages/ParkDetails.jsx
+++ b/frontend/src/router/pages/ParkDetails.jsx
@@ -1,128 +1,44 @@
 import { useParams } from "react-router-dom";
-import { faChevronDown, faPen, faChevronUp } from "@fa-kit/icons/classic/solid";
-import { faCircleExclamation } from "@fa-kit/icons/classic/regular";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import NavBack from "../../components/NavBack";
-import walkInCamping from "../../assets/icons/walk-in-camping.svg";
-
+import { useApiGet } from "@/hooks/useApi";
+import NavBack from "@/components/NavBack";
+import LoadingBar from "@/components/LoadingBar";
+import SubArea from "@/components/ParkDetailsSubArea";
 import "./ParkDetails.scss";
 
+// Returns an array of sub-area components
+function getSubAreas(park) {
+  if (!park) return [];
+
+  return Object.entries(park.subAreas).map(([title, subArea]) => (
+    <SubArea key={title} title={title} data={subArea} />
+  ));
+}
+
 function ParkDetails() {
-  // @TODO: fetch park name + details
   const { parkId } = useParams();
+  const { data: park, loading, error } = useApiGet(`/parks/${parkId}`);
+
+  function renderSubAreas() {
+    if (loading) {
+      return <LoadingBar />;
+    }
+
+    if (error) {
+      return <p>Error loading parks data: {error.message}</p>;
+    }
+
+    return getSubAreas(park);
+  }
 
   return (
     <div className="page park-details">
       <NavBack routePath={"/"}>Back to Dates management</NavBack>
 
       <header className="page-header internal">
-        <h1>Elk Falls Park #{parkId}</h1>
+        <h1>{park?.name}</h1>
       </header>
 
-      <section className="sub-area">
-        <h2>
-          <img src={walkInCamping} className="sub-area-icon" /> Frontcountry
-          Camping
-        </h2>
-
-        <div className="season">
-          <div className="details">
-            <header>
-              <h3>2025 season</h3>
-              <span className="badge rounded-pill text-bg-warning">
-                Requested
-              </span>
-              <button className="btn btn-text-primary expand-toggle">
-                <span>Last updated: Never</span>
-                <FontAwesomeIcon
-                  className="append-content ms-2"
-                  icon={faChevronDown}
-                />
-              </button>
-            </header>
-          </div>
-
-          <div className="controls">
-            <button className="btn btn-text-primary">
-              <FontAwesomeIcon className="append-content me-2" icon={faPen} />
-              <span>Edit</span>
-            </button>
-          </div>
-        </div>
-
-        <div className="season expanded">
-          <div className="details expanded">
-            <header>
-              <h3>2024 season</h3>
-              <span className="badge rounded-pill text-bg-success">
-                Published
-              </span>
-              <button className="btn btn-text-primary expand-toggle">
-                <span>Last updated: Never</span>
-                <FontAwesomeIcon
-                  className="append-content ms-2"
-                  icon={faChevronUp}
-                />
-              </button>
-            </header>
-
-            <div className="details-content">
-              <h4>Alouette Campground</h4>
-
-              <table className="table table-striped sub-area-dates">
-                <tbody>
-                  <tr>
-                    <th scope="row">Operating dates</th>
-                    <td>Mon, Mar 28 - Wed, Oct 15</td>
-                  </tr>
-                  <tr>
-                    <th scope="row">Reservation dates</th>
-                    <td>
-                      Tue, Mar 28 - Wed, Apr 1<br />
-                      Mon, May 1 - Wed, Oct 14
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
-
-              <h4>Gold Creek Campground</h4>
-
-              <table className="table table-striped sub-area-dates">
-                <tbody>
-                  <tr>
-                    <th scope="row">Operating dates</th>
-                    <td>Mon, Mar 28 - Wed, Oct 15</td>
-                  </tr>
-                  <tr>
-                    <th scope="row">Reservation dates</th>
-                    <td>
-                      Tue, Mar 28 - Wed, Apr 1<br />
-                      Mon, May 1 - Wed, Oct 14
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
-            </div>
-          </div>
-
-          <div className="controls">
-            <button className="btn btn-text-primary">
-              <FontAwesomeIcon className="append-content me-2" icon={faPen} />
-              <span>Edit</span>
-            </button>
-
-            <div className="divider"></div>
-
-            <button className="btn btn-text-primary">
-              <FontAwesomeIcon
-                className="append-content me-2"
-                icon={faCircleExclamation}
-              />
-              <span>Preview</span>
-            </button>
-          </div>
-        </div>
-      </section>
+      {renderSubAreas()}
     </div>
   );
 }

--- a/frontend/src/router/pages/ParkDetails.scss
+++ b/frontend/src/router/pages/ParkDetails.scss
@@ -1,7 +1,11 @@
 .page.park-details {
   .sub-area {
+    &:not(:last-of-type) {
+      margin-bottom: var(--layout-margin-xxlarge);
+    }
+
     & > h2 {
-      margin-bottom: var(--layout-margin-xlarge);
+      margin-bottom: var(--layout-margin-large);
       display: flex;
       gap: var(--layout-margin-medium);
 

--- a/frontend/src/router/pages/ParkDetails.scss
+++ b/frontend/src/router/pages/ParkDetails.scss
@@ -70,14 +70,15 @@
       .details-content {
         padding: 0 var(--layout-padding-large) var(--layout-padding-large);
 
+        .feature {
+          &:not(:last-of-type) {
+            margin-bottom: var(--layout-margin-large);
+          }
+        }
+
         .sub-area-dates {
           border-top: var(--layout-border-width-medium) solid
             var(--surface-color-border-dark);
-          margin-bottom: var(--layout-margin-large);
-
-          &:last-child {
-            margin-bottom: 0;
-          }
         }
       }
     }

--- a/frontend/src/router/pages/ParkDetails.scss
+++ b/frontend/src/router/pages/ParkDetails.scss
@@ -97,6 +97,7 @@
         border-left: none;
         border-radius: 0 var(--layout-border-radius-medium)
           var(--layout-border-radius-medium) 0;
+        min-height: 5.5rem;
       }
 
       .divider {

--- a/frontend/src/router/pages/ReviewChanges.scss
+++ b/frontend/src/router/pages/ReviewChanges.scss
@@ -14,22 +14,7 @@
     }
   }
 
-  .date-range {
-    display: flex;
-    justify-content: space-between;
-    width: fit-content;
-
-    .date {
-      min-width: 6em;
-      max-width: fit-content;
-    }
-
-    .separator {
-      margin-inline: 1em;
-    }
-  }
-
-  // spacing between date range values
+  // spacing between DateRange components
   td:not(:last-child) .date-range {
     margin-right: 1em;
   }


### PR DESCRIPTION
### Jira Ticket

CMS-452

### Description
<!-- What did you change, and why? -->

This branch builds out components for the Park Details page, and hooks it up to data from the API.

I added a useDate hook to let us parse and format dates. We can add other date functions in there as needed.
(I thought about automatically parsing all dates inside the API hook, but that may not be necessary for this MVP)

It also adds a StatusBadge component and replaces the placeholder content on the "Edit and Review" table landing page. It has a hardcoded list of possible status strings.

## Two things from the ticket that aren't done:

> Global variable for reviewer 

I think this sill need to be done after we import data from Strapi (or elsewhere). Let me know if there's anything I should do in the meantime.

> Displayed on expansion of accordion 
> - Summary of dates 
> - Notes  

Do we have an endpoint that provides this data already? Should I add one? I'd prefer to make it a separate ticket if it still needs to be built.
