### PR TITLE
CMS-517: add modal windows and flash messages

### DIFF
--- a/backend/routes/api/parks.js
+++ b/backend/routes/api/parks.js
@@ -14,7 +14,7 @@ const router = Router();
 
 function getParkStatus(seasons) {
   // if any season has status==requested, return requested
-  // else if any season has status==under_review, return under_review
+  // else if any season has status==under review, return under review
   // else if any season has status==approved, return approved
   // if all seasons have status==published, return published
 

--- a/frontend/src/components/ConfirmationDialog.jsx
+++ b/frontend/src/components/ConfirmationDialog.jsx
@@ -1,0 +1,42 @@
+import PropTypes from "prop-types";
+import "./ConfirmationDialog.scss";
+
+function ConfirmationDialog({
+  title,
+  message,
+  notes,
+  onCancel,
+  onConfirm,
+  isOpen,
+}) {
+  if (!isOpen) return null;
+
+  return (
+    <div className="confirmation-dialog-overlay">
+      <div className="confirmation-dialog-container">
+        <h3 className="confirmation-dialog-title">{title}</h3>
+        <p className="confirmation-dialog-message">{message}</p>
+        <p className="confirmation-dialog-message">{notes}</p>
+        <div className="confirmation-dialog-actions">
+          <button className="btn btn-outline-primary" onClick={onCancel}>
+            Cancel
+          </button>
+          <button className="btn btn-primary" onClick={onConfirm}>
+            Confirm
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+ConfirmationDialog.propTypes = {
+  title: PropTypes.string.isRequired,
+  message: PropTypes.string.isRequired,
+  notes: PropTypes.string.isRequired,
+  onCancel: PropTypes.func.isRequired,
+  onConfirm: PropTypes.func.isRequired,
+  isOpen: PropTypes.bool.isRequired,
+};
+
+export default ConfirmationDialog;

--- a/frontend/src/components/ConfirmationDialog.jsx
+++ b/frontend/src/components/ConfirmationDialog.jsx
@@ -1,4 +1,6 @@
 import PropTypes from "prop-types";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faClose } from "@fa-kit/icons/classic/regular";
 import "./ConfirmationDialog.scss";
 
 function ConfirmationDialog({
@@ -13,17 +15,26 @@ function ConfirmationDialog({
 
   return (
     <div className="confirmation-dialog-overlay">
-      <div className="confirmation-dialog-container">
-        <h3 className="confirmation-dialog-title">{title}</h3>
-        <p className="confirmation-dialog-message">{message}</p>
-        <p className="confirmation-dialog-message">{notes}</p>
-        <div className="confirmation-dialog-actions">
-          <button className="btn btn-outline-primary" onClick={onCancel}>
-            Cancel
-          </button>
-          <button className="btn btn-primary" onClick={onConfirm}>
-            Confirm
-          </button>
+      <div className="confirmation-dialog-outer">
+        <div className="confirmation-dialog-left-warning-column"></div>
+        <div className="confirmation-dialog-container">
+          <div className="confirmation-dialog-header">
+            <h3 className="confirmation-dialog-title">{title}</h3>
+            <button onClick={onCancel} className="confirmation-dialog-close">
+              <FontAwesomeIcon icon={faClose} />
+            </button>
+          </div>
+
+          <p className="confirmation-dialog-message">{message}</p>
+          <p className="confirmation-dialog-message">{notes}</p>
+          <div className="confirmation-dialog-actions">
+            <button className="btn btn-outline-primary" onClick={onCancel}>
+              Cancel
+            </button>
+            <button className="btn btn-primary" onClick={onConfirm}>
+              Confirm
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/frontend/src/components/ConfirmationDialog.jsx
+++ b/frontend/src/components/ConfirmationDialog.jsx
@@ -15,26 +15,23 @@ function ConfirmationDialog({
 
   return (
     <div className="confirmation-dialog-overlay">
-      <div className="confirmation-dialog-outer">
-        <div className="confirmation-dialog-left-warning-column"></div>
-        <div className="confirmation-dialog-container">
-          <div className="confirmation-dialog-header">
-            <h3 className="confirmation-dialog-title">{title}</h3>
-            <button onClick={onCancel} className="confirmation-dialog-close">
-              <FontAwesomeIcon icon={faClose} />
-            </button>
-          </div>
+      <div className="confirmation-dialog-container">
+        <div className="confirmation-dialog-header">
+          <h3 className="confirmation-dialog-title">{title}</h3>
+          <button onClick={onCancel} className="confirmation-dialog-close">
+            <FontAwesomeIcon icon={faClose} />
+          </button>
+        </div>
 
-          <p className="confirmation-dialog-message">{message}</p>
-          <p className="confirmation-dialog-message">{notes}</p>
-          <div className="confirmation-dialog-actions">
-            <button className="btn btn-outline-primary" onClick={onCancel}>
-              Cancel
-            </button>
-            <button className="btn btn-primary" onClick={onConfirm}>
-              Confirm
-            </button>
-          </div>
+        <p className="confirmation-dialog-message">{message}</p>
+        <p className="confirmation-dialog-message">{notes}</p>
+        <div className="confirmation-dialog-actions">
+          <button className="btn btn-outline-primary" onClick={onCancel}>
+            Cancel
+          </button>
+          <button className="btn btn-primary" onClick={onConfirm}>
+            Confirm
+          </button>
         </div>
       </div>
     </div>

--- a/frontend/src/components/ConfirmationDialog.scss
+++ b/frontend/src/components/ConfirmationDialog.scss
@@ -11,34 +11,24 @@
   z-index: 100;
 }
 
-.confirmation-dialog-outer {
-  display: grid;
+.confirmation-dialog-container {
   grid-template-columns: 1% 99%;
   border-radius: var(--layout-border-radius-large);
   box-shadow:
     0 4px 6px -1px rgba(0, 0, 0, 0.1),
     0 2px 4px -1px rgba(0, 0, 0, 0.06);
 
+  background-color: white;
+  padding: var(--layout-padding-large);
+  border-radius: var(--layout-border-radius-large);
+  border-left: 5px solid var(--support-border-color-warning);
+
   max-width: 80%;
   width: 100%;
+
   @include from-md {
     max-width: 50%;
   }
-}
-
-.confirmation-dialog-container {
-  background-color: white;
-  padding: var(--layout-padding-large);
-  border-top-right-radius: var(--layout-border-radius-large);
-  border-bottom-right-radius: var(--layout-border-radius-large);
-}
-
-.confirmation-dialog-left-warning-column {
-  background-color: var(--support-border-color-warning);
-  display: inline-block;
-  padding: 10px;
-  border-top-left-radius: var(--layout-border-radius-large);
-  border-bottom-left-radius: var(--layout-border-radius-large);
 }
 
 .confirmation-dialog-title {
@@ -69,5 +59,4 @@
   border: none;
   color: var(--icons-color-secondary);
   font-size: 32px;
-  // float: right;
 }

--- a/frontend/src/components/ConfirmationDialog.scss
+++ b/frontend/src/components/ConfirmationDialog.scss
@@ -1,0 +1,61 @@
+.confirmation-dialog-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 100;
+}
+
+.confirmation-dialog-container {
+  background-color: white;
+  padding: 24px;
+  border-radius: 8px;
+  box-shadow:
+    0 4px 6px -1px rgba(0, 0, 0, 0.1),
+    0 2px 4px -1px rgba(0, 0, 0, 0.06);
+  max-width: 50%;
+  width: 100%;
+
+  @media (max-width: 767px) {
+    max-width: 80%;
+  }
+}
+
+.confirmation-dialog-title {
+  font-size: 18px;
+  font-weight: bold;
+  margin-bottom: 16px;
+}
+
+.confirmation-dialog-message {
+  margin-bottom: 24px;
+}
+
+.confirmation-dialog-actions {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.confirmation-dialog-cancel-btn {
+  background-color: transparent;
+  color: #6b7280;
+  padding: 8px 16px;
+  border-radius: 4px;
+  margin-right: 8px;
+  cursor: pointer;
+  transition: background-color 0.3s;
+}
+
+.confirmation-dialog-cancel-btn:hover {
+  background-color: #f3f4f6;
+}
+
+.confirmation-dialog-confirm-btn:hover {
+  background-color: #2563eb;
+}

--- a/frontend/src/components/ConfirmationDialog.scss
+++ b/frontend/src/components/ConfirmationDialog.scss
@@ -2,8 +2,8 @@
   position: fixed;
   top: 0;
   left: 0;
-  width: 100%;
-  height: 100%;
+  bottom: 0;
+  right: 0;
   background-color: rgba(0, 0, 0, 0.5);
   display: flex;
   justify-content: center;
@@ -11,24 +11,46 @@
   z-index: 100;
 }
 
-.confirmation-dialog-container {
-  background-color: white;
-  padding: var(--layout-padding-large);
+.confirmation-dialog-outer {
+  display: grid;
+  grid-template-columns: 1% 99%;
   border-radius: var(--layout-border-radius-large);
   box-shadow:
     0 4px 6px -1px rgba(0, 0, 0, 0.1),
     0 2px 4px -1px rgba(0, 0, 0, 0.06);
-  max-width: 50%;
-  width: 100%;
 
-  @media (max-width: 767px) {
-    max-width: 80%;
+  max-width: 80%;
+  width: 100%;
+  @include from-md {
+    max-width: 50%;
   }
+}
+
+.confirmation-dialog-container {
+  background-color: white;
+  padding: var(--layout-padding-large);
+  border-top-right-radius: var(--layout-border-radius-large);
+  border-bottom-right-radius: var(--layout-border-radius-large);
+}
+
+.confirmation-dialog-left-warning-column {
+  background-color: var(--support-border-color-warning);
+  display: inline-block;
+  padding: 10px;
+  border-top-left-radius: var(--layout-border-radius-large);
+  border-bottom-left-radius: var(--layout-border-radius-large);
 }
 
 .confirmation-dialog-title {
   font-size: var(--typography-regular-H6);
   font-weight: bold;
+  margin-bottom: var(--layout-margin-none);
+}
+
+.confirmation-dialog-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
   margin-bottom: var(--layout-margin-medium);
 }
 
@@ -42,15 +64,10 @@
   align-items: center;
 }
 
-.confirmation-dialog-cancel-btn {
+.confirmation-dialog-close {
   background-color: transparent;
-  color: var(--surface-color-primary-default);
-  padding: 8px 16px;
-  border-radius: var(--layout-border-radius-default);
-  margin-right: var(--layout-margin-small);
-  transition: background-color 0.3s;
-}
-
-.confirmation-dialog-confirm-btn:hover {
-  background-color: var(--surface-color-primary-default);
+  border: none;
+  color: var(--icons-color-secondary);
+  font-size: 32px;
+  // float: right;
 }

--- a/frontend/src/components/ConfirmationDialog.scss
+++ b/frontend/src/components/ConfirmationDialog.scss
@@ -13,8 +13,8 @@
 
 .confirmation-dialog-container {
   background-color: white;
-  padding: 24px;
-  border-radius: 8px;
+  padding: var(--layout-padding-large);
+  border-radius: var(--layout-border-radius-large);
   box-shadow:
     0 4px 6px -1px rgba(0, 0, 0, 0.1),
     0 2px 4px -1px rgba(0, 0, 0, 0.06);
@@ -27,13 +27,13 @@
 }
 
 .confirmation-dialog-title {
-  font-size: 18px;
+  font-size: var(--typography-regular-H6);
   font-weight: bold;
-  margin-bottom: 16px;
+  margin-bottom: var(--layout-margin-medium);
 }
 
 .confirmation-dialog-message {
-  margin-bottom: 24px;
+  margin-bottom: var(--layout-margin-large);
 }
 
 .confirmation-dialog-actions {
@@ -44,18 +44,13 @@
 
 .confirmation-dialog-cancel-btn {
   background-color: transparent;
-  color: #6b7280;
+  color: var(--surface-color-primary-default);
   padding: 8px 16px;
-  border-radius: 4px;
-  margin-right: 8px;
-  cursor: pointer;
+  border-radius: var(--layout-border-radius-default);
+  margin-right: var(--layout-margin-small);
   transition: background-color 0.3s;
 }
 
-.confirmation-dialog-cancel-btn:hover {
-  background-color: #f3f4f6;
-}
-
 .confirmation-dialog-confirm-btn:hover {
-  background-color: #2563eb;
+  background-color: var(--surface-color-primary-default);
 }

--- a/frontend/src/components/FlashMessage.jsx
+++ b/frontend/src/components/FlashMessage.jsx
@@ -1,5 +1,4 @@
 // FlashMessage.jsx
-import { useEffect } from "react";
 import PropTypes from "prop-types";
 import "./FlashMessage.scss";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -10,22 +9,9 @@ function FlashMessage({
   message,
   isVisible,
   onClose,
-  duration = 3000,
   icon = faCheck,
   variant = "success",
 }) {
-  useEffect(() => {
-    if (isVisible && duration) {
-      const timer = setTimeout(() => {
-        onClose();
-      }, duration);
-
-      return () => clearTimeout(timer);
-    }
-
-    return () => {};
-  }, [isVisible, duration, onClose]);
-
   if (!isVisible) return null;
 
   return (
@@ -54,7 +40,6 @@ FlashMessage.propTypes = {
   message: PropTypes.string.isRequired,
   isVisible: PropTypes.bool.isRequired,
   onClose: PropTypes.func.isRequired,
-  duration: PropTypes.number,
   icon: PropTypes.string,
   variant: PropTypes.oneOf(["success", "error"]),
 };

--- a/frontend/src/components/ParkDetailsSeason.jsx
+++ b/frontend/src/components/ParkDetailsSeason.jsx
@@ -91,31 +91,34 @@ export default function ParkSeason({ season }) {
 
   const updateDate = formatDate(season.updatedAt);
 
-  function navigateToEdit() {
+  async function navigateToEdit() {
     if (season.status === "under review") {
-      openConfirmation(
+      const confirm = await openConfirmation(
         "Edit submitted dates?",
         "A review may already be in progress and all dates will need to be reviewed again.",
-        () => {
-          navigate(`/park/${parkId}/edit/${season.id}`);
-        },
       );
+
+      if (confirm) {
+        navigate(`/park/${parkId}/edit/${season.id}`);
+      }
     } else if (season.status === "approved") {
-      openConfirmation(
+      const confirm = await openConfirmation(
         "Edit approved dates?",
         "Dates will need to be reviewed again to be approved.",
-        () => {
-          navigate(`/park/${parkId}/edit/${season.id}`);
-        },
       );
+
+      if (confirm) {
+        navigate(`/park/${parkId}/edit/${season.id}`);
+      }
     } else if (season.status === "published") {
-      openConfirmation(
+      const confirm = openConfirmation(
         "Edit published dates?",
         "Dates will need to be reviewed again to be approved and published. If reservations have already begun, visitors will be affected.",
-        () => {
-          navigate(`/park/${parkId}/edit/${season.id}`);
-        },
       );
+
+      if (confirm) {
+        navigate(`/park/${parkId}/edit/${season.id}`);
+      }
     } else {
       navigate(`/park/${parkId}/edit/${season.id}`);
     }

--- a/frontend/src/hooks/useConfirmation.js
+++ b/frontend/src/hooks/useConfirmation.js
@@ -2,32 +2,36 @@ import { useState } from "react";
 
 export function useConfirmation() {
   const [isOpen, setIsOpen] = useState(false);
-  const [confirmAction, setConfirmAction] = useState(null);
   const [title, setTitle] = useState("");
   const [message, setMessage] = useState("");
   const [notes, setNotes] = useState("");
+  const [resolvePromise, setResolvePromise] = useState(null);
 
   function openConfirmation(
     confirmationTitle,
     confirmationMessage,
-    action,
     notesParam = "",
   ) {
-    setTitle(confirmationTitle);
-    setMessage(confirmationMessage);
-    setNotes(notesParam);
-    setConfirmAction(() => action);
-    setIsOpen(true);
+    return new Promise((resolve) => {
+      setTitle(confirmationTitle);
+      setMessage(confirmationMessage);
+      setNotes(notesParam);
+      setResolvePromise(() => resolve); // Store the resolve function
+      setIsOpen(true);
+    });
   }
 
   function handleConfirm() {
-    if (confirmAction) {
-      confirmAction();
+    if (resolvePromise) {
+      resolvePromise(true); // Resolve with true
     }
     setIsOpen(false);
   }
 
   function handleCancel() {
+    if (resolvePromise) {
+      resolvePromise(false); // Resolve with false
+    }
     setIsOpen(false);
   }
 

--- a/frontend/src/hooks/useConfirmation.js
+++ b/frontend/src/hooks/useConfirmation.js
@@ -1,0 +1,43 @@
+import { useState } from "react";
+
+export function useConfirmation() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [confirmAction, setConfirmAction] = useState(null);
+  const [title, setTitle] = useState("");
+  const [message, setMessage] = useState("");
+  const [notes, setNotes] = useState("");
+
+  function openConfirmation(
+    confirmationTitle,
+    confirmationMessage,
+    action,
+    notesParam = "",
+  ) {
+    setTitle(confirmationTitle);
+    setMessage(confirmationMessage);
+    setNotes(notesParam);
+    setConfirmAction(() => action);
+    setIsOpen(true);
+  }
+
+  function handleConfirm() {
+    if (confirmAction) {
+      confirmAction();
+    }
+    setIsOpen(false);
+  }
+
+  function handleCancel() {
+    setIsOpen(false);
+  }
+
+  return {
+    title,
+    message,
+    confirmationDialogNotes: notes,
+    openConfirmation,
+    handleConfirm,
+    handleCancel,
+    isConfirmationOpen: isOpen,
+  };
+}

--- a/frontend/src/hooks/useFlashMessage.js
+++ b/frontend/src/hooks/useFlashMessage.js
@@ -1,0 +1,25 @@
+import { useState } from "react";
+
+export function useFlashMessage() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [title, setTitle] = useState("");
+  const [message, setMessage] = useState("");
+
+  function openFlashMessage(confirmationTitle, confirmationMessage) {
+    setTitle(confirmationTitle);
+    setMessage(confirmationMessage);
+    setIsOpen(true);
+  }
+
+  function handleFlashClose() {
+    setIsOpen(false);
+  }
+
+  return {
+    flashTitle: title,
+    flashMessage: message,
+    openFlashMessage,
+    handleFlashClose,
+    isFlashOpen: isOpen,
+  };
+}

--- a/frontend/src/hooks/useNavigationGuard.js
+++ b/frontend/src/hooks/useNavigationGuard.js
@@ -1,0 +1,48 @@
+import { useEffect } from "react";
+import { useBlocker } from "react-router-dom";
+import { removeTrailingSlash } from "@/lib/utils";
+
+export function useNavigationGuard(hasChanges, openConfirmation) {
+  const blocker = useBlocker(({ currentLocation, nextLocation }) => {
+    const currentPath = currentLocation.pathname;
+    const nextPath = removeTrailingSlash(nextLocation.pathname);
+
+    if (`${currentPath}/preview` === nextPath) {
+      return false;
+    }
+    return hasChanges();
+  });
+
+  useEffect(() => {
+    async function handleBlocker() {
+      if (blocker.state === "blocked") {
+        const proceed = await openConfirmation(
+          "Discard changes?",
+          "Discarded changes will be permanently deleted.",
+        );
+
+        if (proceed) {
+          blocker.proceed();
+        } else {
+          blocker.reset();
+        }
+      }
+    }
+
+    handleBlocker();
+  }, [blocker, openConfirmation]);
+
+  useEffect(() => {
+    async function handleBeforeUnload(e) {
+      if (hasChanges()) {
+        e.preventDefault();
+      }
+    }
+
+    window.addEventListener("beforeunload", handleBeforeUnload);
+
+    return () => {
+      window.removeEventListener("beforeunload", handleBeforeUnload);
+    };
+  }, [hasChanges, openConfirmation]);
+}

--- a/frontend/src/lib/utils.js
+++ b/frontend/src/lib/utils.js
@@ -45,3 +45,11 @@ export function formatDatetoISO(date) {
 
   return formatISO(date, { representation: "date" });
 }
+
+// used to properly compare paths
+export function removeTrailingSlash(str) {
+  if (str.endsWith("/")) {
+    return str.slice(0, -1);
+  }
+  return str;
+}

--- a/frontend/src/router/pages/ExportPage.jsx
+++ b/frontend/src/router/pages/ExportPage.jsx
@@ -1,9 +1,32 @@
 import { faCalendarCheck } from "@fa-kit/icons/classic/regular";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { useFlashMessage } from "@/hooks/useFlashMessage";
+import FlashMessage from "@/components/FlashMessage";
 
 function ExportPage() {
+  const {
+    flashTitle,
+    flashMessage,
+    openFlashMessage,
+    handleFlashClose,
+    isFlashOpen,
+  } = useFlashMessage();
+
+  function exportDates() {
+    openFlashMessage(
+      "Export complete",
+      "Check your Downloads for the Excel document.",
+    );
+  }
+
   return (
     <div className="page export">
+      <FlashMessage
+        title={flashTitle}
+        message={flashMessage}
+        isVisible={isFlashOpen}
+        onClose={handleFlashClose}
+      />
       <p>Select the format of your export:</p>
 
       <div className="row">
@@ -151,7 +174,9 @@ function ExportPage() {
           </fieldset>
 
           <fieldset>
-            <button className="btn btn-primary">Export report</button>
+            <button className="btn btn-primary" onClick={exportDates}>
+              Export report
+            </button>
           </fieldset>
         </div>
       </div>

--- a/frontend/src/router/pages/PublishPage.jsx
+++ b/frontend/src/router/pages/PublishPage.jsx
@@ -1,8 +1,42 @@
+import { useConfirmation } from "@/hooks/useConfirmation";
+import ConfirmationDialog from "@/components/ConfirmationDialog";
+
 function PublishPage() {
+  const {
+    title,
+    message,
+    confirmationDialogNotes,
+    openConfirmation,
+    handleConfirm,
+    handleCancel,
+    isConfirmationOpen,
+  } = useConfirmation();
+
+  function publishToApi() {
+    openConfirmation(
+      "Publish dates to API?",
+      "All parks that are not flagged will be made public. This cannot be undone.",
+      () => {
+        console.log("Publishing to API");
+      },
+      "Publishing may take up to one hour.",
+    );
+  }
+
   return (
     <div className="page publish">
+      <ConfirmationDialog
+        isOpen={isConfirmationOpen}
+        onConfirm={handleConfirm}
+        onCancel={handleCancel}
+        title={title}
+        message={message}
+        notes={confirmationDialogNotes}
+      />
       <div className="d-flex justify-content-end mb-2">
-        <button className="btn btn-primary">Publish to API</button>
+        <button className="btn btn-primary" onClick={publishToApi}>
+          Publish to API
+        </button>
       </div>
 
       <div className="table-responsive">

--- a/frontend/src/router/pages/PublishPage.jsx
+++ b/frontend/src/router/pages/PublishPage.jsx
@@ -23,18 +23,19 @@ function PublishPage() {
     isFlashOpen,
   } = useFlashMessage();
 
-  function publishToApi() {
-    openConfirmation(
+  async function publishToApi() {
+    const confirm = await openConfirmation(
       "Publish dates to API?",
       "All parks that are not flagged will be made public. This cannot be undone.",
-      () => {
-        openFlashMessage(
-          "Dates publishing to API",
-          "Approved dates publishing may take up to one hour.",
-        );
-      },
       "Publishing may take up to one hour.",
     );
+
+    if (confirm) {
+      openFlashMessage(
+        "Dates publishing to API",
+        "Approved dates publishing may take up to one hour.",
+      );
+    }
   }
 
   return (

--- a/frontend/src/router/pages/PublishPage.jsx
+++ b/frontend/src/router/pages/PublishPage.jsx
@@ -1,5 +1,8 @@
 import { useConfirmation } from "@/hooks/useConfirmation";
+import { useFlashMessage } from "@/hooks/useFlashMessage";
+
 import ConfirmationDialog from "@/components/ConfirmationDialog";
+import FlashMessage from "@/components/FlashMessage";
 
 function PublishPage() {
   const {
@@ -12,12 +15,23 @@ function PublishPage() {
     isConfirmationOpen,
   } = useConfirmation();
 
+  const {
+    flashTitle,
+    flashMessage,
+    openFlashMessage,
+    handleFlashClose,
+    isFlashOpen,
+  } = useFlashMessage();
+
   function publishToApi() {
     openConfirmation(
       "Publish dates to API?",
       "All parks that are not flagged will be made public. This cannot be undone.",
       () => {
-        console.log("Publishing to API");
+        openFlashMessage(
+          "Dates publishing to API",
+          "Approved dates publishing may take up to one hour.",
+        );
       },
       "Publishing may take up to one hour.",
     );
@@ -25,6 +39,12 @@ function PublishPage() {
 
   return (
     <div className="page publish">
+      <FlashMessage
+        title={flashTitle}
+        message={flashMessage}
+        isVisible={isFlashOpen}
+        onClose={handleFlashClose}
+      />
       <ConfirmationDialog
         isOpen={isConfirmationOpen}
         onConfirm={handleConfirm}

--- a/frontend/src/router/pages/SubmitDates.jsx
+++ b/frontend/src/router/pages/SubmitDates.jsx
@@ -124,14 +124,15 @@ function SubmitDates() {
     }
 
     if (["under review", "approved", "published"].includes(season.status)) {
-      openConfirmation(
+      const confirm = await openConfirmation(
         "Move back to draft?",
         "The dates will be moved back to draft and need to be submitted again to be reviewed.",
-        () => {
-          saveChanges(savingDraft);
-        },
         "If dates have already been published, they will not be updated until new dates are submitted, approved, and published.",
       );
+
+      if (confirm) {
+        saveChanges(savingDraft);
+      }
     } else {
       saveChanges(savingDraft);
     }

--- a/frontend/src/router/pages/SubmitDates.jsx
+++ b/frontend/src/router/pages/SubmitDates.jsx
@@ -7,11 +7,10 @@ import NavBack from "@/components/NavBack";
 import ContactBox from "@/components/ContactBox";
 import ReadyToPublishBox from "@/components/ReadyToPublishBox";
 import groupCamping from "@/assets/icons/group-camping.svg";
-import { formatDateRange, formatTimestamp } from "@/lib/utils";
+import { formatDateRange } from "@/lib/utils";
 import LoadingBar from "@/components/LoadingBar";
 import FlashMessage from "@/components/FlashMessage";
 import ChangeLogsList from "@/components/ChangeLogsList";
-import useValidation from "@/hooks/useValidation";
 import ConfirmationDialog from "@/components/ConfirmationDialog";
 
 import useValidation from "@/hooks/useValidation";
@@ -151,9 +150,7 @@ function SubmitDates() {
 
   async function saveAsDraft() {
     try {
-      setNotes("");
       fetchData();
-      setShowFlash(true);
       await submitChanges(true);
     } catch (err) {
       console.error(err);

--- a/frontend/src/router/pages/SubmitDates.jsx
+++ b/frontend/src/router/pages/SubmitDates.jsx
@@ -104,14 +104,15 @@ function SubmitDates() {
 
   async function submitChanges(savingDraft = false) {
     if (["under review", "approved", "published"].includes(season.status)) {
-      openConfirmation(
+      const confirm = await openConfirmation(
         "Move back to draft?",
         "The dates will be moved back to draft and need to be submitted again to be reviewed.",
-        () => {
-          saveChanges(savingDraft);
-        },
         "If dates have already been published, they will not be updated until new dates are submitted, approved, and published.",
       );
+
+      if (confirm) {
+        saveChanges(savingDraft);
+      }
     } else {
       saveChanges(savingDraft);
     }


### PR DESCRIPTION
### ### Jira Ticket

CMS-517

### Description
Both modal windows and flash messages have their own hook. You can use their how to show the element on screen and pass params. It's basically just a way to avoid duplication and send different prop values to the components on demand. 

I also created a hook for the components in which we need to warn the user when they leave the page with unsaved changes. 
- navigating away by clicking a button or a link will show the custom dialog 
- browser-level actions like closing the tab or refreshing would only show the default browser warning


You can check in the ticket where are flash messages and modals supposed to appear. 
The only one that is not included in this PR, because it relates to submitting for review, and that's not part of this version is:
> Submit with missing dates? When there are empty date fields and they clicked submit for review
> Continue editing - return to form
> Submit - Submitted for review and return to park details
