### PR TITLE
CMS-583: create campgrounds

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -11,7 +11,9 @@
     "migrate": "sequelize-cli db:migrate",
     "test": "echo \"Error: no test specified\" && exit 1",
     "sync-data": "node strapi-sync/syncData.js",
-    "one-time-data-import": "node strapi-sync/oneTimeDataImport.js"
+    "one-time-data-import": "node strapi-sync/oneTimeDataImport.js",
+    "create-single-item-campgrounds": "node strapi-sync/create-single-item-campgrounds.js",
+    "create-multiple-item-campgrounds": "node strapi-sync/create-multiple-item-campgrounds.js"
   },
   "author": "",
   "license": "ISC",

--- a/backend/strapi-sync/create-multiple-item-campgrounds.js
+++ b/backend/strapi-sync/create-multiple-item-campgrounds.js
@@ -1,4 +1,4 @@
-import { Campground, Feature } from "../models/index.js";
+import { Campground, Feature, Park } from "../models/index.js";
 
 import { getItemByAttributes, createModel } from "./utils.js";
 
@@ -412,21 +412,27 @@ async function updateFeature(item, campgroundId) {
 }
 
 async function createCampground(item) {
+  const park = await getItemByAttributes(Park, {
+    strapiId: item.parkId,
+  });
+
   // create campground with FK to Park
   const data = {
     name: item.campgroundName,
-    parkId: item.parkId,
+    parkId: park.id,
   };
 
   const campground = await createModel(Campground, data);
 
   await Promise.all(
-    item.items.map((feature) => updateFeature(feature, campground.id)),
+    item.items.map(
+      async (feature) => await updateFeature(feature, campground.id),
+    ),
   );
 }
 
 async function createCampgrounds(items) {
-  await Promise.all(items.map((item) => createCampground(item)));
+  await Promise.all(items.map(async (item) => await createCampground(item)));
 }
 
 createCampgrounds(campgrounds);

