### PR TITLE
CMS-614: Hide reservations row when hasReservations is false

### DIFF
--- a/frontend/src/router/pages/PreviewChanges.jsx
+++ b/frontend/src/router/pages/PreviewChanges.jsx
@@ -167,23 +167,26 @@ function PreviewChanges() {
                   </button>
                 </td>
               </tr>
+
+              {feature.hasReservations && (
               <tr>
                 <td>Reservation</td>
                 <td>{getPrevSeasonDates(feature, "Reservation")}</td>
                 <td>{getCurrentSeasonDates(feature, "Reservation")}</td>
                 <td>
-                  <button
-                    onClick={navigateToEdit}
-                    className="btn btn-text-primary"
-                  >
-                    <FontAwesomeIcon
-                      className="append-content me-2"
-                      icon={faPen}
-                    />
-                    <span>Edit</span>
-                  </button>
-                </td>
-              </tr>
+                    <button
+                      onClick={navigateToEdit}
+                      className="btn btn-text-primary"
+                    >
+                      <FontAwesomeIcon
+                        className="append-content me-2"
+                        icon={faPen}
+                      />
+                      <span>Edit</span>
+                    </button>
+                  </td>
+                </tr>
+              )}
             </tbody>
           </table>
         </div>


### PR DESCRIPTION
### Jira Ticket

CMS-614

### Description
<!-- What did you change, and why? -->

Hides the reservations row in the table on the Preview page, if the feature's `hasReservations` is false. 
Same pattern that's used on the SubmitDates page. 

Note that the Park Details page currently does it slightly differently and doesn't look at hasReservations, but the row is hidden because the "Reservation" date type doesn't exist in the object there. Let me know if you think we should update that too.