### PR TITLE
CMS-618: Redirect to Park Details on approval

### DIFF
--- a/frontend/src/hooks/useNavigationGuard.js
+++ b/frontend/src/hooks/useNavigationGuard.js
@@ -7,7 +7,10 @@ export function useNavigationGuard(hasChanges, openConfirmation) {
     const currentPath = currentLocation.pathname;
     const nextPath = removeTrailingSlash(nextLocation.pathname);
 
-    if (`${currentPath}/preview` === nextPath) {
+    // Get query string from nextPath
+    const queryString = new URLSearchParams(nextLocation.search);
+
+    if (nextPath === `${currentPath}/preview` || queryString.has("approved")) {
       return false;
     }
     return hasChanges();

--- a/frontend/src/hooks/useNavigationGuard.js
+++ b/frontend/src/hooks/useNavigationGuard.js
@@ -10,6 +10,7 @@ export function useNavigationGuard(hasChanges, openConfirmation) {
     // Get query string from nextPath
     const queryString = new URLSearchParams(nextLocation.search);
 
+    // Bypass the blocker when saving or approving
     if (nextPath === `${currentPath}/preview` || queryString.has("approved")) {
       return false;
     }

--- a/frontend/src/router/pages/ParkDetails.jsx
+++ b/frontend/src/router/pages/ParkDetails.jsx
@@ -1,13 +1,12 @@
-import { useParams } from "react-router-dom";
+import { useEffect } from "react";
+import { useParams, useSearchParams } from "react-router-dom";
 import { useApiGet } from "@/hooks/useApi";
 import { useFlashMessage } from "@/hooks/useFlashMessage";
-import { useSearchParams } from "react-router-dom";
 import NavBack from "@/components/NavBack";
 import LoadingBar from "@/components/LoadingBar";
 import SubArea from "@/components/ParkDetailsSubArea";
 import FlashMessage from "@/components/FlashMessage";
 import "./ParkDetails.scss";
-import { useEffect } from "react";
 
 // Returns an array of sub-area components
 function getSubAreas(park) {

--- a/frontend/src/router/pages/ParkDetails.jsx
+++ b/frontend/src/router/pages/ParkDetails.jsx
@@ -68,7 +68,7 @@ function ParkDetails() {
       "Dates approved",
       `${park.name} ${approvedFeature.featureType.name} ${approvedFeature.operatingYear} season dates marked approved`,
     );
-  });
+  }, [isFlashOpen, park, searchParams, setSearchParams, openFlashMessage]);
 
   return (
     <div className="page park-details">

--- a/frontend/src/router/pages/ParkDetails.jsx
+++ b/frontend/src/router/pages/ParkDetails.jsx
@@ -1,9 +1,13 @@
 import { useParams } from "react-router-dom";
 import { useApiGet } from "@/hooks/useApi";
+import { useFlashMessage } from "@/hooks/useFlashMessage";
+import { useSearchParams } from "react-router-dom";
 import NavBack from "@/components/NavBack";
 import LoadingBar from "@/components/LoadingBar";
 import SubArea from "@/components/ParkDetailsSubArea";
+import FlashMessage from "@/components/FlashMessage";
 import "./ParkDetails.scss";
+import { useEffect } from "react";
 
 // Returns an array of sub-area components
 function getSubAreas(park) {
@@ -18,6 +22,16 @@ function ParkDetails() {
   const { parkId } = useParams();
   const { data: park, loading, error } = useApiGet(`/parks/${parkId}`);
 
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const {
+    flashTitle,
+    flashMessage,
+    openFlashMessage,
+    handleFlashClose,
+    isFlashOpen,
+  } = useFlashMessage();
+
   function renderSubAreas() {
     if (loading) {
       return <LoadingBar />;
@@ -30,8 +44,42 @@ function ParkDetails() {
     return getSubAreas(park);
   }
 
+  // Show a flash message if the user just approved dates
+  useEffect(() => {
+    if (isFlashOpen) return;
+
+    let featureId = searchParams.get("approved");
+
+    if (!park || featureId === null) return;
+    featureId = Number(featureId);
+
+    // Remove the query string so the flash message won't show again
+    searchParams.delete("approved");
+    setSearchParams(searchParams);
+
+    // Find the feature in the park data by its ID
+    const allFeatures = Object.values(park.subAreas).flat();
+    const approvedFeature = allFeatures.find(
+      (feature) => feature.id === featureId,
+    );
+
+    if (!approvedFeature) return;
+
+    openFlashMessage(
+      "Dates approved",
+      `${park.name} ${approvedFeature.featureType.name} ${approvedFeature.operatingYear} season dates marked approved`,
+    );
+  });
+
   return (
     <div className="page park-details">
+      <FlashMessage
+        title={flashTitle}
+        message={flashMessage}
+        isVisible={isFlashOpen}
+        onClose={handleFlashClose}
+      />
+
       <NavBack routePath={"/"}>Back to Dates management</NavBack>
 
       <header className="page-header internal">

--- a/frontend/src/router/pages/PreviewChanges.jsx
+++ b/frontend/src/router/pages/PreviewChanges.jsx
@@ -120,12 +120,8 @@ function PreviewChanges() {
       notes,
       readyToPublish,
     });
-    setNotes("");
-    fetchData();
-    openFlashMessage(
-      "Dates approved",
-      `${data?.park.name} ${data?.featureType.name} ${data?.operatingYear} season dates mark approved`,
-    );
+
+    navigate(`/park/${parkId}?approved=${data.id}`);
   }
 
   function Feature({ feature }) {

--- a/frontend/src/router/pages/PreviewChanges.jsx
+++ b/frontend/src/router/pages/PreviewChanges.jsx
@@ -121,6 +121,8 @@ function PreviewChanges() {
       readyToPublish,
     });
 
+    // Redirect back to the Park Details page on success.
+    // Use the "approved" query param to show a flash message.
     navigate(`/park/${parkId}?approved=${data.id}`);
   }
 


### PR DESCRIPTION
### Jira Ticket

CMS-618

### Description
<!-- What did you change, and why? -->

Instead of staying on the Preview page when you approve dates, now it redirects to the Park Details page.

Most of the changes here were to move the flash message to the Park Details page. I used an "approved" query param and useEffect. I'm not sure I used the hook efficiently so let me know if you think of any improvements.
An improvement for a future version could be to make the flash message global in the layout so we can call it and still change routes. 