### PR TITLE
CMS-591: Add ChangeLogs (notes) component to details page

### DIFF
--- a/frontend/src/components/ChangeLogs.jsx
+++ b/frontend/src/components/ChangeLogs.jsx
@@ -1,0 +1,29 @@
+import PropTypes from "prop-types";
+import { formatTimestamp } from "@/lib/utils";
+
+// Displays season date changelogs (aka "notes")
+export default function ChangeLogs({ changeLogs = [] }) {
+  return (
+    <>
+      {changeLogs.map((changeLog) => (
+        <p key={changeLog.id}>
+          {changeLog.notes && (
+            <span>
+              {changeLog.notes}
+              <br />
+            </span>
+          )}
+          <span className="note-metadata">
+            {changeLog.notes ? "" : "Submitted "}
+            {formatTimestamp(changeLog.createdAt)} by {changeLog.user.name}
+          </span>
+        </p>
+      ))}
+    </>
+  );
+}
+
+// Prop validation
+ChangeLogs.propTypes = {
+  changeLogs: PropTypes.array,
+};

--- a/frontend/src/components/ChangeLogsList.jsx
+++ b/frontend/src/components/ChangeLogsList.jsx
@@ -1,10 +1,12 @@
 import PropTypes from "prop-types";
 import { formatTimestamp } from "@/lib/utils";
 
