### PR TITLE
CMS-598: Update "Pending review" label

### DIFF
--- a/backend/routes/api/parks.js
+++ b/backend/routes/api/parks.js
@@ -14,7 +14,7 @@ const router = Router();
 
 function getParkStatus(seasons) {
   // if any season has status==requested, return requested
-  // else if any season has status==under review, return under review
+  // else if any season has status==pending review, return pending review
   // else if any season has status==approved, return approved
   // if all seasons have status==published, return published
 
@@ -24,10 +24,10 @@ function getParkStatus(seasons) {
     return "requested";
   }
 
-  const underReview = seasons.some((s) => s.status === "under review");
+  const pendingReview = seasons.some((s) => s.status === "pending review");
 
-  if (underReview) {
-    return "under review";
+  if (pendingReview) {
+    return "pending review";
   }
 
   const approved = seasons.some((s) => s.status === "approved");

--- a/backend/routes/api/seasons.js
+++ b/backend/routes/api/seasons.js
@@ -22,12 +22,12 @@ const router = Router();
 //   // rn we're just setting everything to requested
 //   // For staff
 //   //   requested -- > requested
-//   //   under review -- > under review
-//   //   approved -- > under review
-//   //   published --> under review
+//   //   pending review -- > pending review
+//   //   approved -- > pending review
+//   //   published --> pending review
 //   // For operator
 //   //   requested -- > requested
-//   //   under review -- > requested
+//   //   pending review -- > requested
 //   //   approved -- > requested
 //   //   published --> requested
 //   return season.status;

--- a/frontend/src/components/ParkDetailsSeason.jsx
+++ b/frontend/src/components/ParkDetailsSeason.jsx
@@ -92,7 +92,7 @@ export default function ParkSeason({ season }) {
   const updateDate = formatDate(season.updatedAt);
 
   async function navigateToEdit() {
-    if (season.status === "under review") {
+    if (season.status === "pending review") {
       const confirm = await openConfirmation(
         "Edit submitted dates?",
         "A review may already be in progress and all dates will need to be reviewed again.",

--- a/frontend/src/router/pages/EditAndReview.jsx
+++ b/frontend/src/router/pages/EditAndReview.jsx
@@ -12,7 +12,7 @@ function EditAndReview() {
   const parks = data || [];
 
   const statusOptions = [
-    { value: "under review", label: "Under review" },
+    { value: "pending review", label: "Pending review" },
     { value: "requested", label: "Requested" },
     { value: "approved", label: "Approved" },
     { value: "published", label: "Published" },

--- a/frontend/src/router/pages/SubmitDates.jsx
+++ b/frontend/src/router/pages/SubmitDates.jsx
@@ -119,7 +119,7 @@ function SubmitDates() {
   }
 
   async function submitChanges(savingDraft = false) {
-    if (["under review", "approved", "published"].includes(season.status)) {
+    if (["pending review", "approved", "published"].includes(season.status)) {
       const confirm = await openConfirmation(
         "Move back to draft?",
         "The dates will be moved back to draft and need to be submitted again to be reviewed.",


### PR DESCRIPTION
### Jira Ticket

CMS-598

### Description
<!-- What did you change, and why? -->

Updated the text for the "under review" status to "pending review". I don't think we need a migration or anything because there shouldn't be any "under review" values in the db currently, and nothing should ever come from Strapi with that status.

I noticed the status badge component on the frontend doesn't even have a case for "under review"/"pending review" but we can add that in a future release when the status is used.

Right now the only place you'd notice this change is in the filter box for the list of parks on the homepage.