### PR TITLE
CMS-453: Update status change logic and add not-ready flag

### DIFF
--- a/backend/routes/api/parks.js
+++ b/backend/routes/api/parks.js
@@ -54,7 +54,7 @@ router.get(
         {
           model: Season,
           as: "seasons",
-          attributes: ["id", "status"],
+          attributes: ["id", "status", "readyToPublish"],
         },
         {
           model: Feature,
@@ -92,6 +92,7 @@ router.get(
         hasReservations: park.features.some(
           (feature) => feature.hasReservations && feature.active,
         ),
+        readyToPublish: park.seasons.every((s) => s.readyToPublish),
       }));
 
     // Return all rows

--- a/backend/routes/api/parks.js
+++ b/backend/routes/api/parks.js
@@ -1,6 +1,13 @@
 import { Router } from "express";
 import _ from "lodash";
-import { Park, Season, FeatureType, Feature } from "../../models/index.js";
+import {
+  Park,
+  Season,
+  FeatureType,
+  Feature,
+  Dateable,
+  DateRange,
+} from "../../models/index.js";
 import asyncHandler from "express-async-handler";
 
 const router = Router();
@@ -53,21 +60,39 @@ router.get(
           model: Feature,
           as: "features",
           attributes: ["id", "hasReservations"],
+          include: [
+            {
+              model: Dateable,
+              as: "dateable",
+              attributes: ["id"],
+              include: [
+                {
+                  model: DateRange,
+                  as: "dateRanges",
+                  attributes: ["id"],
+                },
+              ],
+            },
+          ],
         },
       ],
     });
 
     const parks = parksWithBundlesAndSeasons.map((park) => park.toJSON());
 
-    const output = parks.map((park) => ({
-      id: park.id,
-      name: park.name,
-      orcs: park.orcs,
-      status: getParkStatus(park.seasons),
-      hasReservations: park.features.some(
-        (feature) => feature.hasReservations && feature.active,
-      ),
-    }));
+    const output = parks
+      .filter((item) =>
+        item.features.some((feature) => feature.dateable.dateRanges.length > 0),
+      )
+      .map((park) => ({
+        id: park.id,
+        name: park.name,
+        orcs: park.orcs,
+        status: getParkStatus(park.seasons),
+        hasReservations: park.features.some(
+          (feature) => feature.hasReservations && feature.active,
+        ),
+      }));
 
     // Return all rows
     res.json(output);