+import "./ChangeLogsList.scss";
+
 // Displays season date changelogs (aka "notes")
 export default function ChangeLogsList({ changeLogs = [] }) {
   return (
-    <>
+    <div className="change-logs-list">
       {changeLogs.map((changeLog) => (
         <p key={changeLog.id}>
           {changeLog.notes && (
@@ -19,7 +21,7 @@ export default function ChangeLogsList({ changeLogs = [] }) {
           </span>
         </p>
       ))}
-    </>
+    </div>
   );
 }
 

--- a/frontend/src/components/ChangeLogsList.jsx
+++ b/frontend/src/components/ChangeLogsList.jsx
@@ -2,7 +2,7 @@ import PropTypes from "prop-types";
 import { formatTimestamp } from "@/lib/utils";
 
 // Displays season date changelogs (aka "notes")
-export default function ChangeLogs({ changeLogs = [] }) {
+export default function ChangeLogsList({ changeLogs = [] }) {
   return (
     <>
       {changeLogs.map((changeLog) => (
@@ -24,6 +24,6 @@ export default function ChangeLogs({ changeLogs = [] }) {
 }
 
 // Prop validation
-ChangeLogs.propTypes = {
+ChangeLogsList.propTypes = {
   changeLogs: PropTypes.array,
 };

--- a/frontend/src/components/ChangeLogsList.scss
+++ b/frontend/src/components/ChangeLogsList.scss
@@ -1,0 +1,5 @@
+.change-logs-list {
+  .note-metadata {
+    color: var(--theme-gray-80);
+  }
+}

--- a/frontend/src/components/ParkDetailsSeasonDates.jsx
+++ b/frontend/src/components/ParkDetailsSeasonDates.jsx
@@ -1,6 +1,9 @@
 import groupBy from "lodash/groupBy";
 import DateRange from "@/components/DateRange";
 import PropTypes from "prop-types";
+import ChangeLogs from "./ChangeLogs";
+
+import "./ParkDetailsSeasonDates.scss";
 
 function DateTypeRow({ dateTypeName, dateRanges }) {
   return (
@@ -29,7 +32,7 @@ function CampGroundFeature({ feature }) {
 
   return (
     <div className="feature">
-      <h5>{feature.name}</h5>
+      <h4>{feature.name}</h4>
 
       <table className="table table-striped sub-area-dates mb-0">
         <tbody>
@@ -61,15 +64,29 @@ function CampGround({ campground }) {
 
 export default function SeasonDates({ data }) {
   return (
-    <div className="details-content">
-      <div className={data.campgrounds.length > 0 ? "mb-4" : ""}>
-        {data.campgrounds.map((campground) => (
-          <CampGround key={campground.id} campground={campground} />
-        ))}
-      </div>
-      {data.features.map((feature) => (
-        <CampGroundFeature key={feature.id} feature={feature} />
-      ))}
+    <div className="park-details-season-dates details-content">
+      {data.campgrounds.length > 0 && (
+        <div className="campgrounds">
+          {data.campgrounds.map((campground) => (
+            <CampGround key={campground.id} campground={campground} />
+          ))}
+        </div>
+      )}
+
+      {data.features.length > 0 && (
+        <div className="features">
+          {data.features.map((feature) => (
+            <CampGroundFeature key={feature.id} feature={feature} />
+          ))}
+        </div>
+      )}
+
+      {data.changeLogs.length > 0 && (
+        <div className="notes">
+          <h4>Notes</h4>
+          <ChangeLogs changeLogs={data.changeLogs} />
+        </div>
+      )}
     </div>
   );
 }
@@ -102,6 +119,7 @@ SeasonDates.propTypes = {
   data: PropTypes.shape({
     campgrounds: PropTypes.arrayOf(campgroundPropShape),
     features: PropTypes.arrayOf(campgroundFeaturePropShape),
+    changeLogs: PropTypes.array.isRequired,
   }),
 };
 

--- a/frontend/src/components/ParkDetailsSeasonDates.jsx
+++ b/frontend/src/components/ParkDetailsSeasonDates.jsx
@@ -1,7 +1,7 @@
 import groupBy from "lodash/groupBy";
-import DateRange from "@/components/DateRange";
 import PropTypes from "prop-types";
-import ChangeLogs from "./ChangeLogs";
+import DateRange from "@/components/DateRange";
+import ChangeLogsList from "@/components/ChangeLogsList.jsx";
 
 import "./ParkDetailsSeasonDates.scss";
 
@@ -84,7 +84,7 @@ export default function SeasonDates({ data }) {
       {data.changeLogs.length > 0 && (
         <div className="notes">
           <h4>Notes</h4>
-          <ChangeLogs changeLogs={data.changeLogs} />
+          <ChangeLogsList changeLogs={data.changeLogs} />
         </div>
       )}
     </div>

--- a/frontend/src/components/ParkDetailsSeasonDates.scss
+++ b/frontend/src/components/ParkDetailsSeasonDates.scss
@@ -1,0 +1,13 @@
+.park-details-season-dates {
+  &.details-content {
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+
+    .notes {
+      p:last-child {
+        margin-bottom: 0;
+      }
+    }
+  }
+}

--- a/frontend/src/router/pages/ParkDetails.scss
+++ b/frontend/src/router/pages/ParkDetails.scss
@@ -30,7 +30,6 @@
     }
 
     & > .details {
-      color: var(--surface-color-primary-default);
       border-radius: 0 0 var(--layout-border-radius-medium)
         var(--layout-border-radius-medium);
 
@@ -57,6 +56,7 @@
         align-items: center;
         gap: var(--layout-margin-medium);
         padding: var(--layout-padding-large);
+        color: var(--surface-color-primary-default);
 
         > h3 {
           margin: 0;

--- a/frontend/src/router/pages/PreviewChanges.jsx
+++ b/frontend/src/router/pages/PreviewChanges.jsx
@@ -1,7 +1,6 @@
 import PropTypes from "prop-types";
 import { useNavigate, useParams } from "react-router-dom";
 import { useEffect, useState } from "react";
-import { formatTimestamp } from "@/lib/utils";
 import { useApiGet, useApiPost } from "@/hooks/useApi";
 
 import { faPen } from "@fa-kit/icons/classic/solid";
@@ -14,6 +13,7 @@ import ContactBox from "@/components/ContactBox";
 import ReadyToPublishBox from "@/components/ReadyToPublishBox";
 import FlashMessage from "@/components/FlashMessage";
 import DateRange from "@/components/DateRange";
+import ChangeLogs from "@/components/ChangeLogs";
 
 import { Link } from "react-router-dom";
 
@@ -238,20 +238,7 @@ function PreviewChanges() {
         <div className="col-lg-6">
           <h2 className="mb-4">Notes</h2>
 
-          {data?.changeLogs.map((changeLog) => (
-            <p key={changeLog.id}>
-              {changeLog.notes && (
-                <span>
-                  {changeLog.notes}
-                  <br />
-                </span>
-              )}
-              <span className="note-metadata">
-                {changeLog.notes ? "" : "Submitted "}
-                {formatTimestamp(changeLog.createdAt)} by {changeLog.user.name}
-              </span>
-            </p>
-          ))}
+          <ChangeLogs changeLogs={data?.changeLogs} />
 
           <p>
             If you are updating the current year’s dates, provide an explanation

--- a/frontend/src/router/pages/PreviewChanges.jsx
+++ b/frontend/src/router/pages/PreviewChanges.jsx
@@ -13,7 +13,7 @@ import ContactBox from "@/components/ContactBox";
 import ReadyToPublishBox from "@/components/ReadyToPublishBox";
 import FlashMessage from "@/components/FlashMessage";
 import DateRange from "@/components/DateRange";
-import ChangeLogs from "@/components/ChangeLogs";
+import ChangeLogsList from "@/components/ChangeLogsList";
 
 import { Link } from "react-router-dom";
 
@@ -238,7 +238,7 @@ function PreviewChanges() {
         <div className="col-lg-6">
           <h2 className="mb-4">Notes</h2>
 
-          <ChangeLogs changeLogs={data?.changeLogs} />
+          <ChangeLogsList changeLogs={data?.changeLogs} />
 
           <p>
             If you are updating the current year’s dates, provide an explanation

--- a/frontend/src/router/pages/PreviewChanges.scss
+++ b/frontend/src/router/pages/PreviewChanges.scss
@@ -38,11 +38,6 @@
   }
 
   .notes {
-    .note-metadata {
-      color: var(--typography-color-secondary);
-      filter: brightness(1.5); // muted font color, lighter than color-secondary
-    }
-
     .controls {
       gap: var(--layout-margin-medium);
     }

--- a/frontend/src/router/pages/SubmitDates.jsx
+++ b/frontend/src/router/pages/SubmitDates.jsx
@@ -7,9 +7,10 @@ import NavBack from "@/components/NavBack";
 import ContactBox from "@/components/ContactBox";
 import ReadyToPublishBox from "@/components/ReadyToPublishBox";
 import groupCamping from "@/assets/icons/group-camping.svg";
-import { formatDateRange, formatTimestamp } from "@/lib/utils";
+import { formatDateRange } from "@/lib/utils";
 import LoadingBar from "@/components/LoadingBar";
 import FlashMessage from "@/components/FlashMessage";
+import ChangeLogs from "@/components/ChangeLogs";
 import useValidation from "@/hooks/useValidation";
 
 import DatePicker from "react-datepicker";
@@ -520,20 +521,7 @@ function SubmitDates() {
         <div className="col-lg-6">
           <h2 className="mb-4">Notes</h2>
 
-          {season?.changeLogs.map((changeLog) => (
-            <p key={changeLog.id}>
-              {changeLog.notes && (
-                <span>
-                  {changeLog.notes}
-                  <br />
-                </span>
-              )}
-              <span className="note-metadata">
-                {changeLog.notes ? "" : "Submitted "}
-                {formatTimestamp(changeLog.createdAt)} by {changeLog.user.name}
-              </span>
-            </p>
-          ))}
+          <ChangeLogs changeLogs={season?.changeLogs} />
 
           <p>
             If you are updating the current year’s dates, provide an explanation

--- a/frontend/src/router/pages/SubmitDates.jsx
+++ b/frontend/src/router/pages/SubmitDates.jsx
@@ -10,7 +10,7 @@ import groupCamping from "@/assets/icons/group-camping.svg";
 import { formatDateRange } from "@/lib/utils";
 import LoadingBar from "@/components/LoadingBar";
 import FlashMessage from "@/components/FlashMessage";
-import ChangeLogs from "@/components/ChangeLogs";
+import ChangeLogsList from "@/components/ChangeLogsList";
 import useValidation from "@/hooks/useValidation";
 
 import DatePicker from "react-datepicker";
@@ -521,7 +521,7 @@ function SubmitDates() {
         <div className="col-lg-6">
           <h2 className="mb-4">Notes</h2>
 
-          <ChangeLogs changeLogs={season?.changeLogs} />
+          <ChangeLogsList changeLogs={season?.changeLogs} />
 
           <p>
             If you are updating the current year’s dates, provide an explanation

--- a/frontend/src/router/pages/SubmitDates.scss
+++ b/frontend/src/router/pages/SubmitDates.scss
@@ -97,11 +97,6 @@
   }
 
   .notes {
-    .note-metadata {
-      color: var(--typography-color-secondary);
-      filter: brightness(1.5); // muted font color, lighter than color-secondary
-    }
-
     .controls {
       gap: var(--layout-margin-medium);
     }


### PR DESCRIPTION
### Jira Ticket

CMS-591

### Description
<!-- What did you change, and why? -->

We had to add the change log notes to the details page, in the expansion panels. I turned the notes list into a component and popped it in there, and made some minor style tweaks to make it match the latest Figma styles.