### PR TITLE
CMS-613: Filter empty notes out of /seasons payload

### DIFF
--- a/backend/routes/api/seasons.js
+++ b/backend/routes/api/seasons.js
@@ -55,6 +55,13 @@ router.get(
           model: SeasonChangeLog,
           as: "changeLogs",
           attributes: ["id", "notes", "createdAt"],
+          // Filter out empty notes
+          where: {
+            notes: {
+              [Op.ne]: "",
+            },
+          },
+          required: false,
           order: [["createdAt", "DESC"]],
           include: [
             {

--- a/frontend/src/components/ChangeLogsList.jsx
+++ b/frontend/src/components/ChangeLogsList.jsx
@@ -16,7 +16,6 @@ export default function ChangeLogsList({ changeLogs = [] }) {
             </span>
           )}
           <span className="note-metadata">
-            {changeLog.notes ? "" : "Submitted "}
             {formatDate(changeLog.createdAt, "America/Vancouver")} by{" "}
             {changeLog.user.name}
           </span>


### PR DESCRIPTION
### Jira Ticket

CMS-613

### Description
<!-- What did you change, and why? -->

Excluding SeasonChangeLogs with no notes. It sounds like they might still want these in the future, so I'm just excluding them from the query results here. We're already doing this in the CSV export, so I copied the query part from that.

If you think it's a good idea, we can look into not creating these blank notes at all... and maybe we don't need the DateChangeLogs either? 