### PR TITLE
CMS-348: Add CSV export feature

### DIFF
--- a/backend/eslint.config.mjs
+++ b/backend/eslint.config.mjs
@@ -30,4 +30,26 @@ export default [
       "new-cap": "off",
     },
   },
+
+  // Limit linting in seeders/migrations directories
+  {
+    files: ["migrations/**/*.js", "seeders/**/*.js"],
+
+    languageOptions: {
+      globals: { ...globals.node },
+
+      parserOptions: {
+        sourceType: "script", // Auto-generated files are CJS modules
+      },
+    },
+
+    rules: {
+      "no-unused-vars": "off", // Ignore parameters added by Sequelize
+    },
+  },
+
+  // Ignore Admin JS bundle directory
+  {
+    ignores: [".adminjs/"],
+  },
 ];

--- a/backend/index.js
+++ b/backend/index.js
@@ -54,8 +54,14 @@ app.use("/", homeRoutes); // example stuff for testing
 
 // Routes with JWT check middleware
 app.use("/nested-path-example/", checkJwt, helloRoute); // example stuff for testing
-app.use("/api/", parkRoutes);
-app.use("/api/", seasonRoutes);
+
+// API routes
+const apiRouter = express.Router();
+
+apiRouter.use("/parks", parkRoutes);
+apiRouter.use("/seasons", seasonRoutes);
+
+app.use("/api", apiRouter);
 
 // AdminJS routes
 app.use(admin.options.rootPath, adminRouter);

--- a/backend/index.js
+++ b/backend/index.js
@@ -11,6 +11,7 @@ import homeRoutes from "./routes/home.js";
 import helloRoute from "./routes/nested-path-example/hello.js";
 import parkRoutes from "./routes/api/parks.js";
 import seasonRoutes from "./routes/api/seasons.js";
+import exportRoutes from "./routes/api/export.js";
 
 if (!process.env.POSTGRES_SERVER || !process.env.ADMIN_PASSWORD) {
   throw new Error("Required environment variables are not set");
@@ -60,6 +61,7 @@ const apiRouter = express.Router();
 
 apiRouter.use("/parks", parkRoutes);
 apiRouter.use("/seasons", seasonRoutes);
+apiRouter.use("/export", exportRoutes);
 
 app.use("/api", apiRouter);
 

--- a/backend/migrations/20241218185747-add-mgmt-area-jsonb.js
+++ b/backend/migrations/20241218185747-add-mgmt-area-jsonb.js
@@ -1,0 +1,14 @@
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    // Add managementAreaIds to Parks table
+    await queryInterface.addColumn("Parks", "managementAreas", {
+      type: Sequelize.JSONB,
+      allowNull: true,
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.removeColumn("Parks", "managementAreas");
+  },
+};

--- a/backend/models/park.js
+++ b/backend/models/park.js
@@ -32,6 +32,9 @@ export default (sequelize) => {
       orcs: DataTypes.STRING,
       dateableId: DataTypes.INTEGER,
       strapiId: DataTypes.INTEGER,
+      // store raw json for Management Area and Section names,
+      // since they're only needed for display in the CSV export
+      managementAreas: DataTypes.JSONB,
     },
     {
       sequelize,

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -17,6 +17,7 @@
         "compression": "^1.7.4",
         "connect-pg-simple": "^10.0.0",
         "cors": "^2.8.5",
+        "date-fns-tz": "^3.2.0",
         "express": "^4.19.2",
         "express-async-handler": "^1.2.0",
         "express-formidable": "^1.2.0",
@@ -92,6 +93,22 @@
       "peerDependencies": {
         "react": "^18.1.0",
         "react-dom": "^18.1.0"
+      }
+    },
+    "node_modules/@adminjs/design-system/node_modules/date-fns": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0"
+      },
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
       }
     },
     "node_modules/@adminjs/express": {
@@ -5614,19 +5631,23 @@
       }
     },
     "node_modules/date-fns": {
-      "version": "2.30.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
-      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
       "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.21.0"
-      },
-      "engines": {
-        "node": ">=0.11"
-      },
+      "peer": true,
       "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/date-fns"
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
+    "node_modules/date-fns-tz": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-3.2.0.tgz",
+      "integrity": "sha512-sg8HqoTEulcbbbVXeg84u5UnlsQa8GS5QXMqjjYIhS4abEVVKIUwe0/l/UhrZdKaL/W5eWZNlbTeEIiOXTcsBQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "date-fns": "^3.0.0 || ^4.0.0"
       }
     },
     "node_modules/debug": {
@@ -9527,6 +9548,22 @@
       "peerDependencies": {
         "react": "^16.9.0 || ^17 || ^18",
         "react-dom": "^16.9.0 || ^17 || ^18"
+      }
+    },
+    "node_modules/react-datepicker/node_modules/date-fns": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0"
+      },
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
       }
     },
     "node_modules/react-dom": {

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@adminjs/express": "^6.1.0",
         "@adminjs/sequelize": "^4.1.1",
+        "@fast-csv/format": "^5.0.2",
         "adminjs": "^7.8.13",
         "axios": "^1.7.8",
         "compression": "^1.7.4",
@@ -2872,6 +2873,19 @@
       "license": "Apache-2.0",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@fast-csv/format": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@fast-csv/format/-/format-5.0.2.tgz",
+      "integrity": "sha512-fRYcWvI8vs0Zxa/8fXd/QlmQYWWkJqKZPAXM+vksnplb3owQFKTPPh9JqOtD0L3flQw/AZjjXdPkD7Kp/uHm8g==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isequal": "^4.5.0",
+        "lodash.isfunction": "^3.0.9",
+        "lodash.isnil": "^4.0.0"
       }
     },
     "node_modules/@floating-ui/core": {
@@ -7959,6 +7973,12 @@
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
       "license": "MIT"
     },
