### PR TITLE
CMS-590: Use react-bootstrap tooltip, update content

### DIFF
--- a/backend/strapi-sync/sync.js
+++ b/backend/strapi-sync/sync.js
@@ -230,19 +230,20 @@ export async function createDateTypes() {
       name: "Operation",
       startDateLabel: "Service Start Date",
       endDateLabel: "Service End Date",
-      description: "Dates of Operation",
+      description:
+        "All nights where the area is open by the operator. Fees and service levels can vary depending on the time of year.",
     },
     {
       name: "Reservation",
       startDateLabel: "Reservation Start Date",
       endDateLabel: "Reservation End Date",
-      description: "Dates for Reservations",
+      description: "Dates where reservations are available.",
     },
     {
       name: "Off Season",
       startDateLabel: "Winter start date",
       endDateLabel: "Winter end date",
-      description: "Winter dates",
+      description: "Reduced services and reduced legislated winter fees.",
     },
   ];
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -22,7 +22,7 @@
         "oidc-client-ts": "^3.0.1",
         "prop-types": "^15.8.1",
         "react": "^18.3.1",
-        "react-bootstrap": "^2.10.5",
+        "react-bootstrap": "^2.10.7",
         "react-datepicker": "^7.5.0",
         "react-dom": "^18.3.1",
         "react-oidc-context": "^3.1.0",
@@ -745,21 +745,6 @@
         "@floating-ui/utils": "^0.2.8"
       }
     },
-    "node_modules/@floating-ui/react": {
-      "version": "0.26.27",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.26.27.tgz",
-      "integrity": "sha512-jLP72x0Kr2CgY6eTYi/ra3VA9LOkTo4C+DUTrbFgFOExKy3omYVmwMjNKqxAHdsnyLS96BIDLcO2SlnsNf8KUQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/react-dom": "^2.1.2",
-        "@floating-ui/utils": "^0.2.8",
-        "tabbable": "^6.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
-    },
     "node_modules/@floating-ui/react-dom": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.2.tgz",
@@ -903,9 +888,9 @@
       }
     },
     "node_modules/@react-aria/ssr": {
-      "version": "3.9.6",
-      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.9.6.tgz",
-      "integrity": "sha512-iLo82l82ilMiVGy342SELjshuWottlb5+VefO3jOQqQRNYnJBFpUSadswDPbRimSgJUZuFwIEYs6AabkP038fA==",
+      "version": "3.9.7",
+      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.9.7.tgz",
+      "integrity": "sha512-GQygZaGlmYjmYM+tiNBA5C6acmiDWF52Nqd40bBp0Znk4M4hP+LTmI0lpI1BuKMw45T8RIhrAsICIfKwZvi2Gg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/helpers": "^0.5.0"
@@ -914,7 +899,7 @@
         "node": ">= 12"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@reduxjs/toolkit": {
@@ -963,24 +948,36 @@
       }
     },
     "node_modules/@restart/ui": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@restart/ui/-/ui-1.8.0.tgz",
-      "integrity": "sha512-xJEOXUOTmT4FngTmhdjKFRrVVF0hwCLNPdatLCHkyS4dkiSK12cEu1Y0fjxktjJrdst9jJIc5J6ihMJCoWEN/g==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@restart/ui/-/ui-1.9.2.tgz",
+      "integrity": "sha512-MWWqJqSyqUWWPBOOiRQrX57CBc/9CoYONg7sE+uag72GCAuYrHGU5c49vU5s4BUSBgiKNY6rL7TULqGDrouUaA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.21.0",
-        "@popperjs/core": "^2.11.6",
+        "@babel/runtime": "^7.26.0",
+        "@popperjs/core": "^2.11.8",
         "@react-aria/ssr": "^3.5.0",
-        "@restart/hooks": "^0.4.9",
-        "@types/warning": "^3.0.0",
+        "@restart/hooks": "^0.5.0",
+        "@types/warning": "^3.0.3",
         "dequal": "^2.0.3",
         "dom-helpers": "^5.2.0",
