### PR TITLE
CMS-468: Override theme link hover color

### DIFF
--- a/frontend/src/components/DateRange.scss
+++ b/frontend/src/components/DateRange.scss
@@ -4,10 +4,11 @@
   width: fit-content;
 
   .date {
+    max-width: fit-content;
+
     @media (min-width: 576px) {
       min-width: 6em;
     }
-    max-width: fit-content;
   }
 
   .separator {

--- a/frontend/src/global.scss
+++ b/frontend/src/global.scss
@@ -43,6 +43,16 @@ header.page-header {
   }
 }
 
+// override bootstrap theme's text hover color
+:root {
+  --bs-link-hover-color: var(--surface-color-primary-hover);
+  --bs-btn-hover-color: var(--surface-color-primary-hover);
+}
+a:hover,
+a:not(.btn):focus {
+  color: var(--surface-color-primary-hover);
+}
+
 // custom bootstrap button style: "text"
 .btn-text-primary {
   --bs-btn-color: var(--theme-primary-blue);


### PR DESCRIPTION
### Jira Ticket

CMS-468

### Description
<!-- What did you change, and why? -->

A small change to update the link/text hover color and make it align with the `surface.color.primary.hover` value from the design tokens page. The bootstrap theme had it using a very bright blue that looked out of place.

I also got a warning about Sass syntax so I re-ordered some lines in DateRange.scss while I was at it. It's an unrelated change but I was fixing small style issues in this branch anyway...