@@ -86,7 +111,13 @@ router.get(
         {
           model: Season,
           as: "seasons",
-          attributes: ["id", "operatingYear", "status", "updatedAt"],
+          attributes: [
+            "id",
+            "operatingYear",
+            "status",
+            "updatedAt",
+            "readyToPublish",
+          ],
           include: [
             {
               model: FeatureType,

--- a/backend/routes/api/seasons.js
+++ b/backend/routes/api/seasons.js
@@ -17,21 +17,21 @@ import { Op } from "sequelize";
 
 const router = Router();
 
-function getNewStatusForSeason(season, user) {
-  // this will depend on the user's role
-  // rn we're just passing null for the user and returning the same status
-  // For staff
-  //   requested -- > requested
-  //   under review -- > under review
-  //   approved -- > under review
-  //   published --> under review
-  // For operator
-  //   requested -- > requested
-  //   under review -- > requested
-  //   approved -- > requested
-  //   published --> requested
-  return season.status;
-}
+// function getNewStatusForSeason(season, user) {
+//   // this will depend on the user's role
+//   // rn we're just setting everything to requested
+//   // For staff
+//   //   requested -- > requested
+//   //   under review -- > under review
+//   //   approved -- > under review
+//   //   published --> under review
+//   // For operator
+//   //   requested -- > requested
+//   //   under review -- > requested
+//   //   approved -- > requested
+//   //   published --> requested
+//   return season.status;
+// }
 
 router.get(
   "/seasons/:seasonId",
@@ -230,8 +230,8 @@ router.post(
     }
 
     // this will depend on the user's role
-    // rn we're just passing null for the user and returning the same status
-    const newStatus = getNewStatusForSeason(season, null);
+    // right now we're just setting everything to requested
+    // const newStatus = getNewStatusForSeason(season, null);
 
     // create season change log
     const seasonChangeLog = await SeasonChangeLog.create({
@@ -239,7 +239,7 @@ router.post(
       userId: 1,
       notes,
       statusOldValue: season.status,
-      statusNewValue: newStatus,
+      statusNewValue: "requested",
       readyToPublishOldValue: season.readyToPublish,
       readyToPublishNewValue: readyToPublish,
     });
@@ -248,7 +248,7 @@ router.post(
     Season.update(
       {
         readyToPublish,
-        status: newStatus,
+        status: "requested",
       },
       {
         where: {
@@ -330,7 +330,7 @@ router.post(
     // update season
     Season.update(
       {
-        readyToPublish: true,
+        readyToPublish,
         status: "approved",
       },
       {

--- a/frontend/src/components/EditAndReviewTable.jsx
+++ b/frontend/src/components/EditAndReviewTable.jsx
@@ -9,6 +9,7 @@ import {
 } from "@fa-kit/icons/classic/solid";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import StatusBadge from "@/components/StatusBadge";
+import NotReadyFlag from "@/components/NotReadyFlag";
 
 function TableRow(park) {
   const navigate = useNavigate();
@@ -27,6 +28,7 @@ function TableRow(park) {
       <th scope="row">{park.name}</th>
       <td>
         <StatusBadge status={park.status} />
+        <NotReadyFlag show={!park.readyToPublish} />
       </td>
       <td className="text-end">
         <Link to={getParkLink()} aria-label={`View ${park.name} park details`}>

--- a/frontend/src/components/NotReadyFlag.jsx
+++ b/frontend/src/components/NotReadyFlag.jsx
@@ -1,0 +1,16 @@
+// Flag icon displayed when status is not "Ready to publish"
+import { faFlag } from "@awesome.me/kit-c1c3245051/icons/classic/solid";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import PropTypes from "prop-types";
+export default function NotReadyFlag({ show = true }) {
+  if (!show) return null;
+  return (
+    <span className="ms-2 text-danger not-ready-flag" aria-hidden="true">
+      <FontAwesomeIcon icon={faFlag} />
+    </span>
+  );
+}
+// Prop validation
+NotReadyFlag.propTypes = {
+  show: PropTypes.bool,
+};

--- a/frontend/src/components/ParkDetailsSeason.jsx
+++ b/frontend/src/components/ParkDetailsSeason.jsx
@@ -10,6 +10,7 @@ import { formatDate } from "@/lib/utils";
 import { useApiGet } from "@/hooks/useApi";
 import LoadingBar from "@/components/LoadingBar";
 import SeasonDates from "@/components/ParkDetailsSeasonDates";
+import NotReadyFlag from "@/components/NotReadyFlag";
 
 export default function ParkSeason({ season }) {
   const { parkId } = useParams();
@@ -90,6 +91,7 @@ export default function ParkSeason({ season }) {
           <h3>{season.operatingYear} season</h3>
 
           <StatusBadge status={season.status} />
+          <NotReadyFlag show={!season.readyToPublish} />
 
           <button
             onClick={toggleExpand}
@@ -140,5 +142,6 @@ ParkSeason.propTypes = {
     operatingYear: PropTypes.number.isRequired,
     status: PropTypes.string.isRequired,
     updatedAt: PropTypes.string.isRequired,
+    readyToPublish: PropTypes.bool.isRequired,
   }),
 };

--- a/frontend/src/router/pages/PreviewChanges.jsx
+++ b/frontend/src/router/pages/PreviewChanges.jsx
@@ -294,7 +294,7 @@ function PreviewChanges() {
             </button>
 
             <button type="button" className="btn btn-primary" onClick={approve}>
-              Mark as approved
+              Mark approved
             </button>
 
             {(saving || savingApproval) && (

--- a/frontend/src/router/pages/SubmitDates.jsx
+++ b/frontend/src/router/pages/SubmitDates.jsx
@@ -28,7 +28,6 @@ function SubmitDates() {
   const [validationError, setValidationError] = useState(null);
   const [readyToPublish, setReadyToPublish] = useState(false);
 
-  // const [showConfirmationDialog, setShowConfirmationDialog] = useState(false);
   const [showFlash, setShowFlash] = useState(false);
 
   const { data, loading, error, fetchData } = useApiGet(`/seasons/${seasonId}`);
@@ -137,6 +136,7 @@ function SubmitDates() {
 
       setSeason(data);
       setDates(currentSeasonDates);
+      setReadyToPublish(data.readyToPublish);
     }
   }, [data]);
 


### PR DESCRIPTION
### Jira Ticket

CMS-453

### Description
- `/seasons` endpoint now returns `readyToPublish` field.
- `/parks` endpoint only returns parks with subAreas that have dates
- status is changed to "requested" after user saves any change. 
- Added not-ready flag component to seasons in which `readyToPublish` is false.
- fixed text for mark approved button
- fixed bug in which `readToPublish` was not being properly set.
