### PR TITLE
CMS-593: Skip saving blank date ranges

### DIFF
--- a/backend/routes/api/seasons.js
+++ b/backend/routes/api/seasons.js
@@ -288,6 +288,9 @@ router.post(
           },
         );
       } else if (!date.id) {
+        // Skip creating empty date ranges
+        if (date.startDate === null && date.endDate === null) return;
+
         // if date doesn't have ID, it's a new date
         DateRange.create({
           seasonId,

--- a/frontend/src/router/pages/SubmitDates.jsx
+++ b/frontend/src/router/pages/SubmitDates.jsx
@@ -95,13 +95,22 @@ function SubmitDates() {
       throw new Error("Form validation failed");
     }
 
+    // Build a list of date ranges of all date types
+    const allDates = Object.values(dates)
+      .reduce(
+        (acc, dateType) => acc.concat(dateType.Operation, dateType.Reservation),
+        [],
+      )
+      // Filter out any blank ranges
+      .filter(
+        (dateRange) =>
+          dateRange.startDate !== null && dateRange.endDate !== null,
+      );
+
     const payload = {
       notes,
       readyToPublish,
-      dates: Object.values(dates).reduce(
-        (acc, dateType) => acc.concat(dateType.Operation, dateType.Reservation),
-        [],
-      ),
+      dates: allDates,
     };
 
     const response = await sendData(payload);


### PR DESCRIPTION
### Jira Ticket

CMS-593

### Description
<!-- What did you change, and why? -->

The requirements say that the way to remove an empty date range is to save it or leave the page and come back, and the empty range(s) will be gone.

This branch adds a filter on the frontend and backend to skip saving date ranges where the start and end date are both null. 

It's explicitly checking for two nulls, but we can easily change it to reject if either of them is null. Validation should catch that on the front end, and I don't know if they'll ever want to save a half-done range as part of a draft in the future.