### PR TITLE
CMS-603: Convert timestamp in change logs to local time when formatting.

### DIFF
--- a/frontend/src/components/ChangeLogsList.jsx
+++ b/frontend/src/components/ChangeLogsList.jsx
@@ -17,7 +17,8 @@ export default function ChangeLogsList({ changeLogs = [] }) {
           )}
           <span className="note-metadata">
             {changeLog.notes ? "" : "Submitted "}
-            {formatDate(changeLog.createdAt)} by {changeLog.user.name}
+            {formatDate(changeLog.createdAt, "America/Vancouver")} by{" "}
+            {changeLog.user.name}
           </span>
         </p>
       ))}

--- a/frontend/src/lib/utils.js
+++ b/frontend/src/lib/utils.js
@@ -21,18 +21,19 @@ export function normalizeToUTCDate(dateObject) {
  * Formats an ISO date string into a human-readable string
  * @param {string} isoString ISO date string
  * @param {string} formatString date-fns formatting string
+ * @param {string} timezone timezone to format the date in
  * @returns {string} The formatted date string
  */
-function isoToFormattedString(isoString, formatString) {
+function isoToFormattedString(isoString, formatString, timezone = "UTC") {
   if (!isoString) return "";
 
   const date = parseISO(isoString);
 
-  return formatInTimeZone(date, "UTC", formatString);
+  return formatInTimeZone(date, timezone, formatString);
 }
 
-export function formatDate(date) {
-  return isoToFormattedString(date, DATE_FORMAT_DEFAULT);
+export function formatDate(date, timezone = "UTC") {
+  return isoToFormattedString(date, DATE_FORMAT_DEFAULT, timezone);
 }
 
 export function formatDateShort(date) {


### PR DESCRIPTION
### Jira Ticket

CMS-603

### Description
Every date and timestamp is saved in UTC. When displaying date in change logs, we need to uses `America/Vancouver` timezone when formatting to display the accurate day. 