-        "uncontrollable": "^8.0.1",
+        "uncontrollable": "^8.0.4",
         "warning": "^4.0.3"
       },
       "peerDependencies": {
         "react": ">=16.14.0",
         "react-dom": ">=16.14.0"
+      }
+    },
+    "node_modules/@restart/ui/node_modules/@restart/hooks": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.5.0.tgz",
+      "integrity": "sha512-wS+h6IusJCPjTkmOOrRZxIPICD/mtFA3PRZviutoM23/b7akyDGfZF/WS+nIFk27u7JDhPE2+0GBdZxjSqHZkg==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@restart/ui/node_modules/uncontrollable": {
@@ -4588,14 +4585,15 @@
       }
     },
     "node_modules/react-bootstrap": {
-      "version": "2.10.5",
-      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-2.10.5.tgz",
-      "integrity": "sha512-XueAOEn64RRkZ0s6yzUTdpFtdUXs5L5491QU//8ZcODKJNDLt/r01tNyriZccjgRImH1REynUc9pqjiRMpDLWQ==",
+      "version": "2.10.7",
+      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-2.10.7.tgz",
+      "integrity": "sha512-w6mWb3uytB5A18S2oTZpYghcOUK30neMBBvZ/bEfA+WIF2dF4OGqjzoFVMpVXBjtyf92gkmRToHlddiMAVhQqQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.24.7",
         "@restart/hooks": "^0.4.9",
-        "@restart/ui": "^1.6.9",
+        "@restart/ui": "^1.9.2",
+        "@types/prop-types": "^15.7.12",
         "@types/react-transition-group": "^4.4.6",
         "classnames": "^2.3.2",
         "dom-helpers": "^5.2.1",
@@ -4631,6 +4629,21 @@
       "peerDependencies": {
         "react": "^16.9.0 || ^17 || ^18",
         "react-dom": "^16.9.0 || ^17 || ^18"
+      }
+    },
+    "node_modules/react-datepicker/node_modules/@floating-ui/react": {
+      "version": "0.26.28",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.26.28.tgz",
+      "integrity": "sha512-yORQuuAtVpiRjpMhdc0wJj06b9JFjrYF4qp96j++v2NBpbi6SEGF7donUJ3TMieerQ6qVkAv1tgr7L4r5roTqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.1.2",
+        "@floating-ui/utils": "^0.2.8",
+        "tabbable": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
       }
     },
     "node_modules/react-datepicker/node_modules/date-fns": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,7 +24,7 @@
     "oidc-client-ts": "^3.0.1",
     "prop-types": "^15.8.1",
     "react": "^18.3.1",
-    "react-bootstrap": "^2.10.5",
+    "react-bootstrap": "^2.10.7",
     "react-datepicker": "^7.5.0",
     "react-dom": "^18.3.1",
     "react-oidc-context": "^3.1.0",

--- a/frontend/src/components/TooltipWrapper.jsx
+++ b/frontend/src/components/TooltipWrapper.jsx
@@ -1,0 +1,40 @@
+import PropTypes from "prop-types";
+import { useState, useRef } from "react";
+import Overlay from "react-bootstrap/Overlay";
+import Tooltip from "react-bootstrap/Tooltip";
+
+export default function TooltipWrapper({
+  placement = "right",
+  content,
+  children,
+}) {
+  const [show, setShow] = useState(false);
+  const target = useRef(null);
+
+  return (
+    <>
+      <span
+        ref={target}
+        onMouseEnter={() => setShow(true)}
+        onMouseLeave={() => setShow(false)}
+      >
+        {children}
+      </span>
+
+      <Overlay target={target.current} show={show} placement={placement}>
+        {(props) => (
+          <Tooltip id="overlay-example" {...props}>
+            {content}
+          </Tooltip>
+        )}
+      </Overlay>
+    </>
+  );
+}
+
+// prop validation
+TooltipWrapper.propTypes = {
+  content: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
+  placement: PropTypes.string,
+};

--- a/frontend/src/router/pages/SubmitDates.jsx
+++ b/frontend/src/router/pages/SubmitDates.jsx
@@ -14,6 +14,7 @@ import groupCamping from "@/assets/icons/group-camping.svg";
 import { formatDateRange } from "@/lib/utils";
 import LoadingBar from "@/components/LoadingBar";
 import FlashMessage from "@/components/FlashMessage";
+import TooltipWrapper from "@/components/TooltipWrapper";
 import ChangeLogsList from "@/components/ChangeLogsList";
 import ConfirmationDialog from "@/components/ConfirmationDialog";
 
@@ -250,6 +251,26 @@ function SubmitDates() {
     });
   }
 
