### PR TITLE
CMS-595: Update DatePicker configuration

### DIFF
--- a/frontend/src/router/pages/SubmitDates.jsx
+++ b/frontend/src/router/pages/SubmitDates.jsx
@@ -373,9 +373,10 @@ function SubmitDates() {
 
         // Don't set the time if it can't be parsed
         if (!isValid(date)) return;
-
-        onSelect(date, dateField);
       }
+
+      // Update the selected date value
+      onSelect(date, dateField);
     }
 
     return (

--- a/frontend/src/router/pages/SubmitDates.jsx
+++ b/frontend/src/router/pages/SubmitDates.jsx
@@ -1,6 +1,7 @@
 import { useParams, useNavigate, Link } from "react-router-dom";
 import { useEffect, useState } from "react";
 import { cloneDeep, set as lodashSet } from "lodash";
+import { isValid, parse } from "date-fns";
 import {
   faCircleInfo,
   faTriangleExclamation,
@@ -347,22 +348,11 @@ function SubmitDates() {
                 maxDate={maxDate}
                 openToDate={openDateStart}
                 selected={formatDate(dateRange.startDate)}
-                onChange={(date) => {
-                  updateDateRange(
-                    dateRange.dateableId,
-                    dateRange.dateType.name,
-                    index,
-                    "startDate",
-                    date,
-                    // Callback to validate the new value
-                    (updatedDates) => {
-                      onUpdateDateRange({
-                        dateRange,
-                        datesObj: updatedDates,
-                      });
-                    },
-                  );
+                onChange={() => {
+                  // Required prop, but handled by onSelect/onKeyDown
                 }}
+                onKeyDown={(event) => onKeyDown(event, "startDate")}
+                onSelect={(date) => onSelect(date, "startDate")}
                 dateFormat="EEE, MMM d, yyyy"
               />
 
@@ -403,22 +393,11 @@ function SubmitDates() {
                 maxDate={maxDate}
                 openToDate={openDateEnd}
                 selected={formatDate(dateRange.endDate)}
-                onChange={(date) => {
-                  updateDateRange(
-                    dateRange.dateableId,
-                    dateRange.dateType.name,
-                    index,
-                    "endDate",
-                    date,
-                    // Callback to validate the new value
-                    (updatedDates) => {
-                      onUpdateDateRange({
-                        dateRange,
-                        datesObj: updatedDates,
-                      });
-                    },
-                  );
+                onChange={() => {
+                  // Required prop, but handled by onSelect/onKeyDown
                 }}
+                onKeyDown={(event) => onKeyDown(event, "endDate")}
+                onSelect={(date) => onSelect(date, "endDate")}
                 dateFormat="EEE, MMM d, yyyy"
               />
 

--- a/frontend/src/router/pages/SubmitDates.jsx
+++ b/frontend/src/router/pages/SubmitDates.jsx
@@ -397,8 +397,11 @@ function SubmitDates() {
                 maxDate={maxDate}
                 openToDate={openDateStart}
                 selected={formatDate(dateRange.startDate)}
-                onChange={() => {
-                  // Required prop, but handled by onSelect/onKeyDown
+                onChange={(date) => {
+                  // Set null if the field has been cleared
+                  if (date === null) {
+                    onSelect(null, "startDate");
+                  }
                 }}
                 onKeyDown={(event) => onKeyDown(event, "startDate")}
                 onSelect={(date) => onSelect(date, "startDate")}
@@ -442,8 +445,11 @@ function SubmitDates() {
                 maxDate={maxDate}
                 openToDate={openDateEnd}
                 selected={formatDate(dateRange.endDate)}
-                onChange={() => {
-                  // Required prop, but handled by onSelect/onKeyDown
+                onChange={(date) => {
+                  // Set null if the field has been cleared
+                  if (date === null) {
+                    onSelect(null, "endDate");
+                  }
                 }}
                 onKeyDown={(event) => onKeyDown(event, "endDate")}
                 onSelect={(date) => onSelect(date, "endDate")}

--- a/frontend/src/router/pages/SubmitDates.jsx
+++ b/frontend/src/router/pages/SubmitDates.jsx
@@ -335,6 +335,8 @@ function SubmitDates() {
                   "form-control": true,
                   "is-invalid": startErrors,
                 })}
+                minDate={new Date(season.operatingYear, 0, 1)}
+                maxDate={new Date(season.operatingYear, 11, 31)}
                 selected={formatDate(dateRange.startDate)}
                 onChange={(date) => {
                   updateDateRange(
@@ -388,6 +390,8 @@ function SubmitDates() {
                   "form-control": true,
                   "is-invalid": endErrors,
                 })}
+                minDate={new Date(season.operatingYear, 0, 1)}
+                maxDate={new Date(season.operatingYear, 11, 31)}
                 selected={formatDate(dateRange.endDate)}
                 onChange={(date) => {
                   updateDateRange(

--- a/frontend/src/router/pages/SubmitDates.jsx
+++ b/frontend/src/router/pages/SubmitDates.jsx
@@ -320,6 +320,14 @@ function SubmitDates() {
     const startErrors = errors?.[startDateId] || groupErrors;
     const endErrors = errors?.[endDateId] || groupErrors;
 
+    // Limit the date range to the operating year
+    const minDate = new Date(season.operatingYear, 0, 1);
+    const maxDate = new Date(season.operatingYear, 11, 31);
+
+    // Open the calendar to Jan 1 of the operating year if no date is set
+    const openDateStart = formatDate(dateRange.startDate) || minDate;
+    const openDateEnd = formatDate(dateRange.endDate) || minDate;
+
     return (
       <div className="row dates-row operating-dates">
         <div className="col-lg-5">
@@ -335,8 +343,9 @@ function SubmitDates() {
                   "form-control": true,
                   "is-invalid": startErrors,
                 })}
-                minDate={new Date(season.operatingYear, 0, 1)}
-                maxDate={new Date(season.operatingYear, 11, 31)}
+                minDate={minDate}
+                maxDate={maxDate}
+                openToDate={openDateStart}
                 selected={formatDate(dateRange.startDate)}
                 onChange={(date) => {
                   updateDateRange(
@@ -390,8 +399,9 @@ function SubmitDates() {
                   "form-control": true,
                   "is-invalid": endErrors,
                 })}
-                minDate={new Date(season.operatingYear, 0, 1)}
-                maxDate={new Date(season.operatingYear, 11, 31)}
+                minDate={minDate}
+                maxDate={maxDate}
+                openToDate={openDateEnd}
                 selected={formatDate(dateRange.endDate)}
                 onChange={(date) => {
                   updateDateRange(


### PR DESCRIPTION
### Jira Ticket

CMS-595

### Description
<!-- What did you change, and why? -->

This fixes a few issues reported by QA with the DatePicker component in the date ranges on the "Submit Dates" page:

1. Disable selection of dates outside of the Operating Year when clicking the calendar
2. If a DatePicker is blank (if you add a new date range, or delete the value) it will open to January of the Operating Year, instead of the current month/year.
3. Allow typing or pasting inputs in a variety of formats before parsing (It waits until you press Enter after typing). I added a bit of a hack to prevent parsing "YYYY-MM-DD" format in the wrong timezone. 

## Known bugs

Right now, it should all work the way you'd expect when typing into a date picker box, except if you use the "YYYY-MM-DD" format, the calendar will highlight the previous day because of the timezone offset. It will ultimately select the right date, but the wrong one will be highlighted. I opened a ticket in the react-datepicker repo to discuss using a custom date parser to prevent this.