### PR TITLE
CMS-322: Add form validation hook

### DIFF
--- a/frontend/src/hooks/useValidation.js
+++ b/frontend/src/hooks/useValidation.js
@@ -147,7 +147,7 @@ export default function useValidation(dates, notes, season) {
     // Check if the start date is before the end date
     if (startDate > endDate) {
       return addError(
-        endDateId,
+        dateRangeId,
         "Enter an end date that comes after the start date",
       );
     }
@@ -160,7 +160,7 @@ export default function useValidation(dates, notes, season) {
       endDate.getFullYear() !== operatingYear
     ) {
       // startDate =< endDate check happens first, so the end date will never fail this check
-      return addError(dateRangeId, `Enter dates for ${operatingYear} only`);
+      return addError(startDateId, `Enter dates for ${operatingYear} only`);
     }
 
     return true;
@@ -233,7 +233,7 @@ export default function useValidation(dates, notes, season) {
 
     if (daysBetween < 1) {
       return addError(
-        dateableFeature,
+        dateableId,
         "Reservation end date must be one or more days before the operating end date.",
       );
     }

--- a/frontend/src/hooks/useValidation.js
+++ b/frontend/src/hooks/useValidation.js
@@ -125,7 +125,6 @@ export default function useValidation(dates, notes, season) {
 
   // Validates the start and end datepicker fields in a date range
   function validateDateRange({
-    dateRange,
     start,
     startDateId,
     end,
@@ -196,7 +195,6 @@ export default function useValidation(dates, notes, season) {
       // Loop over date ranges for the date type
       dateRanges.every((dateRange, index) =>
         validateDateRange({
-          dateRange,
           start: dateRange.startDate,
           startDateId: `start-date-${dateRange.dateableId}-${dateRange.dateType.id}-${index}`,
           end: dateRange.endDate,

--- a/frontend/src/hooks/useValidation.js
+++ b/frontend/src/hooks/useValidation.js
@@ -1,0 +1,298 @@
+import { useState } from "react";
+import { omit, mapValues, minBy, maxBy } from "lodash";
+import { differenceInCalendarDays } from "date-fns";
+
+// Validation functions for the SubmitForm component
+export default function useValidation(dates, notes, season) {
+  // Validation errors
+  const [errors, setErrors] = useState({});
+  // @TODO: Track if the form has been submitted, and validate on change after that
+  const [formSubmitted, setFormSubmitted] = useState(false);
+
+  // Add field key and error message to `errors`
+  function addError(fieldId, message) {
+    setErrors((prevErrors) => ({
+      ...prevErrors,
+      [fieldId]: message,
+    }));
+    return false;
+  }
+
+  // Remove field key from `errors`
+  function clearError(fieldId) {
+    setErrors((prevErrors) => omit(prevErrors, fieldId));
+  }
+
+  // Returns true if innerStart and innerEnd are within outerStart and outerEnd
+  function checkWithinRange(outerStart, outerEnd, innerStart, innerEnd) {
+    return outerStart <= innerStart && outerEnd >= innerEnd;
+  }
+
+  // Calculates the extents of each date type for each campsite grouping
+  function getDateExtents(datesObj = dates) {
+    const mapped = mapValues(datesObj, (campsiteDates) =>
+      mapValues(campsiteDates, (dateTypeDates) => {
+        // Get the dateRange with the earliest start date for this campground & date type
+        const minDateRange = minBy(
+          dateTypeDates,
+          (dateRange) => new Date(dateRange.startDate),
+        );
+        const minDate = minDateRange?.startDate
+          ? new Date(minDateRange?.startDate)
+          : null;
+
+        // Get the dateRange with the latest end date for this campground & date type
+        const maxDateRange = maxBy(
+          dateTypeDates,
+          (dateRange) => new Date(dateRange.endDate),
+        );
+        const maxDate = maxDateRange?.endDate
+          ? new Date(maxDateRange.endDate)
+          : null;
+
+        return { minDate, maxDate };
+      }),
+    );
+
+    return mapped;
+  }
+
+  // Validates the notes textarea field
+  function validateNotes(value = notes) {
+    clearError("notes");
+
+    if (!value && ["approved", "published"].includes(season.status)) {
+      return addError(
+        "notes",
+        "Required when updating previously approved dates",
+      );
+    }
+
+    return true;
+  }
+
+  // validates the start and end datepicker fields in a date range
+  function validateDateRange({
+    dateRange,
+    start,
+    startDateId,
+    end,
+    endDateId,
+    datesObj = dates,
+  }) {
+    clearError(startDateId);
+    clearError(endDateId);
+
+    // If both dates are blank, ignore the range
+    if (!start && !end) {
+      return true;
+    }
+
+    // Both dates are required if one is set
+    if (!start) {
+      return addError(startDateId, "Enter a start date");
+    }
+
+    if (!end) {
+      return addError(endDateId, "Enter an end date");
+    }
+
+    // Parse date strings
+    const startDate = new Date(start);
+    const endDate = new Date(end);
+
+    // Check if the start date is before the end date
+    if (startDate > endDate) {
+      return addError(
+        endDateId,
+        "Enter an end date that comes after the start date",
+      );
+    }
+
+    const operatingYear = season.operatingYear;
+
+    // Date must be within the year for that form
+    if (
+      startDate.getFullYear() !== operatingYear ||
+      endDate.getFullYear() !== operatingYear
+    ) {
+      // startDate =< endDate check happens first, so the end date will never fail this check
+      return addError(startDateId, `Enter dates for ${operatingYear} only`);
+    }
+
+    const dateType = dateRange.dateType.name;
+    const { dateableId } = dateRange;
+
+    const dateExtents = getDateExtents(datesObj);
+
+    // Get the extent of dates for each type
+    const operationExtent = dateExtents[dateableId].Operation;
+    const reservationExtent = dateExtents[dateableId].Reservation;
+
+    // Check if the reservation dates are within the operating dates
+    // @TODO: Check for gaps if operating dates is non-contiguous
+    const withinRange = checkWithinRange(
+      operationExtent.minDate,
+      operationExtent.maxDate,
+      reservationExtent.minDate,
+      reservationExtent.maxDate,
+    );
+
+    // Validate rules specific to Reservation dates
+    if (dateType === "Reservation") {
+      // Date selected is within the operating dates
+      if (!withinRange) {
+        return addError(
+          endDateId,
+          "Enter reservation dates that fall within the operating dates selected.",
+        );
+      }
+    }
+
+    // Validate rules specific to Operation dates
+    if (dateType === "Operation") {
+      // Date selected encompasses reservation dates
+      if (!withinRange) {
+        // @TODO: Highlight the latest extent instead of the one being changed
+        return addError(
+          endDateId,
+          "Enter operating dates that are the same or longer than the reservation dates selected.",
+        );
+      }
+    }
+
+    // End date is one or more days after reservation end date
+    const daysBetween = differenceInCalendarDays(
+      operationExtent.maxDate,
+      reservationExtent.maxDate,
+    );
+
+    // The "within range" check above will ensure that the operation end date
+    // is after the reservation end date, so we only need to check the number of days between the them
+
+    if (dateType === "Operation") {
+      if (daysBetween < 1) {
+        return addError(
+          endDateId,
+          "Operating end date must be one or more days after reservation end date.",
+        );
+      }
+    }
+
+    if (dateType === "Reservation") {
+      if (daysBetween < 1) {
+        return addError(
+          endDateId,
+          "Reservation end date must be one or more days before the operating end date.",
+        );
+      }
+    }
+
+    return true;
+  }
+
+  // Validates all date ranges for a dateable feature from `dates`
+  function validateFeatureDates(dateableId, datesObj = dates) {
+    const dateableFeature = datesObj[dateableId];
+
+    const dateTypeGroups = Object.values(dateableFeature);
+
+    // Clear all errors for this dateable feature:
+    // Build a list of all field IDs to clear from `errors`
+    const fieldIds = dateTypeGroups.flatMap((dateRanges) =>
+      dateRanges.flatMap((dateRange, index) => {
+        const dateRangeId = `${dateRange.dateableId}-${dateRange.dateType.id}-${index}`;
+
+        return [`start-date-${dateRangeId}`, `end-date-${dateRangeId}`];
+      }),
+    );
+
+    // Remove any errors for this dateable feature before revalidating
+    setErrors((prevErrors) => omit(prevErrors, fieldIds));
+
+    const dateTypeGroupsValid = dateTypeGroups.every((dateRanges) =>
+      // Loop over date ranges for the date type
+      dateRanges.every((dateRange, index) =>
+        validateDateRange({
+          dateRange,
+          start: dateRange.startDate,
+          startDateId: `start-date-${dateRange.dateableId}-${dateRange.dateType.id}-${index}`,
+          end: dateRange.endDate,
+          endDateId: `end-date-${dateRange.dateableId}-${dateRange.dateType.id}-${index}`,
+          datesObj,
+        }),
+      ),
+    );
+
+    return dateTypeGroupsValid;
+  }
+
+  function validateForm() {
+    // Clear errors from previous validation
+    setErrors({});
+
+    // Validate notes
+    if (!validateNotes()) return false;
+
+    // Validate all dates:
+    // Loop over dateable features from `dates` (campsite groupings)
+    const dateableIds = Object.keys(dates);
+    const validDates = dateableIds.every((dateableId) =>
+      validateFeatureDates(dateableId),
+    );
+
+    // @TODO: Scroll the first error into view
+
+    return validDates;
+  }
+
+  // Validates a date range, then its parent dateable feature
+  function onUpdateDateRange({
+    dateRange,
+    start,
+    startDateId,
+    end,
+    endDateId,
+    // Allow overriding dates during state updates
+    datesObj = dates,
+  }) {
+    const { dateableId } = dateRange;
+
+    // Validate the date range that changed
+    const rangeValid = validateDateRange({
+      dateRange,
+      start,
+      startDateId,
+      end,
+      endDateId,
+      datesObj,
+    });
+
+    // If the changed dateRange is invalid, don't validate anything else
+    if (!rangeValid) return false;
+
+    // If the changed dateRange is valid, validate the whole campsite grouping feature
+    // to resolve any inter-dependent date range validations.
+
+    // @TODO: This unnecessarily validates the changed dateRange twice;
+    // Consider refactoring to validate once, but only show relevant errors.
+
+    return validateFeatureDates(dateableId, datesObj);
+  }
+
+  return {
+    errors,
+    setErrors,
+    formSubmitted,
+    setFormSubmitted,
+    addError,
+    clearError,
+    checkWithinRange,
+    getDateExtents,
+    validateNotes,
+    validateDateRange,
+    validateFeatureDates,
+    validateForm,
+    onUpdateDateRange,
+  };
+}

--- a/frontend/src/hooks/useValidation.js
+++ b/frontend/src/hooks/useValidation.js
@@ -64,7 +64,7 @@ export default function useValidation(dates, notes, season) {
     if (!value && ["approved", "published"].includes(season.status)) {
       return addError(
         "notes",
-        "Required when updating previously approved dates",
+        "The dates you are editing have already been Approved or Published. Please provide a note explaining the reason for this update.",
       );
     }
 
@@ -169,6 +169,14 @@ export default function useValidation(dates, notes, season) {
   // Validates all date ranges for a dateable feature from `dates`
   function validateFeatureDates(dateableId, datesObj = dates) {
     const dateableFeature = datesObj[dateableId];
+
+    // If the feature has no dates, skip validation
+    if (
+      dateableFeature.Operation.length === 0 &&
+      dateableFeature.Reservation.length === 0
+    ) {
+      return true;
+    }
 
     const dateTypeGroups = Object.values(dateableFeature);
 

--- a/frontend/src/hooks/useValidation.js
+++ b/frontend/src/hooks/useValidation.js
@@ -6,7 +6,7 @@ import { differenceInCalendarDays, parseISO, isBefore, max } from "date-fns";
 export default function useValidation(dates, notes, season) {
   // Validation errors
   const [errors, setErrors] = useState({});
-  // @TODO: Track if the form has been submitted, and validate on change after that
+  // Track if the form has been submitted, and validate on change after that
   const [formSubmitted, setFormSubmitted] = useState(false);
 
   // Add field key and error message to `errors`
@@ -296,6 +296,9 @@ export default function useValidation(dates, notes, season) {
     // Allow overriding dates during state updates
     datesObj = dates,
   }) {
+    // Don't validate until the form has been submitted
+    if (!formSubmitted) return true;
+
     const { dateableId } = dateRange;
 
     // Validate the date range that changed

--- a/frontend/src/router/pages/SubmitDates.jsx
+++ b/frontend/src/router/pages/SubmitDates.jsx
@@ -19,6 +19,7 @@ import PropTypes from "prop-types";
 
 import { useApiGet, useApiPost } from "@/hooks/useApi";
 import "./SubmitDates.scss";
+import classNames from "classnames";
 
 function SubmitDates() {
   const { parkId, seasonId } = useParams();
@@ -240,6 +241,10 @@ function SubmitDates() {
             </label>
             <DatePicker
               id={startDateId}
+              className={classNames({
+                "form-control": true,
+                "is-invalid": errors?.[startDateId],
+              })}
               selected={dateRange.startDate}
               onChange={(date) => {
                 updateDateRange(
@@ -281,6 +286,10 @@ function SubmitDates() {
             </label>
             <DatePicker
               id={endDateId}
+              className={classNames({
+                "form-control": true,
+                "is-invalid": errors?.[endDateId],
+              })}
               selected={dateRange.endDate}
               onChange={(date) => {
                 updateDateRange(
@@ -528,7 +537,10 @@ function SubmitDates() {
             className={`form-group mb-4 ${errors?.notes ? "has-error" : ""}`}
           >
             <textarea
-              className="form-control"
+              className={classNames({
+                "form-control": true,
+                "is-invalid": errors?.notes,
+              })}
               id="notes"
               name="notes"
               rows="5"

--- a/frontend/src/router/pages/SubmitDates.jsx
+++ b/frontend/src/router/pages/SubmitDates.jsx
@@ -1,14 +1,6 @@
 import { useParams, useNavigate } from "react-router-dom";
 import { useEffect, useState } from "react";
-import {
-  omit,
-  mapValues,
-  maxBy,
-  minBy,
-  cloneDeep,
-  set as lodashSet,
-} from "lodash";
-import { differenceInCalendarDays } from "date-fns";
+import { cloneDeep, set as lodashSet } from "lodash";
 import { faCircleInfo } from "@fa-kit/icons/classic/regular";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import NavBack from "@/components/NavBack";
@@ -18,6 +10,7 @@ import groupCamping from "@/assets/icons/group-camping.svg";
 import { formatDateRange, formatTimestamp } from "@/lib/utils";
 import LoadingBar from "@/components/LoadingBar";
 import FlashMessage from "@/components/FlashMessage";
+import useValidation from "@/hooks/useValidation";
 
 import DatePicker from "react-datepicker";
 import "react-datepicker/dist/react-datepicker.css";
@@ -35,283 +28,15 @@ function SubmitDates() {
   const [notes, setNotes] = useState("");
   const [readyToPublish, setReadyToPublish] = useState(false);
 
+  const {
+    errors,
+    setFormSubmitted,
+    validateNotes,
+    validateForm,
+    onUpdateDateRange,
+  } = useValidation(dates, notes, season);
+
   const [showFlash, setShowFlash] = useState(false);
-
-  // Validation errors
-  const [errors, setErrors] = useState({});
-  // @TODO: Track if the form has been submitted, and validate on change after that
-  const [formSubmitted, setFormSubmitted] = useState(false);
-
-  function addError(fieldId, message) {
-    setErrors((prevErrors) => ({
-      ...prevErrors,
-      [fieldId]: message,
-    }));
-    return false;
-  }
-
-  // Remove field key from errors
-  function clearError(fieldId) {
-    setErrors((prevErrors) => omit(prevErrors, fieldId));
-  }
-
-  // Returns true if innerStart and innerEnd are within outerStart and outerEnd
-  function checkWithinRange(outerStart, outerEnd, innerStart, innerEnd) {
-    return outerStart <= innerStart && outerEnd >= innerEnd;
-  }
-
-  // Calculates the extents of each date type for each campsite grouping
-  function getDateExtents(datesObj = dates) {
-    const mapped = mapValues(datesObj, (campsiteDates) =>
-      mapValues(campsiteDates, (dateTypeDates) => {
-        // Get the dateRange with the earliest start date for this campground & date type
-        const minDateRange = minBy(
-          dateTypeDates,
-          (dateRange) => new Date(dateRange.startDate),
-        );
-        const minDate = minDateRange?.startDate
-          ? new Date(minDateRange?.startDate)
-          : null;
-
-        // Get the dateRange with the latest end date for this campground & date type
-        const maxDateRange = maxBy(
-          dateTypeDates,
-          (dateRange) => new Date(dateRange.endDate),
-        );
-        const maxDate = maxDateRange?.endDate
-          ? new Date(maxDateRange.endDate)
-          : null;
-
-        return { minDate, maxDate };
-      }),
-    );
-
-    return mapped;
-  }
-
-  // @TODO: import from an external module
-  const validate = {
-    notes(value = notes) {
-      clearError("notes");
-
-      if (!value && ["approved", "published"].includes(season.status)) {
-        return addError(
-          "notes",
-          "Required when updating previously approved dates",
-        );
-      }
-
-      return true;
-    },
-
-    dateRange({
-      dateRange,
-      start,
-      startDateId,
-      end,
-      endDateId,
-      datesObj = dates,
-    }) {
-      clearError(startDateId);
-      clearError(endDateId);
-
-      // If both dates are blank, ignore the range
-      if (!start && !end) {
-        return true;
-      }
-
-      // Both dates are required if one is set
-      if (!start) {
-        return addError(startDateId, "Enter a start date");
-      }
-
-      if (!end) {
-        return addError(endDateId, "Enter an end date");
-      }
-
-      // Parse date strings
-      const startDate = new Date(start);
-      const endDate = new Date(end);
-
-      // Check if the start date is before the end date
-      if (startDate > endDate) {
-        return addError(
-          endDateId,
-          "Enter an end date that comes after the start date",
-        );
-      }
-
-      const operatingYear = season.operatingYear;
-
-      // Date must be within the year for that form
-      if (
-        startDate.getFullYear() !== operatingYear ||
-        endDate.getFullYear() !== operatingYear
-      ) {
-        // startDate =< endDate check happens first, so the end date will never fail this check
-        return addError(startDateId, `Enter dates for ${operatingYear} only`);
-      }
-
-      const dateType = dateRange.dateType.name;
-      const { dateableId } = dateRange;
-
-      const dateExtents = getDateExtents(datesObj);
-
-      // Get the extent of dates for each type
-      const operationExtent = dateExtents[dateableId].Operation;
-      const reservationExtent = dateExtents[dateableId].Reservation;
-
-      // Check if the reservation dates are within the operating dates
-      // @TODO: Check for gaps if operating dates is non-contiguous
-      const withinRange = checkWithinRange(
-        operationExtent.minDate,
-        operationExtent.maxDate,
-        reservationExtent.minDate,
-        reservationExtent.maxDate,
-      );
-
-      // Validate rules specific to Reservation dates
-      if (dateType === "Reservation") {
-        // Date selected is within the operating dates
-        if (!withinRange) {
-          return addError(
-            endDateId,
-            "Enter reservation dates that fall within the operating dates selected.",
-          );
-        }
-      }
-
-      // Validate rules specific to Operation dates
-      if (dateType === "Operation") {
-        // Date selected encompasses reservation dates
-        if (!withinRange) {
-          // @TODO: Highlight the latest extent instead of the one being changed
-          return addError(
-            endDateId,
-            "Enter operating dates that are the same or longer than the reservation dates selected.",
-          );
-        }
-      }
-
-      // End date is one or more days after reservation end date
-      const daysBetween = differenceInCalendarDays(
-        operationExtent.maxDate,
-        reservationExtent.maxDate,
-      );
-
-      // The "within range" check above will ensure that the operation end date
-      // is after the reservation end date, so we only need to check the number of days between the them
-
-      if (dateType === "Operation") {
-        if (daysBetween < 1) {
-          return addError(
-            endDateId,
-            "Operating end date must be one or more days after reservation end date.",
-          );
-        }
-      }
-
-      if (dateType === "Reservation") {
-        if (daysBetween < 1) {
-          return addError(
-            endDateId,
-            "Reservation end date must be one or more days before the operating end date.",
-          );
-        }
-      }
-
-      return true;
-    },
-  };
-
-  // Validates all date ranges for a dateable feature from `dates`
-  function validateFeatureDates(dateableId, datesObj = dates) {
-    const dateableFeature = datesObj[dateableId];
-
-    const dateTypeGroups = Object.values(dateableFeature);
-
-    // Clear all errors for this dateable feature:
-    // Build a list of all field IDs to clear from `errors`
-    const fieldIds = dateTypeGroups.flatMap((dateRanges) =>
-      dateRanges.flatMap((dateRange, index) => {
-        const dateRangeId = `${dateRange.dateableId}-${dateRange.dateType.id}-${index}`;
-
-        return [`start-date-${dateRangeId}`, `end-date-${dateRangeId}`];
-      }),
-    );
-
-    // Remove any errors for this dateable feature before revalidating
-    setErrors((prevErrors) => omit(prevErrors, fieldIds));
-
-    const dateTypeGroupsValid = dateTypeGroups.every((dateRanges) =>
-      // Loop over date ranges for the date type
-      dateRanges.every((dateRange, index) =>
-        validate.dateRange({
-          dateRange,
-          start: dateRange.startDate,
-          startDateId: `start-date-${dateRange.dateableId}-${dateRange.dateType.id}-${index}`,
-          end: dateRange.endDate,
-          endDateId: `end-date-${dateRange.dateableId}-${dateRange.dateType.id}-${index}`,
-          datesObj,
-        }),
-      ),
-    );
-
-    return dateTypeGroupsValid;
-  }
-
-  function validateForm() {
-    // Clear errors from previous validation
-    setErrors({});
-
-    // Validate notes
-    if (!validate.notes()) return false;
-
-    // Validate all dates:
-    // Loop over dateable features from `dates` (campsite groupings)
-    const dateableIds = Object.keys(dates);
-    const validDates = dateableIds.every((dateableId) =>
-      validateFeatureDates(dateableId),
-    );
-
-    // @TODO: Scroll the first error into view
-
-    return validDates;
-  }
-
-  // Validates a date range, then its parent dateable feature
-  function onUpdateDateRange({
-    dateRange,
-    start,
-    startDateId,
-    end,
-    endDateId,
-    // Allow overriding dates during state updates
-    datesObj = dates,
-  }) {
-    const { dateableId } = dateRange;
-
-    // Validate the date range that changed
-    const rangeValid = validate.dateRange({
-      dateRange,
-      start,
-      startDateId,
-      end,
-      endDateId,
-      datesObj,
-    });
-
-    // If the changed dateRange is invalid, don't validate anything else
-    if (!rangeValid) return false;
-
-    // If the changed dateRange is valid, validate the whole campsite grouping feature
-    // to resolve any inter-dependent date range validations.
-
-    // @TODO: This unnecessarily validates the changed dateRange twice;
-    // Consider refactoring to validate once, but only show relevant errors.
-
-    return validateFeatureDates(dateableId, datesObj);
-  }
 
   const { data, loading, error, fetchData } = useApiGet(`/seasons/${seasonId}`);
   const {
@@ -331,12 +56,6 @@ function SubmitDates() {
       throw new Error("Form validation failed");
     }
 
-    if (notes !== "foo") {
-      throw new Error(
-        "validation passed, but returning false for debugging anyway",
-      );
-    }
-
     const payload = {
       notes,
       readyToPublish,
@@ -353,10 +72,6 @@ function SubmitDates() {
 
   // are there changes to save?
   function hasChanges() {
-    if (formSubmitted) {
-      return true;
-    }
-
     const datesChanged = Object.values(dates).some((dateType) =>
       dateType.Operation.concat(dateType.Reservation).some(
         (dateRange) => dateRange.changed,
@@ -464,11 +179,10 @@ function SubmitDates() {
     const newValue = value ? value.toISOString() : null;
 
     setDates((prevDates) => {
-      const updatedDates = cloneDeep(prevDates); // Create a deep clone to avoid mutations
+      const updatedDates = cloneDeep(prevDates);
 
+      // Update the date value and mark the date range as changed
       lodashSet(updatedDates, [dateableId, dateType, index, key], newValue);
-
-      // Mark the date range as changed
       lodashSet(updatedDates, [dateableId, dateType, index, "changed"], true);
 
       if (callback) {
@@ -534,6 +248,7 @@ function SubmitDates() {
                   index,
                   "startDate",
                   date,
+                  // Callback to validate the new value
                   (updatedDates) => {
                     onUpdateDateRange({
                       dateRange,
@@ -574,6 +289,7 @@ function SubmitDates() {
                   index,
                   "endDate",
                   date,
+                  // Callback to validate the new value
                   (updatedDates) => {
                     onUpdateDateRange({
                       dateRange,
@@ -819,7 +535,7 @@ function SubmitDates() {
               value={notes}
               onChange={(ev) => {
                 setNotes(ev.target.value);
-                validate.notes(ev.target.value);
+                validateNotes(ev.target.value);
               }}
             ></textarea>
             {errors?.notes && (

--- a/frontend/src/router/pages/SubmitDates.jsx
+++ b/frontend/src/router/pages/SubmitDates.jsx
@@ -257,10 +257,6 @@ function SubmitDates() {
                   (updatedDates) => {
                     onUpdateDateRange({
                       dateRange,
-                      start: date,
-                      startDateId,
-                      end: dateRange.endDate,
-                      endDateId,
                       datesObj: updatedDates,
                     });
                   },
@@ -269,6 +265,7 @@ function SubmitDates() {
               dateFormat="EEE, MMM d, yyyy"
             />
 
+            {/* Show validation errors for the startDate field */}
             {errors?.[startDateId] && (
               <div className="error-message mt-2">{errors?.[startDateId]}</div>
             )}
@@ -302,10 +299,6 @@ function SubmitDates() {
                   (updatedDates) => {
                     onUpdateDateRange({
                       dateRange,
-                      start: dateRange.startDate,
-                      startDateId,
-                      end: date,
-                      endDateId,
                       datesObj: updatedDates,
                     });
                   },
@@ -314,11 +307,17 @@ function SubmitDates() {
               dateFormat="EEE, MMM d, yyyy"
             />
 
+            {/* Show validation errors for the endDate field */}
             {errors?.[endDateId] && (
               <div className="error-message mt-2">{errors?.[endDateId]}</div>
             )}
           </div>
         </div>
+
+        {/* Show validation errors for the date range */}
+        {errors?.[dateRangeId] && (
+          <div className="error-message mt-2">{errors?.[dateRangeId]}</div>
+        )}
       </div>
     );
   }
@@ -433,6 +432,11 @@ function SubmitDates() {
               </p>
             </div>
           )}
+
+          {/* Show validation errors for the whole dateable feature */}
+          <div className="error-message mt-2">
+            {errors?.[feature.dateable.id]}
+          </div>
         </div>
       </section>
     );
@@ -446,8 +450,8 @@ function SubmitDates() {
         previousSeasonDates: PropTypes.arrayOf(
           PropTypes.shape({
             id: PropTypes.number.isRequired,
-            startDate: PropTypes.string.isRequired,
-            endDate: PropTypes.string.isRequired,
+            startDate: PropTypes.string,
+            endDate: PropTypes.string,
             dateType: PropTypes.shape({
               id: PropTypes.number.isRequired,
               name: PropTypes.string.isRequired,

--- a/frontend/src/router/pages/SubmitDates.scss
+++ b/frontend/src/router/pages/SubmitDates.scss
@@ -33,6 +33,10 @@
     .dates-row {
       margin-bottom: var(--layout-margin-large);
 
+      .form-label {
+        display: block;
+      }
+
       .form-control {
         margin-bottom: var(--layout-margin-medium);
 

--- a/frontend/src/router/pages/SubmitDates.scss
+++ b/frontend/src/router/pages/SubmitDates.scss
@@ -10,29 +10,6 @@
     }
   }
 
-  .react-datepicker-wrapper {
-    width: 100% !important;
-
-    input {
-      display: block;
-      width: 100%;
-      padding: 0.375rem 0.75rem;
-      font-size: 1rem;
-      font-weight: 400;
-      line-height: 1.5;
-      color: #2d2d2d;
-      appearance: none;
-      width: 100%;
-      background-color: var(--bs-body-bg);
-      background-clip: padding-box;
-      border: var(--bs-border-width) solid #d8d8d8;
-      border-radius: var(--bs-border-radius);
-      transition:
-        border-color 0.15s ease-in-out,
-        box-shadow 0.15s ease-in-out;
-    }
-  }
-
   .campground {
     // alternating background color
     &:nth-child(even) {
@@ -106,14 +83,9 @@
       transparent;
   }
 
-  .has-error {
-    textarea {
-      border: 1px solid var(--support-border-color-danger);
-    }
-  }
-
   .error-message {
     color: var(--support-border-color-danger);
+    font-size: 0.875em;
   }
 
   .notes {

--- a/frontend/src/router/pages/SubmitDates.scss
+++ b/frontend/src/router/pages/SubmitDates.scss
@@ -37,6 +37,10 @@
         display: block;
       }
 
+      .react-datepicker-wrapper {
+        width: 100%;
+      }
+
       .form-control {
         margin-bottom: var(--layout-margin-medium);
 


### PR DESCRIPTION
### Jira Ticket

CMS-322

### Description
<!-- What did you change, and why? -->

This branch adds validation functions for the "SubmitDates" page ("notes" field and the date ranges). The logic turned out to be complicated to implement, even if the rules themselves aren't too bad. 

In our meetings last week, we decided it would be unnecessary hassle to reformat the data into a format to work with React Hook Form, and then write our own custom validators for the data structure (which is dynamic, and deeply-nested). The result is that this whole thing is custom-made, which makes it potentially fragile and error prone! But the benefit is that we can have our data structured the way we want, and run validations without needing to change it and then change it back.

I struggled with the state hooks, updating asynchronously when a field is changed, and then instantly trying to validate. In order to validate the newly-changed values, I added a callback function to `updateDateRange`, which feels sketchy but seems to be a common practice. Let me know if there's a cleaner way to do this.

There's a lot to look at here, so I'm hoping for a review from @diego-oxd especially, but @ayumi-oxd if you get some time even to skim it, I'd welcome any feedback!

## Update from Dec 11:

One `@TODO` items remains right now: 

**Scroll the first error into view:** React Hook Form does this. If the validation errors are outside the viewport when you click the button at the bottom, there should be some indication of why your submission didn't work. Either scroll the errors into view, or show something next to the button to indicate validation errors.

This isn't part of the current requirements, so I'll merge without it but I'll mention to Amanda and see if it's something we want to do in a future ticket.