--- a/backend/strapi-sync/create-multiple-item-campgrounds.js
+++ b/backend/strapi-sync/create-multiple-item-campgrounds.js
@@ -1,4 +1,8 @@
-const items = [
+import { Campground, Feature } from "../models/index.js";
+
+import { getItemByAttributes, createModel } from "./utils.js";
+
+const campgrounds = [
   {
     parkId: 6,
     campgroundName: "Alice Lake Campground",
@@ -393,3 +397,36 @@ const items = [
     ],
   },
 ];
+
+async function updateFeature(item, campgroundId) {
+  // get feature by strapiID
+  const feature = await getItemByAttributes(Feature, {
+    strapiId: item.strapiId,
+  });
+
+  // set campgroundId and name
+  feature.campgroundId = campgroundId;
+  feature.name = item.newName;
+
+  await feature.save();
+}
+
+async function createCampground(item) {
+  // create campground with FK to Park
+  const data = {
+    name: item.campgroundName,
+    parkId: item.parkId,
+  };
+
+  const campground = await createModel(Campground, data);
+
+  await Promise.all(
+    item.items.map((feature) => updateFeature(feature, campground.id)),
+  );
+}
+
+async function createCampgrounds(items) {
+  await Promise.all(items.map((item) => createCampground(item)));
+}
+
+createCampgrounds(campgrounds);

--- a/backend/strapi-sync/create-multiple-item-campgrounds.js
+++ b/backend/strapi-sync/create-multiple-item-campgrounds.js
@@ -1,0 +1,395 @@
+const items = [
+  {
+    parkId: 6,
+    campgroundName: "Alice Lake Campground",
+    items: [
+      {
+        strapiName: "Alice Lake Campground A sites 1-55",
+        newName: "Campground A sites 1-55",
+        strapiId: 60,
+      },
+      {
+        strapiName: "Alice Lake Campground B sites 56-96",
+        newName: "Campground B sites 56-96",
+        strapiId: 61,
+      },
+    ],
+  },
+  {
+    parkId: 6,
+    campgroundName: "Alice Lake Groupsites",
+    items: [
+      {
+        strapiName: "Alice Lake groupsite A",
+        newName: "Groupsite A",
+        strapiId: 177,
+      },
+      {
+        strapiName: "Alice Lake groupsite B",
+        newName: "Groupsite B",
+        strapiId: 178,
+      },
+    ],
+  },
+  {
+    parkId: 53,
+    campgroundName: "Big Bar Lake Campground",
+    items: [
+      {
+        strapiName: "Big Bar Lake Lakeside Campground",
+        newName: "Lakeside Campground",
+        strapiId: 29,
+      },
+      {
+        strapiName: "Big Bar Lake Upper Campground",
+        newName: "Upper Campground",
+        strapiId: 30,
+      },
+    ],
+  },
+  {
+    parkId: 902,
+    campgroundName: "Bighorn Campground",
+    items: [
+      {
+        strapiName: "Bighorn Campground RV sites",
+        newName: "RV Sites",
+        strapiId: 31,
+      },
+      {
+        strapiName: "Bighorn Campground sites 71-86",
+        newName: "Sites 71-86",
+        strapiId: 32,
+      },
+    ],
+  },
+  {
+    parkId: 506,
+    campgroundName: "Furlong Bay Campground",
+    items: [
+      {
+        strapiName: "Furlong Bay Campground sites 1-85",
+        newName: "Sites 1-85",
+        strapiId: 132,
+      },
+      {
+        strapiName: "Furlong Bay Campground sites 86-164",
+        newName: "Sites 86-164",
+        strapiId: 133,
+      },
+    ],
+  },
+  {
+    parkId: 199,
+    campgroundName: "Honeymoon Bay Groupsites",
+    items: [
+      {
+        strapiName: "Honeymoon Bay groupsite A",
+        newName: "Groupsite A",
+        strapiId: 200,
+      },
+      {
+        strapiName: "Honeymoon Bay groupsite B",
+        newName: "Groupsite B",
+        strapiId: 201,
+      },
+    ],
+  },
+  {
+    parkId: 449,
+    campgroundName: "Kettle River Campground",
+    items: [
+      {
+        strapiName: "Kettle River Campground sites 1-9, 21-44, 61-114",
+        newName: "Sites 1-9, 21-44, 61-114",
+        strapiId: 753,
+      },
+      {
+        strapiName: "Kettle River Campground sites 10-20, 45-60",
+        newName: "Sites 10-20, 45-60",
+        strapiId: 226,
+      },
+    ],
+  },
+  {
+    parkId: 247,
+    campgroundName: "Lightning Lake Campground",
+    items: [
+      {
+        strapiName: "Lightning Lake Campground (Large Loop)",
+        newName: "Large Loop",
+        strapiId: 246,
+      },
+      {
+        strapiName: "Lightning Lake Campground (Small Loop)",
+        newName: "Small Loop",
+        strapiId: 247,
+      },
+    ],
+  },
+  {
+    parkId: 525,
+    campgroundName: "Little Qualicum Falls Campground",
+    items: [
+      {
+        strapiName: "Little Qualicum Falls Lower Campground",
+        newName: "Lower Campground",
+        strapiId: 258,
+      },
+      {
+        strapiName: "Little Qualicum Falls Upper Campground",
+        newName: "Upper Campground",
+        strapiId: 462,
+      },
+    ],
+  },
+  {
+    parkId: 247,
+    campgroundName: "Lone Duck Groupsites",
+    items: [
+      {
+        strapiName: "Lone Duck groupsite 1",
+        newName: "Groupsite 1",
+        strapiId: 252,
+      },
+      {
+        strapiName: "Lone Duck groupsite 2",
+        newName: "Groupsite 2",
+        strapiId: 253,
+      },
+    ],
+  },
+  {
+    parkId: 199,
+    campgroundName: "Maple Bay Campground",
+    items: [
+      {
+        strapiName: "Maple Bay Campground sites 1-65",
+        newName: "Sites 1-65",
+        strapiId: 272,
+      },
+      {
+        strapiName: "Maple Bay Campground sites 66-97",
+        newName: "Sites 66-97",
+        strapiId: 273,
+      },
+    ],
+  },
+  {
+    parkId: 573,
+    campgroundName: "Miracle Beach Campground",
+    items: [
+      {
+        strapiName: "Miracle Beach Campground Overflow",
+        newName: "Overflow",
+        strapiId: 922,
+      },
+      {
+        strapiName: "Miracle Beach Campground sites 1-10",
+        newName: "Sites 1-10",
+        strapiId: 282,
+      },
+      {
+        strapiName: "Miracle Beach Campground sites 1-25",
+        newName: "Sites 1-25",
+        strapiId: 915,
+      },
+      {
+        strapiName: "Miracle Beach Campground sites 101-201",
+        newName: "Sites 101-201",
+        strapiId: 281,
+      },
+      {
+        strapiName: "Miracle Beach Campground sites 26-100",
+        newName: "Sites 26-100",
+        strapiId: 285,
+      },
+    ],
+  },
+  {
+    parkId: 681,
+    campgroundName: "Okanagan Lake Campground",
+    items: [
+      {
+        strapiName: "Okanagan Lake North Campground sites 1-81",
+        newName: "North Campground sites 1-81",
+        strapiId: 533,
+      },
+      {
+        strapiName: "Okanagan Lake South Campground sites 1-88",
+        newName: "South Campground sites 1-88",
+        strapiId: 539,
+      },
+    ],
+  },
+  {
+    parkId: 727,
+    campgroundName: "Porpoise Bay Campground",
+    items: [
+      {
+        strapiName: "Porpoise Bay Campground sites 1-30",
+        newName: "Sites 1-30",
+        strapiId: 343,
+      },
+      {
+        strapiName: "Porpoise Bay Campground sites 31-84",
+        newName: "Sites 31-84",
+        strapiId: 342,
+      },
+    ],
+  },
+  {
+    parkId: 264,
+    campgroundName: "Quinsam Campground",
+    items: [
+      {
+        strapiName: "Quinsam Campground sites 1-15",
+        newName: "Sites 1-15",
+        strapiId: 535,
+      },
+      {
+        strapiName: "Quinsam Campground sites 16-70",
+        newName: "Sites 16-70",
+        strapiId: 536,
+      },
+      {
+        strapiName: "Quinsam Campground sites 71-122",
+        newName: "Sites 71-122",
+        strapiId: 537,
+      },
+    ],
+  },
+  {
+    parkId: 760,
+    campgroundName: "Rathtrevor Beach Campground",
+    items: [
+      {
+        strapiName: "Rathtrevor Beach Campground sites 1-174",
+        newName: "Sites 1-174",
+        strapiId: 101,
+      },
+      {
+        strapiName: "Rathtrevor Beach Campground sites 175-226",
+        newName: "Sites 175-226",
+        strapiId: 255,
+      },
+    ],
+  },
+  {
+    parkId: 773,
+    campgroundName: "Roche Lake Campground",
+    items: [
+      {
+        strapiName: "Roche Lake North Campground",
+        newName: "North Campground",
+        strapiId: 369,
+      },
+      {
+        strapiName: "Roche Lake West Campground",
+        newName: "West Campground",
+        strapiId: 370,
+      },
+    ],
+  },
+  {
+    parkId: 486,
+    campgroundName: "Sandspit Campground",
+    items: [
+      {
+        strapiName: "Sandspit Campground lanes 1-3, sites 1-52",
+        newName: "Lanes 1-3, Sites 1-52",
+        strapiId: 381,
+      },
+      {
+        strapiName: "Sandspit Campground lanes 4-6, sites 53-113",
+        newName: "Lanes 4-6, Sites 53-113",
+        strapiId: 382,
+      },
+    ],
+  },
+  {
+    parkId: 816,
+    campgroundName: "Shuswap Lake Campground",
+    items: [
+      {
+        strapiName: "Shuswap Lake Campground sites 1-78, 246-330",
+        newName: "Sites 1-78, 246-330",
+        strapiId: 754,
+      },
+      {
+        strapiName: "Shuswap Lake Campground sites 79-245",
+        newName: "Sites 79-245",
+        strapiId: 755,
+      },
+      {
+        strapiName: "Shuswap Lake overflow sites",
+        newName: "Overflow sites",
+        strapiId: 322,
+      },
+    ],
+  },
+  {
+    parkId: 865,
+    campgroundName: "Sproat Lake Campground",
+    items: [
+      {
+        strapiName: "Sproat Lake Lower Campground",
+        newName: "Lower Campground",
+        strapiId: 259,
+      },
+      {
+        strapiName: "Sproat Lake Upper Campground",
+        newName: "Upper Campground",
+        strapiId: 463,
+      },
+    ],
+  },
+  {
+    parkId: 340,
+    campgroundName: "Texas Creek Campground",
+    items: [
+      {
+        strapiName: "Texas Creek Campground site 1-10 and 35-63",
+        newName: "Site 1-10 and 35-63",
+        strapiId: 451,
+      },
+      {
+        strapiName: "Texas Creek Campground sites 11-34",
+        newName: "Sites 11-34",
+        strapiId: 398,
+      },
+    ],
+  },
+  {
+    parkId: 199,
+    campgroundName: "West Side Groupsites",
+    items: [
+      {
+        strapiName: "West Side groupsite A",
+        newName: "Groupsite A",
+        strapiId: 484,
+      },
+      {
+        strapiName: "West Side groupsite B",
+        newName: "Groupsite B",
+        strapiId: 485,
+      },
+    ],
+  },
+  {
+    parkId: 128,
+    campgroundName: "White Spruce Island",
+    items: [
+      {
+        strapiName: "White Spruce Island North",
+        newName: "Island North",
+        strapiId: 489,
+      },
+      {
+        strapiName: "White Spruce Island South",
+        newName: "Island South",
+        strapiId: 490,
+      },
+    ],
+  },
+];

--- a/backend/strapi-sync/create-multiple-item-campgrounds.js
+++ b/backend/strapi-sync/create-multiple-item-campgrounds.js
@@ -425,14 +425,12 @@ async function createCampground(item) {
   const campground = await createModel(Campground, data);
 
   await Promise.all(
-    item.items.map(
-      async (feature) => await updateFeature(feature, campground.id),
-    ),
+    item.items.map(async (feature) => updateFeature(feature, campground.id)),
   );
 }
 
 async function createCampgrounds(items) {
-  await Promise.all(items.map(async (item) => await createCampground(item)));
+  await Promise.all(items.map(async (item) => createCampground(item)));
 }
 
 createCampgrounds(campgrounds);

--- a/backend/strapi-sync/create-single-item-campgrounds.js
+++ b/backend/strapi-sync/create-single-item-campgrounds.js
@@ -1,4 +1,8 @@
-const items = [
+import { Campground, Feature } from "../models/index.js";
+
+import { getItemByAttributes, createModel } from "./utils.js";
+
+const campgrounds = [
   {
     parkId: "885",
     campgroundName: "8 Mile Log Cabin",
@@ -1806,8 +1810,33 @@ const items = [
     items: [{ featureStrapiId: 380, featureName: "All sites" }],
   },
   {
-    parkId: "1035",
+    parkId: 1035,
     campgroundName: "s\u1e83i\u1e83s overflow camping",
     items: [{ featureStrapiId: 319, featureName: "All sites" }],
   },
 ];
+
+async function createCampground(item) {
+  // create campground with FK to Park
+  const data = {
+    name: item.campgroundName,
+    parkId: parseInt(item.parkId, 10),
+  };
+
+  const campground = await createModel(Campground, data);
+
+  // get feature by strapiID
+  const feature = await getItemByAttributes(Feature, {
+    strapiId: item.items[0].featureStrapiId,
+  });
+
+  feature.campgroundId = campground.id;
+  feature.name = "All sites";
+  await feature.save();
+}
+
+async function createSingleItemsCampgrounds(items) {
+  await Promise.all(items.map((item) => createCampground(item)));
+}
+
+createSingleItemsCampgrounds(campgrounds);

--- a/backend/strapi-sync/create-single-item-campgrounds.js
+++ b/backend/strapi-sync/create-single-item-campgrounds.js
@@ -1,0 +1,1813 @@
+const items = [
+  {
+    parkId: "885",
+    campgroundName: "8 Mile Log Cabin",
+    items: [{ featureStrapiId: 1, featureName: "All sites" }],
+  },
+  {
+    parkId: "634",
+    campgroundName: "Agate Beach Campground",
+    items: [{ featureStrapiId: 2, featureName: "All sites" }],
+  },
+  {
+    parkId: "3",
+    campgroundName: "Akamina Creek backcountry",
+    items: [{ featureStrapiId: 3, featureName: "All sites" }],
+  },
+  {
+    parkId: "1013",
+    campgroundName: "Alces Lake Campground",
+    items: [{ featureStrapiId: 5, featureName: "All sites" }],
+  },
+  {
+    parkId: "6",
+    campgroundName: "Alice Lake walk-in sites",
+    items: [{ featureStrapiId: 469, featureName: "All sites" }],
+  },
+  {
+    parkId: "8",
+    campgroundName: "Allison Lake Campground",
+    items: [{ featureStrapiId: 6, featureName: "All sites" }],
+  },
+  {
+    parkId: "347",
+    campgroundName: "Alouette Campground",
+    items: [{ featureStrapiId: 7, featureName: "All sites" }],
+  },
+  {
+    parkId: "347",
+    campgroundName: "Alouette groupsite",
+    items: [{ featureStrapiId: 8, featureName: "All sites" }],
+  },
+  {
+    parkId: "100",
+    campgroundName: "Applebee Dome Campground",
+    items: [{ featureStrapiId: 9, featureName: "All sites" }],
+  },
+  {
+    parkId: "361",
+    campgroundName: "Arrowhead Campground",
+    items: [{ featureStrapiId: 10, featureName: "All sites" }],
+  },
+  {
+    parkId: "133",
+    campgroundName: "Ashnola Forest Service Road",
+    items: [{ featureStrapiId: 11, featureName: "All sites" }],
+  },
+  {
+    parkId: "957",
+    campgroundName: "Atnarko Campground",
+    items: [{ featureStrapiId: 12, featureName: "All sites" }],
+  },
+  {
+    parkId: "996",
+    campgroundName: "Azure Lake backcountry",
+    items: [{ featureStrapiId: 13, featureName: "All sites" }],
+  },
+  {
+    parkId: "128",
+    campgroundName: "Balsam Island",
+    items: [{ featureStrapiId: 14, featureName: "All sites" }],
+  },
+  {
+    parkId: "32",
+    campgroundName: "Bamberton Campground",
+    items: [{ featureStrapiId: 15, featureName: "All sites" }],
+  },
+  {
+    parkId: "388",
+    campgroundName: "Bastion Mountain Campground",
+    items: [{ featureStrapiId: 16, featureName: "All sites" }],
+  },
+  {
+    parkId: "36",
+    campgroundName: "Bear Creek Campground",
+    items: [{ featureStrapiId: 912, featureName: "All sites" }],
+  },
+  {
+    parkId: "41",
+    campgroundName: "Beatton Campground",
+    items: [{ featureStrapiId: 17, featureName: "All sites" }],
+  },
+  {
+    parkId: "43",
+    campgroundName: "Beaumont Campground",
+    items: [{ featureStrapiId: 18, featureName: "All sites" }],
+  },
+  {
+    parkId: "44",
+    campgroundName: "Beaver Creek Campground",
+    items: [{ featureStrapiId: 615, featureName: "All sites" }],
+  },
+  {
+    parkId: "880",
+    campgroundName: "Bedwell Lake and Baby Bedwell Lake",
+    items: [{ featureStrapiId: 842, featureName: "All sites" }],
+  },
+  {
+    parkId: "801",
+    campgroundName: "Bench Campground",
+    items: [{ featureStrapiId: 19, featureName: "All sites" }],
+  },
+  {
+    parkId: "613",
+    campgroundName: "Berg Lake Trail",
+    items: [{ featureStrapiId: 20, featureName: "All sites" }],
+  },
+  {
+    parkId: "613",
+    campgroundName: "Berg Lake Trail - Kinney Lake Campground",
+    items: [{ featureStrapiId: 23, featureName: "All sites" }],
+  },
+  {
+    parkId: "613",
+    campgroundName: "Berg Lake Trail - Whitehorn Campground",
+    items: [{ featureStrapiId: 27, featureName: "All sites" }],
+  },
+  {
+    parkId: "128",
+    campgroundName: "Bert's Cabin (includes three tent pads)",
+    items: [{ featureStrapiId: 28, featureName: "All sites" }],
+  },
+  {
+    parkId: "55",
+    campgroundName: "Big Bunsby marine-accessible camping",
+    items: [{ featureStrapiId: 532, featureName: "All sites" }],
+  },
+  {
+    parkId: "60",
+    campgroundName: "Birkenhead Campground",
+    items: [{ featureStrapiId: 34, featureName: "All sites" }],
+  },
+  {
+    parkId: "60",
+    campgroundName: "Birkenhead high-density campground",
+    items: [{ featureStrapiId: 35, featureName: "All sites" }],
+  },
+  {
+    parkId: "803",
+    campgroundName: "Bishop Creek Campground",
+    items: [{ featureStrapiId: 759, featureName: "All sites" }],
+  },
+  {
+    parkId: "824",
+    campgroundName: "Black Prince Cabin",
+    items: [{ featureStrapiId: 36, featureName: "All sites" }],
+  },
+  {
+    parkId: "66",
+    campgroundName: "Blanket Creek groupsites",
+    items: [{ featureStrapiId: 179, featureName: "All sites" }],
+  },
+  {
+    parkId: "66",
+    campgroundName: "Blanket Creek sites 1-105",
+    items: [{ featureStrapiId: 394, featureName: "All sites" }],
+  },
+  {
+    parkId: "68",
+    campgroundName: "Blue Earth Lake Campground",
+    items: [{ featureStrapiId: 37, featureName: "All sites" }],
+  },
+  {
+    parkId: "221",
+    campgroundName: "Bold Head",
+    items: [{ featureStrapiId: 39, featureName: "All sites" }],
+  },
+  {
+    parkId: "100",
+    campgroundName: "Boulder Campground",
+    items: [{ featureStrapiId: 40, featureName: "All sites" }],
+  },
+  {
+    parkId: "79",
+    campgroundName: "Boundary Creek Campground",
+    items: [{ featureStrapiId: 41, featureName: "All sites" }],
+  },
+  {
+    parkId: "81",
+    campgroundName: "Bowron Lake Backcountry Canoe Circuit",
+    items: [{ featureStrapiId: 44, featureName: "All sites" }],
+  },
+  {
+    parkId: "81",
+    campgroundName: "Bowron Lake Backcountry Canoe Circuit cabins",
+    items: [{ featureStrapiId: 42, featureName: "All sites" }],
+  },
+  {
+    parkId: "81",
+    campgroundName: "Bowron Lake Campground",
+    items: [{ featureStrapiId: 43, featureName: "All sites" }],
+  },
+  {
+    parkId: "903",
+    campgroundName: "Boya Lake Campground",
+    items: [{ featureStrapiId: 46, featureName: "All sites" }],
+  },
+  {
+    parkId: "89",
+    campgroundName: "Bridge Lake Campground",
+    items: [{ featureStrapiId: 47, featureName: "All sites" }],
+  },
+  {
+    parkId: "89",
+    campgroundName: "Bridge Lake walk-in sites",
+    items: [{ featureStrapiId: 470, featureName: "All sites" }],
+  },
+  {
+    parkId: "92",
+    campgroundName: "Bromley Rock Campground",
+    items: [{ featureStrapiId: 923, featureName: "All sites" }],
+  },
+  {
+    parkId: "92",
+    campgroundName: "Bromley Rock Campground sites 1-17",
+    items: [{ featureStrapiId: 538, featureName: "All sites" }],
+  },
+  {
+    parkId: "247",
+    campgroundName: "Buckhorn Campground",
+    items: [{ featureStrapiId: 793, featureName: "All sites" }],
+  },
+  {
+    parkId: "99",
+    campgroundName: "Buckinghorse River Campground",
+    items: [{ featureStrapiId: 49, featureName: "All sites" }],
+  },
+  {
+    parkId: "102",
+    campgroundName: "Bull Canyon Campground",
+    items: [{ featureStrapiId: 50, featureName: "All sites" }],
+  },
+  {
+    parkId: "2",
+    campgroundName: "Bush Creek Site",
+    items: [{ featureStrapiId: 51, featureName: "All sites" }],
+  },
+  {
+    parkId: "880",
+    campgroundName: "Buttle Lake Campground",
+    items: [{ featureStrapiId: 52, featureName: "All sites" }],
+  },
+  {
+    parkId: "880",
+    campgroundName: "Buttle Lake and Upper Campbell marine sites",
+    items: [{ featureStrapiId: 498, featureName: "All sites" }],
+  },
+  {
+    parkId: "247",
+    campgroundName: "Cambie Creek (groupsite 3)",
+    items: [{ featureStrapiId: 57, featureName: "All sites" }],
+  },
+  {
+    parkId: "122",
+    campgroundName: "Cape Scott backcountry",
+    items: [{ featureStrapiId: 62, featureName: "All sites" }],
+  },
+  {
+    parkId: "127",
+    campgroundName: "Carmanah Walbran backcountry",
+    items: [{ featureStrapiId: 63, featureName: "All sites" }],
+  },
+  {
+    parkId: "128",
+    campgroundName: "Carp Lake (Kettle Bay) Campground",
+    items: [{ featureStrapiId: 64, featureName: "All sites" }],
+  },
+  {
+    parkId: "133",
+    campgroundName: "Cathedral backcountry",
+    items: [{ featureStrapiId: 65, featureName: "All sites" }],
+  },
+  {
+    parkId: "133",
+    campgroundName: "Cathedral core area",
+    items: [{ featureStrapiId: 66, featureName: "All sites" }],
+  },
+  {
+    parkId: "1013",
+    campgroundName: "Cave Creek backcountry",
+    items: [{ featureStrapiId: 67, featureName: "All sites" }],
+  },
+  {
+    parkId: "138",
+    campgroundName: "Cedar Point Campground",
+    items: [{ featureStrapiId: 68, featureName: "All sites" }],
+  },
+  {
+    parkId: "140",
+    campgroundName: "Champion Lakes Campground",
+    items: [{ featureStrapiId: 69, featureName: "All sites" }],
+  },
+  {
+    parkId: "142",
+    campgroundName: "Charlie Lake Campground",
+    items: [{ featureStrapiId: 70, featureName: "All sites" }],
+  },
+  {
+    parkId: "329",
+    campgroundName: "Cheakamus Lake Campground",
+    items: [{ featureStrapiId: 71, featureName: "All sites" }],
+  },
+  {
+    parkId: "150",
+    campgroundName: "Chilliwack Lake backcountry",
+    items: [{ featureStrapiId: 72, featureName: "All sites" }],
+  },
+  {
+    parkId: "425",
+    campgroundName: "China Beach Campground",
+    items: [{ featureStrapiId: 73, featureName: "All sites" }],
+  },
+  {
+    parkId: "160",
+    campgroundName: "Cinnemousun Narrows marine-accessible camping",
+    items: [{ featureStrapiId: 74, featureName: "All sites" }],
+  },
+  {
+    parkId: "160",
+    campgroundName: "Cinnemousun Narrows shelters",
+    items: [{ featureStrapiId: 387, featureName: "All sites" }],
+  },
+  {
+    parkId: "199",
+    campgroundName: "Clear Creek Campground",
+    items: [{ featureStrapiId: 75, featureName: "All sites" }],
+  },
+  {
+    parkId: "996",
+    campgroundName: "Clearwater Lake Campground",
+    items: [{ featureStrapiId: 77, featureName: "All sites" }],
+  },
+  {
+    parkId: "996",
+    campgroundName: "Clearwater Lake backcountry",
+    items: [{ featureStrapiId: 76, featureName: "All sites" }],
+  },
+  {
+    parkId: "247",
+    campgroundName: "Coldspring Campground",
+    items: [{ featureStrapiId: 78, featureName: "All sites" }],
+  },
+  {
+    parkId: "181",
+    campgroundName: "Conkle Lake Campground",
+    items: [{ featureStrapiId: 79, featureName: "All sites" }],
+  },
+  {
+    parkId: "181",
+    campgroundName: "Conkle Lake groupsites",
+    items: [{ featureStrapiId: 80, featureName: "All sites" }],
+  },
+  {
+    parkId: "100",
+    campgroundName: "Conrad Kain Hut",
+    items: [{ featureStrapiId: 82, featureName: "All sites" }],
+  },
+  {
+    parkId: "197",
+    campgroundName: "Crooked River Campground",
+    items: [{ featureStrapiId: 83, featureName: "All sites" }],
+  },
+  {
+    parkId: "880",
+    campgroundName: "Croteau Lake backcountry groupsite",
+    items: [{ featureStrapiId: 84, featureName: "All sites" }],
+  },
+  {
+    parkId: "717",
+    campgroundName: "Dark Creek Campground",
+    items: [{ featureStrapiId: 752, featureName: "All sites" }],
+  },
+  {
+    parkId: "489",
+    campgroundName: "Davis Creek Campground",
+    items: [{ featureStrapiId: 86, featureName: "All sites" }],
+  },
+  {
+    parkId: "199",
+    campgroundName: "Delta Grove Campground",
+    items: [{ featureStrapiId: 95, featureName: "All sites" }],
+  },
+  {
+    parkId: "217",
+    campgroundName: "Denetiah Lake Cabin",
+    items: [{ featureStrapiId: 96, featureName: "All sites" }],
+  },
+  {
+    parkId: "225",
+    campgroundName: "Dionisio Point backcountry",
+    items: [{ featureStrapiId: 97, featureName: "All sites" }],
+  },
+  {
+    parkId: "226",
+    campgroundName: "Discovery Island backcountry",
+    items: [{ featureStrapiId: 98, featureName: "All sites" }],
+  },
+  {
+    parkId: "230",
+    campgroundName: "Downing Campground",
+    items: [{ featureStrapiId: 99, featureName: "All sites" }],
+  },
+  {
+    parkId: "880",
+    campgroundName: "Driftwood Bay groupsite",
+    items: [{ featureStrapiId: 100, featureName: "All sites" }],
+  },
+  {
+    parkId: "236",
+    campgroundName: "Dry Gulch Campground",
+    items: [{ featureStrapiId: 104, featureName: "All sites" }],
+  },
+  {
+    parkId: "244",
+    campgroundName: "Duu Guusd Campsite",
+    items: [{ featureStrapiId: 465, featureName: "All sites" }],
+  },
+  {
+    parkId: "221",
+    campgroundName: "East Curme Island",
+    items: [{ featureStrapiId: 106, featureName: "All sites" }],
+  },
+  {
+    parkId: "329",
+    campgroundName: "Elfin Lakes Campground",
+    items: [{ featureStrapiId: 107, featureName: "All sites" }],
+  },
+  {
+    parkId: "329",
+    campgroundName: "Elfin Lakes Shelter",
+    items: [{ featureStrapiId: 108, featureName: "All sites" }],
+  },
+  {
+    parkId: "266",
+    campgroundName: "Elk Lakes Cabin",
+    items: [{ featureStrapiId: 110, featureName: "All sites" }],
+  },
+  {
+    parkId: "266",
+    campgroundName: "Elk Lakes backcountry",
+    items: [{ featureStrapiId: 109, featureName: "All sites" }],
+  },
+  {
+    parkId: "880",
+    campgroundName: "Elk River",
+    items: [{ featureStrapiId: 502, featureName: "All sites" }],
+  },
+  {
+    parkId: "271",
+    campgroundName: "Ellison Campground",
+    items: [{ featureStrapiId: 917, featureName: "All sites" }],
+  },
+  {
+    parkId: "361",
+    campgroundName: "Emerald Bay Campground",
+    items: [{ featureStrapiId: 910, featureName: "All sites" }],
+  },
+  {
+    parkId: "274",
+    campgroundName: "Emory Creek Campground",
+    items: [{ featureStrapiId: 116, featureName: "All sites" }],
+  },
+  {
+    parkId: "278",
+    campgroundName: "Englishman River Falls Campground",
+    items: [{ featureStrapiId: 117, featureName: "All sites" }],
+  },
+  {
+    parkId: "199",
+    campgroundName: "Entrance Bay Campground",
+    items: [{ featureStrapiId: 118, featureName: "All sites" }],
+  },
+  {
+    parkId: "996",
+    campgroundName: "Falls Creek Campground",
+    items: [{ featureStrapiId: 119, featureName: "All sites" }],
+  },
+  {
+    parkId: "548",
+    campgroundName: "Feather Cove",
+    items: [{ featureStrapiId: 120, featureName: "All sites" }],
+  },
+  {
+    parkId: "297",
+    campgroundName: "Fillongley Campground sites 1-10",
+    items: [{ featureStrapiId: 121, featureName: "All sites" }],
+  },
+  {
+    parkId: "303",
+    campgroundName: "Fintry Campground sites 1-160",
+    items: [{ featureStrapiId: 921, featureName: "All sites" }],
+  },
+  {
+    parkId: "303",
+    campgroundName: "Fintry groupsites",
+    items: [{ featureStrapiId: 123, featureName: "All sites" }],
+  },
+  {
+    parkId: "933",
+    campgroundName: "Fish Lake Cabin",
+    items: [{ featureStrapiId: 125, featureName: "All sites" }],
+  },
+  {
+    parkId: "957",
+    campgroundName: "Fisheries Pool Campground",
+    items: [{ featureStrapiId: 126, featureName: "All sites" }],
+  },
+  {
+    parkId: "150",
+    campgroundName: "Flora Loop",
+    items: [{ featureStrapiId: 127, featureName: "All sites" }],
+  },
+  {
+    parkId: "307",
+    campgroundName: "Flores Island backcountry",
+    items: [{ featureStrapiId: 128, featureName: "All sites" }],
+  },
+  {
+    parkId: "324",
+    campgroundName: "French Beach Campground",
+    items: [{ featureStrapiId: 129, featureName: "All sites" }],
+  },
+  {
+    parkId: "324",
+    campgroundName: "French Beach groupsite",
+    items: [{ featureStrapiId: 130, featureName: "All sites" }],
+  },
+  {
+    parkId: "486",
+    campgroundName: "Friends Campground",
+    items: [{ featureStrapiId: 131, featureName: "All sites" }],
+  },
+  {
+    parkId: "247",
+    campgroundName: "Frosty Creek Campground",
+    items: [{ featureStrapiId: 795, featureName: "All sites" }],
+  },
+  {
+    parkId: "329",
+    campgroundName: "Garibaldi Lake Campground",
+    items: [{ featureStrapiId: 134, featureName: "All sites" }],
+  },
+  {
+    parkId: "331",
+    campgroundName: "Gibson marine backcountry",
+    items: [{ featureStrapiId: 135, featureName: "All sites" }],
+  },
+  {
+    parkId: "347",
+    campgroundName: "Gold Creek Campground",
+    items: [{ featureStrapiId: 138, featureName: "All sites" }],
+  },
+  {
+    parkId: "347",
+    campgroundName: "Golden Ears backcountry",
+    items: [{ featureStrapiId: 139, featureName: "All sites" }],
+  },
+  {
+    parkId: "347",
+    campgroundName: "Golden Ears groupsite",
+    items: [{ featureStrapiId: 140, featureName: "All sites" }],
+  },
+  {
+    parkId: "347",
+    campgroundName: "Golden Ears marine backcountry",
+    items: [{ featureStrapiId: 141, featureName: "All sites" }],
+  },
+  {
+    parkId: "350",
+    campgroundName: "Goldminer Groupsite",
+    items: [{ featureStrapiId: 611, featureName: "All sites" }],
+  },
+  {
+    parkId: "349",
+    campgroundName: "Goldpan Campground",
+    items: [{ featureStrapiId: 142, featureName: "All sites" }],
+  },
+  {
+    parkId: "350",
+    campgroundName: "Goldstream Campground",
+    items: [{ featureStrapiId: 143, featureName: "All sites" }],
+  },
+  {
+    parkId: "353",
+    campgroundName: "Gordon Bay Campground",
+    items: [{ featureStrapiId: 145, featureName: "All sites" }],
+  },
+  {
+    parkId: "353",
+    campgroundName: "Gordon Bay groupsite",
+    items: [{ featureStrapiId: 146, featureName: "All sites" }],
+  },
+  {
+    parkId: "221",
+    campgroundName: "Grace Harbour",
+    items: [{ featureStrapiId: 147, featureName: "All sites" }],
+  },
+  {
+    parkId: "803",
+    campgroundName: "Granite Falls Campground",
+    items: [{ featureStrapiId: 750, featureName: "All sites" }],
+  },
+  {
+    parkId: "150",
+    campgroundName: "Greendrop Loop",
+    items: [{ featureStrapiId: 150, featureName: "All sites" }],
+  },
+  {
+    parkId: "885",
+    campgroundName: "Grizzly Den Cabin",
+    items: [{ featureStrapiId: 151, featureName: "All sites" }],
+  },
+  {
+    parkId: "486",
+    campgroundName: "Groupsite G1",
+    items: [{ featureStrapiId: 180, featureName: "All sites" }],
+  },
+  {
+    parkId: "945",
+    campgroundName: "Gwe Da Ts'ih Campground",
+    items: [{ featureStrapiId: 185, featureName: "All sites" }],
+  },
+  {
+    parkId: "366",
+    campgroundName: "Gwillim Lake Campground",
+    items: [{ featureStrapiId: 187, featureName: "All sites" }],
+  },
+  {
+    parkId: "373",
+    campgroundName: "Halkett Bay marine backcountry",
+    items: [{ featureStrapiId: 189, featureName: "All sites" }],
+  },
+  {
+    parkId: "247",
+    campgroundName: "Hampton Campground",
+    items: [{ featureStrapiId: 190, featureName: "All sites" }],
+  },
+  {
+    parkId: "221",
+    campgroundName: "Hare Point",
+    items: [{ featureStrapiId: 191, featureName: "All sites" }],
+  },
+  {
+    parkId: "329",
+    campgroundName: "Helm Creek Campground",
+    items: [{ featureStrapiId: 192, featureName: "All sites" }],
+  },
+  {
+    parkId: "801",
+    campgroundName: "Hicks Lake Campground",
+    items: [{ featureStrapiId: 196, featureName: "All sites" }],
+  },
+  {
+    parkId: "801",
+    campgroundName: "Hicks Lake groupsite",
+    items: [{ featureStrapiId: 197, featureName: "All sites" }],
+  },
+  {
+    parkId: "1013",
+    campgroundName: "Home Basin Campground",
+    items: [{ featureStrapiId: 198, featureName: "All sites" }],
+  },
+  {
+    parkId: "388",
+    campgroundName: "Homestead Campground",
+    items: [{ featureStrapiId: 199, featureName: "All sites" }],
+  },
+  {
+    parkId: "27",
+    campgroundName: "Hook (Deep) Bay",
+    items: [{ featureStrapiId: 831, featureName: "All sites" }],
+  },
+  {
+    parkId: "401",
+    campgroundName: "Horsefly Lake Campground",
+    items: [{ featureStrapiId: 202, featureName: "All sites" }],
+  },
+  {
+    parkId: "401",
+    campgroundName: "Horsefly Lake walk-in sites",
+    items: [{ featureStrapiId: 472, featureName: "All sites" }],
+  },
+  {
+    parkId: "192",
+    campgroundName: "Horseshoe Bend groupsite",
+    items: [{ featureStrapiId: 203, featureName: "All sites" }],
+  },
+  {
+    parkId: "773",
+    campgroundName: "Horseshoe Lake Campground",
+    items: [{ featureStrapiId: 204, featureName: "All sites" }],
+  },
+  {
+    parkId: "410",
+    campgroundName: "Inkaneep Campground",
+    items: [{ featureStrapiId: 205, featureName: "All sites" }],
+  },
+  {
+    parkId: "411",
+    campgroundName: "Inland Lake Campground",
+    items: [{ featureStrapiId: 207, featureName: "All sites" }],
+  },
+  {
+    parkId: "411",
+    campgroundName: "Inland Lake backcountry",
+    items: [{ featureStrapiId: 206, featureName: "All sites" }],
+  },
+  {
+    parkId: "1013",
+    campgroundName: "Inlet Creek Campground",
+    items: [{ featureStrapiId: 208, featureName: "All sites" }],
+  },
+  {
+    parkId: "419",
+    campgroundName: "Jedediah Island marine backcountry",
+    items: [{ featureStrapiId: 211, featureName: "All sites" }],
+  },
+  {
+    parkId: "421",
+    campgroundName: "Jewel Lake Campground",
+    items: [{ featureStrapiId: 212, featureName: "All sites" }],
+  },
+  {
+    parkId: "422",
+    campgroundName: "Jimsmith Lake Campground",
+    items: [{ featureStrapiId: 213, featureName: "All sites" }],
+  },
+  {
+    parkId: "423",
+    campgroundName: "Joffre Lakes Backcountry Campground",
+    items: [{ featureStrapiId: 215, featureName: "All sites" }],
+  },
+  {
+    parkId: "424",
+    campgroundName: "Johnstone Creek Campground",
+    items: [{ featureStrapiId: 216, featureName: "All sites" }],
+  },
+  {
+    parkId: "425",
+    campgroundName: "Juan de Fuca Marine Trail backcountry",
+    items: [{ featureStrapiId: 217, featureName: "All sites" }],
+  },
+  {
+    parkId: "428",
+    campgroundName: "Juniper Beach Campground",
+    items: [{ featureStrapiId: 911, featureName: "All sites" }],
+  },
+  {
+    parkId: "457",
+    campgroundName: "Kalispell Trail Campground",
+    items: [{ featureStrapiId: 222, featureName: "All sites" }],
+  },
+  {
+    parkId: "880",
+    campgroundName: "Karst Creek groupsite",
+    items: [{ featureStrapiId: 223, featureName: "All sites" }],
+  },
+  {
+    parkId: "443",
+    campgroundName: "Kekuli Bay Campground sites 1-73",
+    items: [{ featureStrapiId: 530, featureName: "All sites" }],
+  },
+  {
+    parkId: "443",
+    campgroundName: "Kekuli Bay walk-in sites 74-77",
+    items: [{ featureStrapiId: 467, featureName: "All sites" }],
+  },
+  {
+    parkId: "447",
+    campgroundName: "Kentucky-Alleyne Campground",
+    items: [{ featureStrapiId: 224, featureName: "All sites" }],
+  },
+  {
+    parkId: "447",
+    campgroundName: "Kentucky-Alleyne groupsite",
+    items: [{ featureStrapiId: 225, featureName: "All sites" }],
+  },
+  {
+    parkId: "449",
+    campgroundName: "Kettle River groupsite",
+    items: [{ featureStrapiId: 227, featureName: "All sites" }],
+  },
+  {
+    parkId: "247",
+    campgroundName: "Kicking Horse Campground",
+    items: [{ featureStrapiId: 794, featureName: "All sites" }],
+  },
+  {
+    parkId: "457",
+    campgroundName: "Kikomun groupsites",
+    items: [{ featureStrapiId: 229, featureName: "All sites" }],
+  },
+  {
+    parkId: "459",
+    campgroundName: "Kilby Campground",
+    items: [{ featureStrapiId: 230, featureName: "All sites" }],
+  },
+  {
+    parkId: "462",
+    campgroundName: "Kinaskan Lake Campground",
+    items: [{ featureStrapiId: 231, featureName: "All sites" }],
+  },
+  {
+    parkId: "467",
+    campgroundName: "Kiskatinaw Campground",
+    items: [{ featureStrapiId: 232, featureName: "All sites" }],
+  },
+  {
+    parkId: "474",
+    campgroundName: "Kitty Coleman Beach Campground",
+    items: [{ featureStrapiId: 233, featureName: "All sites" }],
+  },
+  {
+    parkId: "474",
+    campgroundName: "Kitty Coleman Beach groupsite",
+    items: [{ featureStrapiId: 234, featureName: "All sites" }],
+  },
+  {
+    parkId: "478",
+    campgroundName: "Kleanza Creek Campground",
+    items: [{ featureStrapiId: 235, featureName: "All sites" }],
+  },
+  {
+    parkId: "487",
+    campgroundName: "Kokanee Glacier Cabin",
+    items: [{ featureStrapiId: 237, featureName: "All sites" }],
+  },
+  {
+    parkId: "487",
+    campgroundName: "Kokanee Glacier backcountry",
+    items: [{ featureStrapiId: 236, featureName: "All sites" }],
+  },
+  {
+    parkId: "489",
+    campgroundName: "Kootenay Lake groupsite",
+    items: [{ featureStrapiId: 166, featureName: "All sites" }],
+  },
+  {
+    parkId: "502",
+    campgroundName: "Lac La Hache Campground",
+    items: [{ featureStrapiId: 238, featureName: "All sites" }],
+  },
+  {
+    parkId: "503",
+    campgroundName: "Lac Le Jeune Campground",
+    items: [{ featureStrapiId: 239, featureName: "All sites" }],
+  },
+  {
+    parkId: "506",
+    campgroundName: "Lakelse Lake groupsite",
+    items: [{ featureStrapiId: 167, featureName: "All sites" }],
+  },
+  {
+    parkId: "801",
+    campgroundName: "Lakeside (Deer Lake) Campground",
+    items: [{ featureStrapiId: 240, featureName: "All sites" }],
+  },
+  {
+    parkId: "918",
+    campgroundName: "Lakeside Campground",
+    items: [{ featureStrapiId: 241, featureName: "All sites" }],
+  },
+  {
+    parkId: "953",
+    campgroundName: "Leighton Campground",
+    items: [{ featureStrapiId: 242, featureName: "All sites" }],
+  },
+  {
+    parkId: "953",
+    campgroundName: "Leighton North Campground",
+    items: [{ featureStrapiId: 244, featureName: "All sites" }],
+  },
+  {
+    parkId: "521",
+    campgroundName: "Liard River Hot Springs Campground",
+    items: [{ featureStrapiId: 245, featureName: "All sites" }],
+  },
+  {
+    parkId: "150",
+    campgroundName: "Lindeman Loop",
+    items: [{ featureStrapiId: 250, featureName: "All sites" }],
+  },
+  {
+    parkId: "527",
+    campgroundName: "Lockhart Beach Campground",
+    items: [{ featureStrapiId: 251, featureName: "All sites" }],
+  },
+  {
+    parkId: "489",
+    campgroundName: "Lost Ledge Campground",
+    items: [{ featureStrapiId: 256, featureName: "All sites" }],
+  },
+  {
+    parkId: "533",
+    campgroundName: "Loveland Bay Campground",
+    items: [{ featureStrapiId: 257, featureName: "All sites" }],
+  },
+  {
+    parkId: "533",
+    campgroundName: "Loveland Bay groupsites",
+    items: [{ featureStrapiId: 181, featureName: "All sites" }],
+  },
+  {
+    parkId: "613",
+    campgroundName: "Lucerne Campground",
+    items: [{ featureStrapiId: 260, featureName: "All sites" }],
+  },
+  {
+    parkId: "541",
+    campgroundName: "Mabel Lake groupsite",
+    items: [{ featureStrapiId: 168, featureName: "All sites" }],
+  },
+  {
+    parkId: "625",
+    campgroundName: "MacDonald Campground",
+    items: [{ featureStrapiId: 261, featureName: "All sites" }],
+  },
+  {
+    parkId: "595",
+    campgroundName: "Magog Lake",
+    items: [{ featureStrapiId: 263, featureName: "All sites" }],
+  },
+  {
+    parkId: "996",
+    campgroundName: "Mahood Lake Campground",
+    items: [{ featureStrapiId: 265, featureName: "All sites" }],
+  },
+  {
+    parkId: "996",
+    campgroundName: "Mahood Lake backcountry",
+    items: [{ featureStrapiId: 264, featureName: "All sites" }],
+  },
+  {
+    parkId: "996",
+    campgroundName: "Mahood Lake groupsites",
+    items: [{ featureStrapiId: 266, featureName: "All sites" }],
+  },
+  {
+    parkId: "902",
+    campgroundName: "Main Campground sites 1-61",
+    items: [{ featureStrapiId: 267, featureName: "All sites" }],
+  },
+  {
+    parkId: "547",
+    campgroundName: "Main Lake backcountry",
+    items: [{ featureStrapiId: 268, featureName: "All sites" }],
+  },
+  {
+    parkId: "199",
+    campgroundName: "Maple Bay Campground Cabins",
+    items: [{ featureStrapiId: 271, featureName: "All sites" }],
+  },
+  {
+    parkId: "556",
+    campgroundName: "Marble Canyon Campground",
+    items: [{ featureStrapiId: 274, featureName: "All sites" }],
+  },
+  {
+    parkId: "560",
+    campgroundName: "Martha Creek Campground",
+    items: [{ featureStrapiId: 913, featureName: "All sites" }],
+  },
+  {
+    parkId: "565",
+    campgroundName: "McDonald Creek Campground",
+    items: [{ featureStrapiId: 363, featureName: "All sites" }],
+  },
+  {
+    parkId: "565",
+    campgroundName: "McDonald Creek Campground first come, first served sites",
+    items: [{ featureStrapiId: 124, featureName: "All sites" }],
+  },
+  {
+    parkId: "792",
+    campgroundName: "Mermaid Cove Campground",
+    items: [{ featureStrapiId: 277, featureName: "All sites" }],
+  },
+  {
+    parkId: "571",
+    campgroundName: "Meziadin Lake Campground",
+    items: [{ featureStrapiId: 278, featureName: "All sites" }],
+  },
+  {
+    parkId: "182",
+    campgroundName: "Middle Copeland Island",
+    items: [{ featureStrapiId: 279, featureName: "All sites" }],
+  },
+  {
+    parkId: "489",
+    campgroundName: "Midge Creek backcountry",
+    items: [{ featureStrapiId: 280, featureName: "All sites" }],
+  },
+  {
+    parkId: "573",
+    campgroundName: "Miracle Beach groupsite",
+    items: [{ featureStrapiId: 169, featureName: "All sites" }],
+  },
+  {
+    parkId: "634",
+    campgroundName: "Misty Meadows Campground",
+    items: [{ featureStrapiId: 286, featureName: "All sites" }],
+  },
+  {
+    parkId: "634",
+    campgroundName: "Misty Meadows Groupsite",
+    items: [{ featureStrapiId: 648, featureName: "All sites" }],
+  },
+  {
+    parkId: "577",
+    campgroundName: "Moberly Lake Campground",
+    items: [{ featureStrapiId: 287, featureName: "All sites" }],
+  },
+  {
+    parkId: "579",
+    campgroundName: "Momich River Campground",
+    items: [{ featureStrapiId: 288, featureName: "All sites" }],
+  },
+  {
+    parkId: "541",
+    campgroundName: "Monashee Loop sites 1-36",
+    items: [{ featureStrapiId: 290, featureName: "All sites" }],
+  },
+  {
+    parkId: "581",
+    campgroundName: "Monashee backcountry",
+    items: [{ featureStrapiId: 289, featureName: "All sites" }],
+  },
+  {
+    parkId: "582",
+    campgroundName: "Monck Campground",
+    items: [{ featureStrapiId: 291, featureName: "All sites" }],
+  },
+  {
+    parkId: "584",
+    campgroundName: "Monkman Campground",
+    items: [{ featureStrapiId: 292, featureName: "All sites" }],
+  },
+  {
+    parkId: "585",
+    campgroundName: "Montague Harbour Campground",
+    items: [{ featureStrapiId: 293, featureName: "All sites" }],
+  },
+  {
+    parkId: "585",
+    campgroundName: "Montague Harbour groupsite",
+    items: [{ featureStrapiId: 170, featureName: "All sites" }],
+  },
+  {
+    parkId: "594",
+    campgroundName: "Morton Lake Campground",
+    items: [{ featureStrapiId: 294, featureName: "All sites" }],
+  },
+  {
+    parkId: "603",
+    campgroundName: "Mount Fernie Campground",
+    items: [{ featureStrapiId: 295, featureName: "All sites" }],
+  },
+  {
+    parkId: "617",
+    campgroundName: "Mount Seymour backcountry",
+    items: [{ featureStrapiId: 577, featureName: "All sites" }],
+  },
+  {
+    parkId: "617",
+    campgroundName: "Mount Seymour groupsite",
+    items: [{ featureStrapiId: 171, featureName: "All sites" }],
+  },
+  {
+    parkId: "622",
+    campgroundName: "Moyie Lake Campground",
+    items: [{ featureStrapiId: 296, featureName: "All sites" }],
+  },
+  {
+    parkId: "247",
+    campgroundName: "Mule Deer Campground",
+    items: [{ featureStrapiId: 297, featureName: "All sites" }],
+  },
+  {
+    parkId: "996",
+    campgroundName: "Murtle Lake backcountry",
+    items: [{ featureStrapiId: 298, featureName: "All sites" }],
+  },
+  {
+    parkId: "626",
+    campgroundName: "M\u146buq\u1d42in wilderness camping",
+    items: [{ featureStrapiId: 540, featureName: "All sites" }],
+  },
+  {
+    parkId: "635",
+    campgroundName: "Nairn Campground",
+    items: [{ featureStrapiId: 299, featureName: "All sites" }],
+  },
+  {
+    parkId: "595",
+    campgroundName: "Naiset Huts",
+    items: [{ featureStrapiId: 300, featureName: "All sites" }],
+  },
+  {
+    parkId: "641",
+    campgroundName: "Nancy Greene Campground",
+    items: [{ featureStrapiId: 301, featureName: "All sites" }],
+  },
+  {
+    parkId: "652",
+    campgroundName: "Newcastle Island Campground",
+    items: [{ featureStrapiId: 302, featureName: "All sites" }],
+  },
+  {
+    parkId: "663",
+    campgroundName: "Niskonlith Lake Campground",
+    items: [{ featureStrapiId: 303, featureName: "All sites" }],
+  },
+  {
+    parkId: "668",
+    campgroundName: "Norbury Lake Campground",
+    items: [{ featureStrapiId: 304, featureName: "All sites" }],
+  },
+  {
+    parkId: "347",
+    campgroundName: "North Beach Campground",
+    items: [{ featureStrapiId: 305, featureName: "All sites" }],
+  },
+  {
+    parkId: "182",
+    campgroundName: "North Copeland Island",
+    items: [{ featureStrapiId: 308, featureName: "All sites" }],
+  },
+  {
+    parkId: "674",
+    campgroundName: "North Thompson River Campground",
+    items: [{ featureStrapiId: 309, featureName: "All sites" }],
+  },
+  {
+    parkId: "803",
+    campgroundName: "North Twin Island Campground",
+    items: [{ featureStrapiId: 749, featureName: "All sites" }],
+  },
+  {
+    parkId: "945",
+    campgroundName: "Nu Chugh Beniz Campground",
+    items: [{ featureStrapiId: 310, featureName: "All sites" }],
+  },
+  {
+    parkId: "595",
+    campgroundName: "Og Lake",
+    items: [{ featureStrapiId: 313, featureName: "All sites" }],
+  },
+  {
+    parkId: "681",
+    campgroundName: "Okanagan Lake South Campground walk-in sites 89-96",
+    items: [{ featureStrapiId: 424, featureName: "All sites" }],
+  },
+  {
+    parkId: "682",
+    campgroundName: "Okanagan wilderness and boat-access camping",
+    items: [{ featureStrapiId: 493, featureName: "All sites" }],
+  },
+  {
+    parkId: "683",
+    campgroundName: "Okeover Arm",
+    items: [{ featureStrapiId: 314, featureName: "All sites" }],
+  },
+  {
+    parkId: "731",
+    campgroundName: "Olympic Legacy Cabins",
+    items: [{ featureStrapiId: 315, featureName: "All sites" }],
+  },
+  {
+    parkId: "486",
+    campgroundName: "Osprey Point Campground",
+    items: [{ featureStrapiId: 317, featureName: "All sites" }],
+  },
+  {
+    parkId: "486",
+    campgroundName: "Osprey Point Campground G2",
+    items: [{ featureStrapiId: 316, featureName: "All sites" }],
+  },
+  {
+    parkId: "247",
+    campgroundName: "Other E.C. Manning backcountry",
+    items: [{ featureStrapiId: 105, featureName: "All sites" }],
+  },
+  {
+    parkId: "613",
+    campgroundName:
+      "Other Mount Robson backcountry (Mount Fitzwilliam and Moose River Trail)",
+    items: [{ featureStrapiId: 318, featureName: "All sites" }],
+  },
+  {
+    parkId: "692",
+    campgroundName: "Otter Lake Campground sites 1-45",
+    items: [{ featureStrapiId: 534, featureName: "All sites" }],
+  },
+  {
+    parkId: "595",
+    campgroundName: "O\u2019Brien Meadows",
+    items: [{ featureStrapiId: 311, featureName: "All sites" }],
+  },
+  {
+    parkId: "595",
+    campgroundName: "O\u2019Brien Meadows Horse Campground",
+    items: [{ featureStrapiId: 312, featureName: "All sites" }],
+  },
+  {
+    parkId: "698",
+    campgroundName: "Paarens Beach Campground",
+    items: [{ featureStrapiId: 323, featureName: "All sites" }],
+  },
+  {
+    parkId: "1013",
+    campgroundName: "Packrat Point Campground",
+    items: [{ featureStrapiId: 324, featureName: "All sites" }],
+  },
+  {
+    parkId: "150",
+    campgroundName: "Paleface Loop",
+    items: [{ featureStrapiId: 325, featureName: "All sites" }],
+  },
+  {
+    parkId: "880",
+    campgroundName: "Paradise Meadows area",
+    items: [{ featureStrapiId: 503, featureName: "All sites" }],
+  },
+  {
+    parkId: "704",
+    campgroundName: "Paul Lake Campground",
+    items: [{ featureStrapiId: 326, featureName: "All sites" }],
+  },
+  {
+    parkId: "704",
+    campgroundName: "Paul Lake groupsite",
+    items: [{ featureStrapiId: 327, featureName: "All sites" }],
+  },
+  {
+    parkId: "27",
+    campgroundName: "Pendleton Bay",
+    items: [{ featureStrapiId: 830, featureName: "All sites" }],
+  },
+  {
+    parkId: "27",
+    campgroundName: "Pierre Creek",
+    items: [{ featureStrapiId: 833, featureName: "All sites" }],
+  },
+  {
+    parkId: "714",
+    campgroundName: "Pilot Bay backcountry",
+    items: [{ featureStrapiId: 334, featureName: "All sites" }],
+  },
+  {
+    parkId: "27",
+    campgroundName: "Pinkut Creek",
+    items: [{ featureStrapiId: 832, featureName: "All sites" }],
+  },
+  {
+    parkId: "720",
+    campgroundName: "Pirates Cove backcountry",
+    items: [{ featureStrapiId: 335, featureName: "All sites" }],
+  },
+  {
+    parkId: "723",
+    campgroundName: "Plumper Cove marine-accessible camping",
+    items: [{ featureStrapiId: 473, featureName: "All sites" }],
+  },
+  {
+    parkId: "595",
+    campgroundName: "Police Meadows Cabin",
+    items: [{ featureStrapiId: 339, featureName: "All sites" }],
+  },
+  {
+    parkId: "457",
+    campgroundName: "Ponderosa Campground",
+    items: [{ featureStrapiId: 340, featureName: "All sites" }],
+  },
+  {
+    parkId: "457",
+    campgroundName: "Ponderosa Campground Cabins",
+    items: [{ featureStrapiId: 341, featureName: "All sites" }],
+  },
+  {
+    parkId: "595",
+    campgroundName: "Porcupine Campground",
+    items: [{ featureStrapiId: 792, featureName: "All sites" }],
+  },
+  {
+    parkId: "727",
+    campgroundName: "Porpoise Bay cyclist-only walk-in sites",
+    items: [{ featureStrapiId: 85, featureName: "All sites" }],
+  },
+  {
+    parkId: "727",
+    campgroundName: "Porpoise Bay groupsite",
+    items: [{ featureStrapiId: 173, featureName: "All sites" }],
+  },
+  {
+    parkId: "731",
+    campgroundName: "Porteau Cove Campground vehicle accessible sites",
+    items: [{ featureStrapiId: 914, featureName: "All sites" }],
+  },
+  {
+    parkId: "731",
+    campgroundName: "Porteau Cove walk-in sites",
+    items: [{ featureStrapiId: 476, featureName: "All sites" }],
+  },
+  {
+    parkId: "732",
+    campgroundName: "Premier Lake Campground",
+    items: [{ featureStrapiId: 344, featureName: "All sites" }],
+  },
+  {
+    parkId: "350",
+    campgroundName: "Prospector Groupsite ",
+    items: [{ featureStrapiId: 610, featureName: "All sites" }],
+  },
+  {
+    parkId: "737",
+    campgroundName: "Prudhomme Lake Campground",
+    items: [{ featureStrapiId: 346, featureName: "All sites" }],
+  },
+  {
+    parkId: "745",
+    campgroundName: "Purden Lake Campground",
+    items: [{ featureStrapiId: 347, featureName: "All sites" }],
+  },
+  {
+    parkId: "996",
+    campgroundName: "Pyramid Campground",
+    items: [{ featureStrapiId: 348, featureName: "All sites" }],
+  },
+  {
+    parkId: "595",
+    campgroundName: "R.C. Hind Hut",
+    items: [{ featureStrapiId: 352, featureName: "All sites" }],
+  },
+  {
+    parkId: "150",
+    campgroundName: "Radium Loop",
+    items: [{ featureStrapiId: 353, featureName: "All sites" }],
+  },
+  {
+    parkId: "755",
+    campgroundName: "Raft Cove backcountry",
+    items: [{ featureStrapiId: 354, featureName: "All sites" }],
+  },
+  {
+    parkId: "880",
+    campgroundName: "Ralph River Campground",
+    items: [{ featureStrapiId: 355, featureName: "All sites" }],
+  },
+  {
+    parkId: "329",
+    campgroundName: "Rampart Ponds Campground",
+    items: [{ featureStrapiId: 356, featureName: "All sites" }],
+  },
+  {
+    parkId: "760",
+    campgroundName: "Rathtrevor Beach groupsites",
+    items: [{ featureStrapiId: 182, featureName: "All sites" }],
+  },
+  {
+    parkId: "760",
+    campgroundName: "Rathtrevor Beach walk-in sites",
+    items: [{ featureStrapiId: 474, featureName: "All sites" }],
+  },
+  {
+    parkId: "885",
+    campgroundName: "Raven Lake Cabin",
+    items: [{ featureStrapiId: 357, featureName: "All sites" }],
+  },
+  {
+    parkId: "764",
+    campgroundName: "Red Bluff Campground",
+    items: [{ featureStrapiId: 358, featureName: "All sites" }],
+  },
+  {
+    parkId: "329",
+    campgroundName: "Red Heather Campground",
+    items: [{ featureStrapiId: 360, featureName: "All sites" }],
+  },
+  {
+    parkId: "486",
+    campgroundName: "Redfish Campground",
+    items: [{ featureStrapiId: 361, featureName: "All sites" }],
+  },
+  {
+    parkId: "388",
+    campgroundName: "Reinecker Campground",
+    items: [{ featureStrapiId: 362, featureName: "All sites" }],
+  },
+  {
+    parkId: "770",
+    campgroundName: "Roberts Creek Campground",
+    items: [{ featureStrapiId: 364, featureName: "All sites" }],
+  },
+  {
+    parkId: "613",
+    campgroundName: "Robson Meadows Campground",
+    items: [{ featureStrapiId: 365, featureName: "All sites" }],
+  },
+  {
+    parkId: "613",
+    campgroundName: "Robson River Campground",
+    items: [{ featureStrapiId: 367, featureName: "All sites" }],
+  },
+  {
+    parkId: "613",
+    campgroundName: "Robson River Campground electrified sites",
+    items: [{ featureStrapiId: 368, featureName: "All sites" }],
+  },
+  {
+    parkId: "613",
+    campgroundName: "Robson Meadows groupsite",
+    items: [{ featureStrapiId: 366, featureName: "All sites" }],
+  },
+  {
+    parkId: "777",
+    campgroundName: "Rolley Lake Campground",
+    items: [{ featureStrapiId: 371, featureName: "All sites" }],
+  },
+  {
+    parkId: "778",
+    campgroundName: "Roscoe Bay",
+    items: [{ featureStrapiId: 372, featureName: "All sites" }],
+  },
+  {
+    parkId: "781",
+    campgroundName: "Rosebery Campground",
+    items: [{ featureStrapiId: 373, featureName: "All sites" }],
+  },
+  {
+    parkId: "832",
+    campgroundName: "Ross Lake Campground",
+    items: [{ featureStrapiId: 374, featureName: "All sites" }],
+  },
+  {
+    parkId: "832",
+    campgroundName: "Ross Lake groupsite",
+    items: [{ featureStrapiId: 375, featureName: "All sites" }],
+  },
+  {
+    parkId: "786",
+    campgroundName: "Ruckle Campground RV sites",
+    items: [{ featureStrapiId: 379, featureName: "All sites" }],
+  },
+  {
+    parkId: "786",
+    campgroundName: "Ruckle Campground walk-in sites",
+    items: [{ featureStrapiId: 376, featureName: "All sites" }],
+  },
+  {
+    parkId: "786",
+    campgroundName: "Ruckle groupsites",
+    items: [{ featureStrapiId: 183, featureName: "All sites" }],
+  },
+  {
+    parkId: "329",
+    campgroundName: "Russet Lake Campground",
+    items: [{ featureStrapiId: 377, featureName: "All sites" }],
+  },
+  {
+    parkId: "27",
+    campgroundName: "Sandpoint",
+    items: [{ featureStrapiId: 834, featureName: "All sites" }],
+  },
+  {
+    parkId: "548",
+    campgroundName: "Sarah Point",
+    items: [{ featureStrapiId: 383, featureName: "All sites" }],
+  },
+  {
+    parkId: "805",
+    campgroundName: "Schoen Lake Campground",
+    items: [{ featureStrapiId: 384, featureName: "All sites" }],
+  },
+  {
+    parkId: "808",
+    campgroundName: "Seeley Lake Campground",
+    items: [{ featureStrapiId: 385, featureName: "All sites" }],
+  },
+  {
+    parkId: "22",
+    campgroundName: "Shelter Bay Campground",
+    items: [{ featureStrapiId: 386, featureName: "All sites" }],
+  },
+  {
+    parkId: "816",
+    campgroundName: "Shuswap Lake groupsite",
+    items: [{ featureStrapiId: 174, featureName: "All sites" }],
+  },
+  {
+    parkId: "822",
+    campgroundName: "Silver Beach Campground",
+    items: [{ featureStrapiId: 389, featureName: "All sites" }],
+  },
+  {
+    parkId: "823",
+    campgroundName: "Silver Lake Campground",
+    items: [{ featureStrapiId: 390, featureName: "All sites" }],
+  },
+  {
+    parkId: "487",
+    campgroundName: "Silver Spray Cabin",
+    items: [{ featureStrapiId: 391, featureName: "All sites" }],
+  },
+  {
+    parkId: "329",
+    campgroundName: "Singing Creek Campground",
+    items: [{ featureStrapiId: 392, featureName: "All sites" }],
+  },
+  {
+    parkId: "832",
+    campgroundName: "Skagit Valley wilderness",
+    items: [{ featureStrapiId: 415, featureName: "All sites" }],
+  },
+  {
+    parkId: "837",
+    campgroundName: "Skihist Campground",
+    items: [{ featureStrapiId: 416, featureName: "All sites" }],
+  },
+  {
+    parkId: "247",
+    campgroundName: "Skyview RV Campground",
+    items: [{ featureStrapiId: 417, featureName: "All sites" }],
+  },
+  {
+    parkId: "846",
+    campgroundName: "Smelt Bay Campground",
+    items: [{ featureStrapiId: 418, featureName: "All sites" }],
+  },
+  {
+    parkId: "27",
+    campgroundName: "Smithers Landing",
+    items: [{ featureStrapiId: 829, featureName: "All sites" }],
+  },
+  {
+    parkId: "824",
+    campgroundName: "Snowmobile Chalet",
+    items: [{ featureStrapiId: 419, featureName: "All sites" }],
+  },
+  {
+    parkId: "221",
+    campgroundName: "South Curme Island",
+    items: [{ featureStrapiId: 425, featureName: "All sites" }],
+  },
+  {
+    parkId: "859",
+    campgroundName: "Sowchea Bay Campground",
+    items: [{ featureStrapiId: 426, featureName: "All sites" }],
+  },
+  {
+    parkId: "128",
+    campgroundName: "Spirea Island",
+    items: [{ featureStrapiId: 427, featureName: "All sites" }],
+  },
+  {
+    parkId: "870",
+    campgroundName: "Stamp River Campground",
+    items: [{ featureStrapiId: 428, featureName: "All sites" }],
+  },
+  {
+    parkId: "871",
+    campgroundName: "Stawamus Chief drive-in sites",
+    items: [{ featureStrapiId: 102, featureName: "All sites" }],
+  },
+  {
+    parkId: "871",
+    campgroundName: "Stawamus Chief walk-in sites",
+    items: [{ featureStrapiId: 475, featureName: "All sites" }],
+  },
+  {
+    parkId: "873",
+    campgroundName: "Steelhead Campground",
+    items: [{ featureStrapiId: 429, featureName: "All sites" }],
+  },
+  {
+    parkId: "875",
+    campgroundName: "Stemwinder Campground",
+    items: [{ featureStrapiId: 916, featureName: "All sites" }],
+  },
+  {
+    parkId: "192",
+    campgroundName: "Stoltz Pool Campground",
+    items: [{ featureStrapiId: 430, featureName: "All sites" }],
+  },
+  {
+    parkId: "192",
+    campgroundName: "Stoltz Pool groupsite",
+    items: [{ featureStrapiId: 431, featureName: "All sites" }],
+  },
+  {
+    parkId: "625",
+    campgroundName: "Strawberry Flats Campground",
+    items: [{ featureStrapiId: 433, featureName: "All sites" }],
+  },
+  {
+    parkId: "902",
+    campgroundName: "Sturgeon Point groupsite",
+    items: [{ featureStrapiId: 436, featureName: "All sites" }],
+  },
+  {
+    parkId: "889",
+    campgroundName: "Summit Lake Campground",
+    items: [{ featureStrapiId: 438, featureName: "All sites" }],
+  },
+  {
+    parkId: "877",
+    campgroundName: "Summit Lake Campground",
+    items: [{ featureStrapiId: 437, featureName: "All sites" }],
+  },
+  {
+    parkId: "361",
+    campgroundName: "Sunset View Campground sites 1-54",
+    items: [{ featureStrapiId: 439, featureName: "All sites" }],
+  },
+  {
+    parkId: "361",
+    campgroundName: "Sunset View groupsite",
+    items: [{ featureStrapiId: 441, featureName: "All sites" }],
+  },
+  {
+    parkId: "361",
+    campgroundName: "Sunset View walk-in sites",
+    items: [{ featureStrapiId: 442, featureName: "All sites" }],
+  },
+  {
+    parkId: "595",
+    campgroundName: "Surprise Creek Cabin",
+    items: [{ featureStrapiId: 443, featureName: "All sites" }],
+  },
+  {
+    parkId: "457",
+    campgroundName: "Surveyors Campground",
+    items: [{ featureStrapiId: 444, featureName: "All sites" }],
+  },
+  {
+    parkId: "900",
+    campgroundName: "Swan Lake Campground",
+    items: [{ featureStrapiId: 445, featureName: "All sites" }],
+  },
+  {
+    parkId: "915",
+    campgroundName: "Taylor Arm groupsites G1-G3",
+    items: [{ featureStrapiId: 184, featureName: "All sites" }],
+  },
+  {
+    parkId: "541",
+    campgroundName: "Taylor Creek Loop sites 85-114",
+    items: [{ featureStrapiId: 448, featureName: "All sites" }],
+  },
+  {
+    parkId: "329",
+    campgroundName: "Taylor Meadows Campground",
+    items: [{ featureStrapiId: 449, featureName: "All sites" }],
+  },
+  {
+    parkId: "221",
+    campgroundName: "Tenedos Bay",
+    items: [{ featureStrapiId: 450, featureName: "All sites" }],
+  },
+  {
+    parkId: "933",
+    campgroundName: "Top of the World backcountry",
+    items: [{ featureStrapiId: 452, featureName: "All sites" }],
+  },
+  {
+    parkId: "918",
+    campgroundName: "Touring Campground",
+    items: [{ featureStrapiId: 453, featureName: "All sites" }],
+  },
+  {
+    parkId: "541",
+    campgroundName: "Trinity Loop sites 37-84",
+    items: [{ featureStrapiId: 455, featureName: "All sites" }],
+  },
+  {
+    parkId: "996",
+    campgroundName: "Trophy Mountain backcountry",
+    items: [{ featureStrapiId: 456, featureName: "All sites" }],
+  },
+  {
+    parkId: "945",
+    campgroundName: "Ts'il?os backcountry",
+    items: [{ featureStrapiId: 457, featureName: "All sites" }],
+  },
+  {
+    parkId: "952",
+    campgroundName: "Tudyah Lake Campground",
+    items: [{ featureStrapiId: 458, featureName: "All sites" }],
+  },
+  {
+    parkId: "953",
+    campgroundName: "Tunkwa Campground",
+    items: [{ featureStrapiId: 459, featureName: "All sites" }],
+  },
+  {
+    parkId: "957",
+    campgroundName: "Tweedsmuir backcountry",
+    items: [{ featureStrapiId: 460, featureName: "All sites" }],
+  },
+  {
+    parkId: "958",
+    campgroundName: "Tyhee Lake Campground",
+    items: [{ featureStrapiId: 461, featureName: "All sites" }],
+  },
+  {
+    parkId: "958",
+    campgroundName: "Tyhee Lake groupsite",
+    items: [{ featureStrapiId: 175, featureName: "All sites" }],
+  },
+  {
+    parkId: "978",
+    campgroundName: "Vaseux Lake Campground",
+    items: [{ featureStrapiId: 464, featureName: "All sites" }],
+  },
+  {
+    parkId: "16",
+    campgroundName: "Vetter Creek Campground",
+    items: [{ featureStrapiId: 466, featureName: "All sites" }],
+  },
+  {
+    parkId: "987",
+    campgroundName: "Wallace Island backcountry",
+    items: [{ featureStrapiId: 477, featureName: "All sites" }],
+  },
+  {
+    parkId: "128",
+    campgroundName: "War Lake Campground",
+    items: [{ featureStrapiId: 479, featureName: "All sites" }],
+  },
+  {
+    parkId: "993",
+    campgroundName: "Wasa Lake Campground",
+    items: [{ featureStrapiId: 480, featureName: "All sites" }],
+  },
+  {
+    parkId: "329",
+    campgroundName: "Wedgemount Lake Campground",
+    items: [{ featureStrapiId: 482, featureName: "All sites" }],
+  },
+  {
+    parkId: "221",
+    campgroundName: "West Curme Island",
+    items: [{ featureStrapiId: 483, featureName: "All sites" }],
+  },
+  {
+    parkId: "1007",
+    campgroundName: "Whiskers Point Campground",
+    items: [{ featureStrapiId: 486, featureName: "All sites" }],
+  },
+  {
+    parkId: "1009",
+    campgroundName: "White Lake Campground",
+    items: [{ featureStrapiId: 487, featureName: "All sites" }],
+  },
+  {
+    parkId: "1013",
+    campgroundName: "White River Campground",
+    items: [{ featureStrapiId: 488, featureName: "All sites" }],
+  },
+  {
+    parkId: "832",
+    campgroundName: "Whitworth Horse Camp",
+    items: [{ featureStrapiId: 491, featureName: "All sites" }],
+  },
+  {
+    parkId: "717",
+    campgroundName: "Widgeon Creek Campground",
+    items: [{ featureStrapiId: 751, featureName: "All sites" }],
+  },
+  {
+    parkId: "329",
+    campgroundName: "Wilderness Camping Area",
+    items: [{ featureStrapiId: 492, featureName: "All sites" }],
+  },
+  {
+    parkId: "487",
+    campgroundName: "Woodbury Cabin",
+    items: [{ featureStrapiId: 494, featureName: "All sites" }],
+  },
+  {
+    parkId: "347",
+    campgroundName: "Woodlands groupsite",
+    items: [{ featureStrapiId: 613, featureName: "All sites" }],
+  },
+  {
+    parkId: "1029",
+    campgroundName: "Yahk Campground",
+    items: [{ featureStrapiId: 495, featureName: "All sites" }],
+  },
+  {
+    parkId: "1036",
+    campgroundName: "sx\u030c\u02b7\u0259x\u030c\u02b7nitk\u02b7 Campground",
+    items: [{ featureStrapiId: 446, featureName: "All sites" }],
+  },
+  {
+    parkId: "1035",
+    campgroundName: "s\u1e83i\u1e83s Campground",
+    items: [{ featureStrapiId: 380, featureName: "All sites" }],
+  },
+  {
+    parkId: "1035",
+    campgroundName: "s\u1e83i\u1e83s overflow camping",
+    items: [{ featureStrapiId: 319, featureName: "All sites" }],
+  },
+];

--- a/backend/strapi-sync/create-single-item-campgrounds.js
+++ b/backend/strapi-sync/create-single-item-campgrounds.js
@@ -1840,7 +1840,7 @@ async function createCampground(item) {
 }
 
 async function createSingleItemsCampgrounds(items) {
-  await Promise.all(items.map(async (item) => await createCampground(item)));
+  await Promise.all(items.map(async (item) => createCampground(item)));
 }
 
 createSingleItemsCampgrounds(campgrounds);

--- a/backend/strapi-sync/create-single-item-campgrounds.js
+++ b/backend/strapi-sync/create-single-item-campgrounds.js
@@ -1,4 +1,4 @@
-import { Campground, Feature } from "../models/index.js";
+import { Campground, Feature, Park } from "../models/index.js";
 
 import { getItemByAttributes, createModel } from "./utils.js";
 
@@ -1817,10 +1817,14 @@ const campgrounds = [
 ];
 
 async function createCampground(item) {
+  const park = await getItemByAttributes(Park, {
+    strapiId: parseInt(item.parkId, 10),
+  });
+
   // create campground with FK to Park
   const data = {
     name: item.campgroundName,
-    parkId: parseInt(item.parkId, 10),
+    parkId: park.id,
   };
 
   const campground = await createModel(Campground, data);
@@ -1836,7 +1840,7 @@ async function createCampground(item) {
 }
 
 async function createSingleItemsCampgrounds(items) {
-  await Promise.all(items.map((item) => createCampground(item)));
+  await Promise.all(items.map(async (item) => await createCampground(item)));
 }
 
 createSingleItemsCampgrounds(campgrounds);

--- a/backend/strapi-sync/sync.js
+++ b/backend/strapi-sync/sync.js
@@ -258,7 +258,13 @@ export async function createOrUpdateFeature(item) {
   let dbItem = await getItemByAttributes(Feature, { strapiId: item.id });
 
   if (dbItem) {
-    dbItem.name = item.attributes.parkSubArea;
+    // if dbItems has campgroundId, don't update the name
+    // there is a script to create campgrounds and assign features to them
+    // this script will rename the feature to fit within the campground
+    if (!dbItem.campgroundId) {
+      dbItem.name = item.attributes.parkSubArea;
+    }
+
     const featureType = await getItemByAttributes(FeatureType, {
       strapiId: item.attributes.parkSubAreaType.data.id,
     });

--- a/backend/strapi-sync/sync.js
+++ b/backend/strapi-sync/sync.js
@@ -151,6 +151,8 @@ export async function createOrUpdatePark(item) {
 
   if (dbItem) {
     dbItem.name = item.attributes.protectedAreaName;
+
+    await dbItem.save();
   } else {
     const dateable = await createModel(Dateable);
     const data = {
@@ -191,6 +193,8 @@ export async function createOrUpdateFeatureType(strapiData, item) {
   if (dbItem) {
     dbItem.name = item.attributes.subAreaType;
     dbItem.icon = icon;
+
+    await dbItem.save();
   } else {
     const data = {
       name: item.attributes.subAreaType,
@@ -272,6 +276,8 @@ export async function createOrUpdateFeature(item) {
     dbItem.featureTypeId = featureType.id;
     dbItem.hasReservations = item.attributes.hasReservations;
     dbItem.active = item.attributes.isActive;
+
+    await dbItem.save();
   } else {
     const dateable = await createModel(Dateable);
     const park = await getItemByAttributes(Park, {


### PR DESCRIPTION
### Jira Ticket

CMS-583

### Description
Please refer to the ticket to see the logic behind the grouping. 
There are 2 scripts that create campgrounds and assign features to them.
1. For campgrounds that only have one feature, the campground will keep the name of the single feature and the feature will be renamed to "All Sites". This can be optionally displayed on the FE. 
2. For campgrounds that have multiple features, the campground will have it's own general name, and features will have their name that only reflects their specific part of the campground (e.g. "Alice Lake Campground Sites 1-20" -- > "Sites 1-20").
