### PR TITLE
CMS-566: fix issue in which some seasons didn't have any dates at all

### DIFF
--- a/backend/routes/api/seasons.js
+++ b/backend/routes/api/seasons.js
@@ -97,6 +97,7 @@ router.get(
     const parkFeatures = await Feature.findAll({
       where: {
         parkId: season.park.id,
+        active: true,
         featureTypeId: season.featureType.id,
       },
       attributes: ["id", "name", "hasReservations", "active"],
@@ -110,11 +111,13 @@ router.get(
           model: Dateable,
           as: "dateable",
           attributes: ["id"],
+          required: false,
           include: [
             // get all the dateRanges for this feature for this season and previous season
             {
               model: DateRange,
               as: "dateRanges",
+              required: false,
               attributes: ["id", "seasonId", "startDate", "endDate"],
               include: [
                 {

--- a/backend/routes/api/seasons.js
+++ b/backend/routes/api/seasons.js
@@ -97,7 +97,6 @@ router.get(
     const parkFeatures = await Feature.findAll({
       where: {
         parkId: season.park.id,
-        active: true,
         featureTypeId: season.featureType.id,
       },
       attributes: ["id", "name", "hasReservations", "active"],

--- a/backend/strapi-sync/sync.js
+++ b/backend/strapi-sync/sync.js
@@ -334,7 +334,7 @@ export async function createDatesAndSeasons(datesData) {
         strapiId: subAreaId,
       });
 
-      if (feature) {
+      if (feature && feature.active) {
         const featureTypeId = feature.featureTypeId;
         const parkId = feature.parkId;
         const operatingYear = item.attributes.operatingYear;


### PR DESCRIPTION
### Jira Ticket

CMS-566

### Description
This changes the one-time-data-import script so that seasons and dates will only be created for active features. Some inactive features have missing dates or dates that are also inactive. 
Given that the API considers which features are active and which features have dates, we don't want to create "seasons" for features that wouldn't be returned by the API anyway. 

Note that this requires the database to be recreated and all the syncing process to be done from scratch. Just follow steps 1 to 7 in the readme. 

The `required: false`  in the query is to make the query a left outer join instead of an inner join. This was causing 500 errors given that in some cases dateable was being returned as `null` even though the feature had a dateable. 