+  /**
+   * Returns an override for the Operating Dates description text if the
+   * feature type has a specific description.
+   * Otherwise, returns the general description from the db.
+   * @param {string} featureType Feature Type name from the db
+   * @returns {string} Operating dates tooltip text
+   */
+  function getOperatingDatesTooltip(featureType) {
+    if (featureType === "Frontcountry campground") {
+      return "All nights where the site is open for camping by the operator. Fees and service levels can vary depending on the time of year.";
+    }
+
+    if (featureType === "Backcountry") {
+      return "All nights where camping is allowed. Fees and service levels can vary depending on the time of year.";
+    }
+
+    // Default: general operating dates tooltip
+    return season.dateTypes.Operation.description;
+  }
+
   // The wireframes don't show the option to remove a date, but if we need it, we can add it here
   // function removeDateRange(dateType, dateableId, index) {
   //   setDates((prevDates) => ({
@@ -430,17 +451,17 @@ function SubmitDates() {
         <div className="row">
           <div className="col-md-6">
             <div>
-              Operating dates{" "}
+              <span className="me-1">Operating dates</span>
               {season?.dateTypes?.Operation?.description && (
-                <div className="tooltip-container">
+                <TooltipWrapper
+                  placement="top"
+                  content={getOperatingDatesTooltip(season.featureType.name)}
+                >
                   <FontAwesomeIcon
-                    className="append-content ms-1"
+                    className="append-content "
                     icon={faCircleInfo}
                   />
-                  <span className="tooltip-text">
-                    {season.dateTypes.Operation.description}
-                  </span>
-                </div>
+                </TooltipWrapper>
               )}
             </div>
 
@@ -477,17 +498,17 @@ function SubmitDates() {
           {feature.hasReservations && (
             <div className="col-md-6">
               <div>
-                Reservation dates{" "}
+                <span className="me-1">Reservation dates</span>
                 {season?.dateTypes?.Reservation?.description && (
-                  <div className="tooltip-container">
+                  <TooltipWrapper
+                    placement="top"
+                    content={season.dateTypes.Reservation.description}
+                  >
                     <FontAwesomeIcon
-                      className="append-content ms-1"
+                      className="append-content "
                       icon={faCircleInfo}
                     />
-                    <span className="tooltip-text">
-                      {season.dateTypes.Reservation.description}
-                    </span>
-                  </div>
+                  </TooltipWrapper>
                 )}
               </div>
 

--- a/frontend/src/router/pages/SubmitDates.scss
+++ b/frontend/src/router/pages/SubmitDates.scss
@@ -55,29 +55,6 @@
     gap: var(--layout-margin-medium);
   }
 
-  .tooltip-container {
-    position: relative;
-    display: inline-block;
-  }
-
-  .tooltip-text {
-    visibility: hidden;
-    background-color: var(--surface-color-border-dark);
-    color: var(--typography-color-primary-invert);
-    text-align: center;
-    padding: var(--layout-padding-xsmall) var(--layout-padding-small);
-    border-radius: var(--layout-border-radius-large);
-    position: absolute;
-    z-index: 1;
-    bottom: 125%; /* Position above the icon */
-    left: 50%;
-    transform: translateX(-50%);
-    white-space: nowrap;
-    font-size: 14px;
-    opacity: 0;
-    transition: opacity 0.3s;
-  }
-
   /* Arrow at the bottom of tooltip */
   .tooltip-text::after {
     content: "";
@@ -100,11 +77,5 @@
     .controls {
       gap: var(--layout-margin-medium);
     }
-  }
-
-  /* Show tooltip on hover */
-  .tooltip-container:hover .tooltip-text {
-    visibility: visible;
-    opacity: 1;
   }
 }


### PR DESCRIPTION
### Jira Ticket

CMS-590

### Description
<!-- What did you change, and why? -->

Some new tooltip text was revealed in a sharepoint doc, which has specific text for certain feature types. I updated the text and made a method to resolve the tooltips for Operating Dates with those feature types.

The new text was very long so I installed react-bootstrap to use their tooltip component because our existing one didn't wrap long lines. Turns out we already had react-bootstrap installed but weren't using it anywhere(?) Good to know! There's probably more stuff in there we can pull in to make our lives easier.

I made a "TooltipWrapper" component so we can use react-bootstrap tooltips anywhere. Mostly copied and pasted the example from their docs.