### PR TITLE
CMS-580: Fix bug that prevents sync script to get all the data.

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -9,7 +9,9 @@
     "start": "node index.js",
     "lint": "eslint .",
     "migrate": "sequelize-cli db:migrate",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "sync-data": "node strapi-sync/syncData.js",
+    "one-time-data-import": "node strapi-sync/oneTimeDataImport.js"
   },
   "author": "",
   "license": "ISC",

--- a/backend/routes/api/seasons.js
+++ b/backend/routes/api/seasons.js
@@ -236,6 +236,7 @@ router.post(
     // create season change log
     const seasonChangeLog = await SeasonChangeLog.create({
       seasonId,
+      // TODO: get real user ID from session
       userId: 1,
       notes,
       statusOldValue: season.status,

--- a/backend/strapi-sync/oneTimeDataImport.js
+++ b/backend/strapi-sync/oneTimeDataImport.js
@@ -1,0 +1,3 @@
+import { oneTimeDataImport } from "./sync";
+
+oneTimeDataImport();

--- a/backend/strapi-sync/sync.js
+++ b/backend/strapi-sync/sync.js
@@ -23,13 +23,12 @@ import {
 async function getPageData(url) {
   try {
     const response = await get(url);
-    const data = response.data;
 
-    return data.data;
+    return response.data;
   } catch (error) {
     console.error(error);
 
-    return error;
+    return [];
   }
 }
 
@@ -134,7 +133,7 @@ export async function fetchAllModels() {
           params.append(`populate[${field}][fields]`, "id");
         }
       }
-      item.items = getData(currentUrl, params);
+      item.items = await getData(currentUrl, params);
     }),
   );
 
@@ -229,21 +228,21 @@ export async function createDateTypes() {
   const data = [
     {
       name: "Operation",
-      startDateLabel: "",
-      endDateLabel: "",
-      description: "",
+      startDateLabel: "Service Start Date",
+      endDateLabel: "Service End Date",
+      description: "Dates of Operation",
     },
     {
       name: "Reservation",
-      startDateLabel: "",
-      endDateLabel: "",
-      description: "",
+      startDateLabel: "Reservation Start Date",
+      endDateLabel: "Reservation End Date",
+      description: "Dates for Reservations",
     },
     {
       name: "Off Season",
-      startDateLabel: "",
-      endDateLabel: "",
-      description: "",
+      startDateLabel: "Winter start date",
+      endDateLabel: "Winter end date",
+      description: "Winter dates",
     },
   ];
 
@@ -459,7 +458,12 @@ export async function oneTimeDataImport() {
     }
   }
 
+  await createDateTypes();
+
   datesData.items = await getData(currentUrl, params);
 
   await createDatesAndSeasons(datesData);
 }
+
+// syncData();
+// oneTimeDataImport();

--- a/backend/strapi-sync/syncData.js
+++ b/backend/strapi-sync/syncData.js
@@ -1,0 +1,3 @@
+import { syncData } from "./sync.js";
+
+syncData();


### PR DESCRIPTION
### Jira Ticket

CMS-580

### Description
Followed the steps described in the ticket to test.

`syncData()` can run as many times as you want
`oneTimeDataImport()` should only run one time. 

Note that campgrounds are not created here given that the names of the subareas in Strapi are not consistent enough to assign campsite groupings to campgrounds. 

I created a separate script to help with the process, but it will probably need to be verified manually. 