+    "node_modules/lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
+      "license": "MIT"
+    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -7971,10 +7991,28 @@
       "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
       "license": "MIT"
     },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isfunction": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",
+      "integrity": "sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw==",
+      "license": "MIT"
+    },
     "node_modules/lodash.isinteger": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
       "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnil": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.isnil/-/lodash.isnil-4.0.0.tgz",
+      "integrity": "sha512-up2Mzq3545mwVnMhTDMdfoG1OurpA/s5t88JmQX809eH3C8491iu2sfKhTfhQtKY78oPNhiaHJUpT/dUDAAtng==",
       "license": "MIT"
     },
     "node_modules/lodash.isnumber": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -35,6 +35,7 @@
     "compression": "^1.7.4",
     "connect-pg-simple": "^10.0.0",
     "cors": "^2.8.5",
+    "date-fns-tz": "^3.2.0",
     "express": "^4.19.2",
     "express-async-handler": "^1.2.0",
     "express-formidable": "^1.2.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "@adminjs/express": "^6.1.0",
     "@adminjs/sequelize": "^4.1.1",
+    "@fast-csv/format": "^5.0.2",
     "adminjs": "^7.8.13",
     "axios": "^1.7.8",
     "compression": "^1.7.4",

--- a/backend/routes/api/export.js
+++ b/backend/routes/api/export.js
@@ -1,0 +1,157 @@
+import { Router } from "express";
+import { Op, Sequelize } from "sequelize";
+import asyncHandler from "express-async-handler";
+import { writeToString } from "@fast-csv/format";
+import _ from "lodash";
+
+import {
+  Park,
+  Season,
+  FeatureType,
+  Feature,
+  DateType,
+  DateRange,
+  Dateable,
+} from "../../models/index.js";
+
+const router = Router();
+
+// Get options for the export form
+router.get(
+  "/options",
+  asyncHandler(async (req, res) => {
+    const featureTypes = FeatureType.findAll({
+      attributes: ["id", "name"],
+    });
+
+    const years = (
+      await Season.findAll({
+        attributes: [
+          [
+            Sequelize.fn("DISTINCT", Sequelize.col("operatingYear")),
+            "operatingYear",
+          ],
+        ],
+
+        order: [[Sequelize.col("operatingYear"), "ASC"]],
+      })
+    ).map((year) => year.operatingYear);
+
+    res.json({
+      years,
+      featureTypes: await featureTypes,
+    });
+  }),
+);
+
+// Export to csv
+router.get(
+  "/csv",
+  asyncHandler(async (req, res) => {
+    const exportType = req.query.type;
+    // Cast query param values as numbers
+    const operatingYear = +req.query.year;
+    const featureTypeIds = req.query.features?.map((id) => +id) ?? [];
+
+    // Update WHERE clause based on query parameters
+    const featuresWhere = {
+      active: true,
+    };
+
+    if (exportType === "bcp-only") {
+      featuresWhere.hasReservations = true;
+    }
+
+    const featuresData = await Feature.findAll({
+      where: featuresWhere,
+      attributes: ["id", "name", "hasReservations"],
+      include: [
+        {
+          model: Park,
+          as: "park",
+          attributes: ["id", "name", "orcs"],
+        },
+        {
+          model: FeatureType,
+          as: "featureType",
+          attributes: ["id", "name"],
+          where: {
+            id: {
+              [Op.in]: featureTypeIds,
+            },
+          },
+        },
+        {
+          model: Dateable,
+          as: "dateable",
+          attributes: ["id"],
+          include: [
+            {
+              model: DateRange,
+              as: "dateRanges",
+              attributes: ["id", "startDate", "endDate"],
+              include: [
+                {
+                  model: Season,
+                  as: "season",
+                  attributes: ["id", "operatingYear"],
+                  where: {
+                    operatingYear,
+                  },
+                },
+                {
+                  model: DateType,
+                  as: "dateType",
+                  attributes: ["id", "name"],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    // Flatten data for CSV row format
+    const flattened = featuresData.flatMap((feature) =>
+      feature.dateable.dateRanges.map((dateRange) => ({
+        // featureId: feature.id,
+        Park: feature.park.name,
+        // parkId: feature.park.id,
+        // parkOrcs: feature.park.orcs,
+        Feature: feature.name,
+        "Feature Type": feature.featureType.name,
+        // featureTypeId: feature.featureType.id,
+        "Date Type": dateRange.dateType.name,
+        // dateTypeId: dateRange.dateType.id,
+        "Start Date": dateRange.startDate?.toISOString(),
+        "End Date": dateRange.endDate?.toISOString(),
+        Reservations: feature.hasReservations,
+      })),
+    );
+
+    // Sort results
+    const sorted = _.sortBy(flattened, [
+      "Park",
+      "Feature",
+      "Feature Type",
+      "Date Type",
+      "Start Date",
+    ]);
+
+    // Convert to CSV string
+    const csv = await writeToString(sorted, { headers: true });
+
+    // Build filename
+    const displayType =
+      exportType === "bcp-only" ? "BCP reservations only" : "All";
+    const filename = `${operatingYear} season - ${displayType} dates.csv`;
+
+    // Send CSV string as response
+    res.setHeader("Content-Type", "text/csv");
+    res.setHeader("Content-Disposition", `attachment; filename="${filename}"`);
+    res.setHeader("Content-Length", Buffer.byteLength(csv));
+    res.send(csv);
+  }),
+);
+
+export default router;

--- a/backend/routes/api/export.js
+++ b/backend/routes/api/export.js
@@ -79,7 +79,7 @@ router.get(
         {
           model: Park,
           as: "park",
-          attributes: ["id", "name", "orcs"],
+          attributes: ["id", "name", "orcs", "managementAreas"],
         },
         {
           model: FeatureType,
@@ -150,8 +150,13 @@ router.get(
     // Flatten data for CSV row format
     const flattened = featuresData.flatMap((feature) =>
       feature.dateable.dateRanges.map((dateRange) => ({
-        Section: "@TODO: map Park to section values from Strapi",
-        "Management Area": "@TODO: map Park to Mgmt Area values from Strapi",
+        // get park management area and section names from jsonb field
+        Section: feature.park.managementAreas
+          .map((m) => m.section.name)
+          .join(", "),
+        "Management Area": feature.park.managementAreas
+          .map((m) => m.mgmtArea.name)
+          .join(", "),
         ORCS: feature.park.orcs,
         "Park Name": feature.park.name,
         "Sub-Area": feature.name,

--- a/backend/routes/api/export.js
+++ b/backend/routes/api/export.js
@@ -3,6 +3,7 @@ import { Op, Sequelize } from "sequelize";
 import asyncHandler from "express-async-handler";
 import { writeToString } from "@fast-csv/format";
 import _ from "lodash";
+import { format } from "date-fns-tz";
 
 import {
   Park,
@@ -46,12 +47,22 @@ router.get(
   }),
 );
 
+// Returns a string with the note, author and email address
 function formatChangeLog(changeLog) {
   const user = changeLog.user;
   const notes = changeLog.notes;
   const formatted = `${user.name} (${user.email}): ${notes}`;
 
   return formatted;
+}
+
+/**
+ * Formats a UTC date string as "Weekday, Month Day, Year"
+ * @param {string} ISODate UTC date in ISO format
+ * @returns {string} - Formatted date string
+ */
+function formatDate(ISODate) {
+  return format(new Date(ISODate), "EEEE, MMMM d, yyyy", { timeZone: "UTC" });
 }
 
 // Export to csv
@@ -164,8 +175,8 @@ router.get(
         "Sub-Area Type (Park feature)": feature.featureType.name,
         "Operating Year": dateRange.season.operatingYear,
         "Type of date": dateRange.dateType.name,
-        "Start date": dateRange.startDate?.toISOString(),
-        "End date": dateRange.endDate?.toISOString(),
+        "Start date": formatDate(dateRange.startDate),
+        "End date": formatDate(dateRange.endDate),
         Status: dateRange.season.status,
         "Ready to publish": dateRange.season.readyToPublish,
         Notes: dateRange.season.changeLogs.map(formatChangeLog).join("\n"),

--- a/backend/routes/api/export.js
+++ b/backend/routes/api/export.js
@@ -154,8 +154,6 @@ router.get(
         "Management Area": "@TODO: map Park to Mgmt Area values from Strapi",
         ORCS: feature.park.orcs,
         "Park Name": feature.park.name,
-        "psa.id (Park sub area ID)": feature.strapiId, // for "IS" only
-        "psad.id  (Park sub area date ID)": "@TODO: find this value in Strapi", // for "IS" only
         "Sub-Area": feature.name,
         "Sub-Area Type (Park feature)": feature.featureType.name,
         "Operating Year": dateRange.season.operatingYear,

--- a/backend/routes/api/export.js
+++ b/backend/routes/api/export.js
@@ -119,12 +119,13 @@ router.get(
                       model: SeasonChangeLog,
                       as: "changeLogs",
                       attributes: ["id", "notes", "createdAt"],
+                      // Filter out empty notes
                       where: {
-                        // Ignore empty notes
                         notes: {
                           [Op.ne]: "",
                         },
                       },
+                      required: false,
                       include: [
                         {
                           model: User,

--- a/backend/routes/api/parks.js
+++ b/backend/routes/api/parks.js
@@ -46,7 +46,7 @@ function getParkStatus(seasons) {
 }
 
 router.get(
-  "/parks/",
+  "/",
   asyncHandler(async (req, res) => {
     const parksWithBundlesAndSeasons = await Park.findAll({
       attributes: ["id", "orcs", "name"],
@@ -101,7 +101,7 @@ router.get(
 );
 
 router.get(
-  "/parks/:orcs",
+  "/:orcs",
   asyncHandler(async (req, res) => {
     const { orcs } = req.params;
 

--- a/backend/routes/api/seasons.js
+++ b/backend/routes/api/seasons.js
@@ -351,6 +351,4 @@ router.post(
 
 // publish
 
-// export to csv
-
 export default router;

--- a/backend/routes/api/seasons.js
+++ b/backend/routes/api/seasons.js
@@ -34,7 +34,7 @@ const router = Router();
 // }
 
 router.get(
-  "/seasons/:seasonId",
+  "/:seasonId",
   asyncHandler(async (req, res) => {
     const { seasonId } = req.params;
 
@@ -204,7 +204,7 @@ router.get(
 
 // save draft (role determined by user)
 router.post(
-  "/seasons/:seasonId/save/",
+  "/:seasonId/save/",
   asyncHandler(async (req, res) => {
     const { seasonId } = req.params;
     const { notes, dates, readyToPublish } = req.body;
@@ -303,7 +303,7 @@ router.post(
 
 // approve
 router.post(
-  "/seasons/:seasonId/approve/",
+  "/:seasonId/approve/",
   asyncHandler(async (req, res) => {
     const { seasonId } = req.params;
     const { notes, readyToPublish } = req.body;

--- a/frontend/src/components/FlashMessage.scss
+++ b/frontend/src/components/FlashMessage.scss
@@ -4,7 +4,7 @@
   top: var(--layout-margin-medium);
   right: var(--layout-margin-medium);
   z-index: 1000;
-  max-width: 30vw;
+  max-width: 75vw;
 
   display: flex;
   align-items: center;
@@ -14,6 +14,10 @@
   border-radius: var(--layout-border-radius-large);
   color: var(--typography-color-primary-invert);
   animation: slideIn 0.3s ease-out;
+
+  @include from-md {
+    max-width: 40vw;
+  }
 
   &.success {
     background-color: var(--support-border-color-success);

--- a/frontend/src/router/pages/ExportPage.jsx
+++ b/frontend/src/router/pages/ExportPage.jsx
@@ -1,5 +1,10 @@
+import { useEffect, useState } from "react";
+import classNames from "classnames";
 import { faCalendarCheck } from "@fa-kit/icons/classic/regular";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { useApiGet } from "@/hooks/useApi";
+import LoadingBar from "@/components/LoadingBar";
+import getEnv from "@/config/getEnv";
 import { useFlashMessage } from "@/hooks/useFlashMessage";
 import FlashMessage from "@/components/FlashMessage";
 
@@ -12,12 +17,69 @@ function ExportPage() {
     isFlashOpen,
   } = useFlashMessage();
 
-  function exportDates() {
-    openFlashMessage(
-      "Export complete",
-      "Check your Downloads for the Excel document.",
-    );
+  const { data: options, loading, error } = useApiGet("/export/options");
+  const [exportYear, setExportYear] = useState();
+  const [exportFeatures, setExportFeatures] = useState([]);
+
+  // Set the initial values when options are loaded
+  useEffect(() => {
+    // Initially select the latest year from the data
+    if (options?.years) {
+      setExportYear(options.years.at(-1));
+    }
+
+    // Initially select all feature types
+    if (options?.featureTypes?.length) {
+      setExportFeatures(options.featureTypes.map((feature) => feature.id));
+    }
+  }, [options]);
+
+  function onExportFeaturesChange(event) {
+    const { checked } = event.target;
+    const value = +event.target.value;
+
+    setExportFeatures((prevFeatures) => {
+      if (checked) {
+        return [...prevFeatures, value];
+      }
+
+      return prevFeatures.filter((feature) => feature !== value);
+    });
   }
+
+  const exportTypes = [
+    { value: "all", label: "All dates" },
+    { value: "bcp-only", label: "BCP reservations only" },
+  ];
+  const [exportType, setExportType] = useState("all");
+
+  function getExportUrl() {
+    const url = new URL(getEnv("VITE_API_BASE_URL"));
+    const params = new URLSearchParams();
+
+    url.pathname += "/export/csv";
+
+    params.append("type", exportType);
+    params.append("year", exportYear);
+    exportFeatures.forEach((featureId) => {
+      params.append("features[]", featureId);
+    });
+
+    url.search = params.toString();
+
+    return url;
+  }
+
+  if (error) {
+    return <p className="px-3">Error loading options data: {error.message}</p>;
+  }
+
+  if (loading)
+    return (
+      <div className="p-3 pt-0">
+        <LoadingBar />
+      </div>
+    );
 
   return (
     <div className="page export">
@@ -33,150 +95,93 @@ function ExportPage() {
         <div className="col-md-6 col-lg-5">
           <fieldset className="mb-3">
             <legend className="append-required">Export type</legend>
-
-            <div className="form-check">
-              <input
-                className="form-check-input"
-                type="radio"
-                name="type"
-                id="type-all-dates"
-                value="all-dates"
-              />
-              <label className="form-check-label" htmlFor="type-all-dates">
-                All dates
-              </label>
-            </div>
-
-            <div className="form-check">
-              <input
-                className="form-check-input"
-                type="radio"
-                name="type"
-                id="type-bcp-only"
-                value="bcp-only"
-              />
-              <label className="form-check-label" htmlFor="type-bcp-only">
-                BCP reservations only
-              </label>
-            </div>
+            {exportTypes.map((option) => (
+              <div className="form-check" key={option.value}>
+                <input
+                  className="form-check-input"
+                  type="radio"
+                  name="exportType"
+                  id={`type-${option.value}`}
+                  value={option.value}
+                  checked={exportType === option.value}
+                  onChange={(e) => setExportType(e.target.value)}
+                />
+                <label
+                  className="form-check-label"
+                  htmlFor={`type-${option.value}`}
+                >
+                  {option.label}
+                </label>
+              </div>
+            ))}
           </fieldset>
-
           <fieldset className="mb-3">
             <legend className="append-required">Year</legend>
-
-            <div className="input-with-append">
-              <select id="year" className="form-select"></select>
+            <div className="input-with-append col-8 col-sm-6">
+              <select
+                id="year"
+                className="form-select"
+                value={exportYear}
+                onChange={(ev) => setExportYear(+ev.target.value)}
+              >
+                {options.years.map((year) => (
+                  <option key={year} value={year}>
+                    {year}
+                  </option>
+                ))}
+              </select>
               <FontAwesomeIcon
                 className="append-content"
                 icon={faCalendarCheck}
               />
             </div>
           </fieldset>
-
           <fieldset className="mb-3">
             <legend className="append-required">Park features</legend>
-
-            <div className="form-check">
-              <input
-                className="form-check-input"
-                type="checkbox"
-                name="features"
-                id="features-backcountry-camping"
-                value="Backcountry camping"
-              />
-              <label
-                className="form-check-label"
-                htmlFor="features-backcountry-camping"
-              >
-                Backcountry camping
-              </label>
-            </div>
-
-            <div className="form-check">
-              <input
-                className="form-check-input"
-                type="checkbox"
-                name="features"
-                id="features-cabins-huts"
-                value="Cabins and huts"
-              />
-              <label
-                className="form-check-label"
-                htmlFor="features-cabins-huts"
-              >
-                Cabins and huts
-              </label>
-            </div>
-
-            <div className="form-check">
-              <input
-                className="form-check-input"
-                type="checkbox"
-                name="features"
-                id="features-frontcountry-camping"
-                value="Frontcountry camping"
-              />
-              <label
-                className="form-check-label"
-                htmlFor="features-frontcountry-camping"
-              >
-                Frontcountry camping
-              </label>
-            </div>
-
-            <div className="form-check">
-              <input
-                className="form-check-input"
-                type="checkbox"
-                name="features"
-                id="features-group-camping"
-                value="Group camping"
-              />
-              <label
-                className="form-check-label"
-                htmlFor="features-group-camping"
-              >
-                Group camping
-              </label>
-            </div>
-
-            <div className="form-check">
-              <input
-                className="form-check-input"
-                type="checkbox"
-                name="features"
-                id="features-picnic-areas"
-                value="Picnic areas"
-              />
-              <label
-                className="form-check-label"
-                htmlFor="features-picnic-areas"
-              >
-                Picnic areas
-              </label>
-            </div>
-
-            <div className="form-check">
-              <input
-                className="form-check-input"
-                type="checkbox"
-                name="features"
-                id="features-walk-in-camping"
-                value="Walk-in camping"
-              />
-              <label
-                className="form-check-label"
-                htmlFor="features-walk-in-camping"
-              >
-                Walk-in camping
-              </label>
-            </div>
+            {options.featureTypes.map((feature) => (
+              <div className="form-check" key={feature.id}>
+                <input
+                  className="form-check-input"
+                  type="checkbox"
+                  name="features"
+                  id={`features-${feature.id}`}
+                  value={feature.id}
+                  checked={exportFeatures.includes(feature.id)}
+                  onChange={onExportFeaturesChange}
+                />
+                <label
+                  className="form-check-label"
+                  htmlFor={`features-${feature.id}`}
+                >
+                  {feature.name}
+                </label>
+              </div>
+            ))}
           </fieldset>
-
           <fieldset>
-            <button className="btn btn-primary" onClick={exportDates}>
+            <a
+              href={getExportUrl()}
+              target="_blank"
+              rel="noopener"
+              className={classNames({
+                btn: true,
+                "btn-primary": true,
+                disabled: exportFeatures.length === 0,
+              })}
+              onClick={(ev) => {
+                if (exportFeatures.length === 0) {
+                  ev.preventDefault();
+                } else {
+                  // Show success flash message
+                  openFlashMessage(
+                    "Export complete",
+                    "Check your Downloads for the Excel document.",
+                  );
+                }
+              }}
+            >
               Export report
-            </button>
+            </a>
           </fieldset>
         </div>
       </div>

--- a/frontend/src/styles/breakpoints.scss
+++ b/frontend/src/styles/breakpoints.scss
@@ -38,14 +38,14 @@
   .my-component {
     display: block;
 
-    @include from-small {
+    @include from-sm {
       display: flex;
       background: transparent;
     }
   }
 
   // Style rules for viewports >= 768px wide
-  @include from-medium {
+  @include from-md {
     .container {
       max-width: 100%;
     }


### PR DESCRIPTION
### Jira Ticket

CMS-348

### Description
<!-- What did you change, and why? -->

The CSVs require some info we weren't pulling from strapi, and we don't need that info anywhere else so I didn't want to two new FK tables and a junction table just for that. I tried a few approaches and this was the cleanest/simplest one:
- Added a jsonb field to the Park model called "managementAreas" which stores an array like this:

```json
[
  {
    "mgmtArea": {
      "strapiId": 123,
      "name": "North Okanagan"
    },
    "section": {
      "strapiId": 57,
      "name": "Okanagan"
    }
  }
]
```

The details get fetched in the normal syncData script, and the CSV export just prints out the names from that array.

In particular, I'd like someone to look at the Sequelize query in the Export endpoint, because was guessing at some of the sub-query/join stuff. I've been testing it since I imported the real Strapi data and it looks okay, but let me know if you notice anything strange.

Other stuff:
- Updated the eslint config to stop showing errors in the seeders/migrations/.adminJs folders with auto-generated files.
- Refactored the Express routes slightly so they're all sub-routes of /api/ and we don't need to add /api/ and the base path to every new route we define.
- Tweaked the fluid width of the flash message so it looks better with the long message on the Export page