### PR TITLE
CMS-591: Update changelog datestamp

### DIFF
--- a/frontend/src/components/ChangeLogsList.jsx
+++ b/frontend/src/components/ChangeLogsList.jsx
@@ -1,5 +1,5 @@
 import PropTypes from "prop-types";
-import { formatTimestamp } from "@/lib/utils";
+import { formatDate } from "@/lib/utils";
 
 import "./ChangeLogsList.scss";
 
@@ -17,7 +17,7 @@ export default function ChangeLogsList({ changeLogs = [] }) {
           )}
           <span className="note-metadata">
             {changeLog.notes ? "" : "Submitted "}
-            {formatTimestamp(changeLog.createdAt)} by {changeLog.user.name}
+            {formatDate(changeLog.createdAt)} by {changeLog.user.name}
           </span>
         </p>
       ))}

--- a/frontend/src/lib/utils.js
+++ b/frontend/src/lib/utils.js
@@ -6,8 +6,6 @@ const DATE_FORMAT_DEFAULT = "MMMM d, yyyy";
 // Abbreviated day of the week, abbreviated month, day
 const DATE_FORMAT_SHORT = "EEE, MMM d";
 const DATE_FORMAT_SHORT_WITH_YEAR = "EEE, MMM d, yyyy";
-// Abbreviated month, day, year, time
-const DATE_FORMAT_TIMESTAMP = "MMM d, yyyy, h:mm a";
 
 export function normalizeToUTCDate(dateObject) {
   return new Date(
@@ -57,10 +55,6 @@ export function formatDateRange(dateRange) {
   );
 
   return `${startDate} - ${endDate}`;
-}
-
-export function formatTimestamp(timestamp) {
-  return isoToFormattedString(timestamp, DATE_FORMAT_TIMESTAMP);
 }
 
 export function formatDatetoISO(date) {


### PR DESCRIPTION
### Jira Ticket

CMS-591

### Description
<!-- What did you change, and why? -->

Updated the notes/changelog timestamps to match the updates in Figma. Removed the "formatTimestamp" function since it's no longer used. Easy to add back if we need it later.