### PR TITLE
CMS-622: Update CSV export options and functions

### DIFF
--- a/backend/routes/api/export.js
+++ b/backend/routes/api/export.js
@@ -28,6 +28,11 @@ router.get(
       order: [["name", "ASC"]],
     });
 
+    const dateTypes = DateType.findAll({
+      attributes: ["id", "name"],
+      order: [["name", "ASC"]],
+    });
+
     const years = (
       await Season.findAll({
         attributes: [
@@ -44,6 +49,7 @@ router.get(
     res.json({
       years,
       featureTypes: await featureTypes,
+      dateTypes: await dateTypes,
     });
   }),
 );

--- a/backend/routes/api/export.js
+++ b/backend/routes/api/export.js
@@ -196,16 +196,8 @@ router.get(
     // Convert to CSV string
     const csv = await writeToString(sorted, { headers: true });
 
-    // Build filename
-    const displayType =
-      exportType === "bcp-only" ? "BCP reservations only" : "All dates";
-    const dateTypes = "All types"; // @TODO: Make this dynamic when the date type selection is implemented
-    // (CMS-622: "Operating", "Reservations", "Winter fees", "All types")
-    const filename = `${operatingYear} season - ${displayType} - ${dateTypes}.csv`;
-
     // Send CSV string as response
     res.setHeader("Content-Type", "text/csv");
-    res.setHeader("Content-Disposition", `attachment; filename="${filename}"`);
     res.setHeader("Content-Length", Buffer.byteLength(csv));
     res.send(csv);
   }),

--- a/backend/routes/api/export.js
+++ b/backend/routes/api/export.js
@@ -80,6 +80,7 @@ router.get(
     // Cast query param values as numbers
     const operatingYear = +req.query.year;
     const featureTypeIds = req.query.features?.map((id) => +id) ?? [];
+    const dateTypeIds = req.query.dateTypes?.map((id) => +id) ?? [];
 
     // Update WHERE clause based on query parameters
     const featuresWhere = {
@@ -158,6 +159,12 @@ router.get(
                   model: DateType,
                   as: "dateType",
                   attributes: ["id", "name"],
+                  where: {
+                    id: {
+                      [Op.in]: dateTypeIds,
+                    },
+                  },
+                  required: true,
                 },
               ],
             },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,6 +19,7 @@
         "classnames": "^2.5.1",
         "date-fns": "^4.1.0",
         "date-fns-tz": "^3.2.0",
+        "file-saver": "^2.0.5",
         "lodash": "^4.17.21",
         "oidc-client-ts": "^3.0.1",
         "prop-types": "^15.8.1",
@@ -3039,6 +3040,12 @@
       "engines": {
         "node": ">=16.0.0"
       }
+    },
+    "node_modules/file-saver": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.5.tgz",
+      "integrity": "sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA==",
+      "license": "MIT"
     },
     "node_modules/find-up": {
       "version": "5.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,7 @@
     "classnames": "^2.5.1",
     "date-fns": "^4.1.0",
     "date-fns-tz": "^3.2.0",
+    "file-saver": "^2.0.5",
     "lodash": "^4.17.21",
     "oidc-client-ts": "^3.0.1",
     "prop-types": "^15.8.1",

--- a/frontend/src/hooks/useApi.js
+++ b/frontend/src/hooks/useApi.js
@@ -50,8 +50,13 @@ export function useApiGet(endpoint, options = {}) {
       const response = await axiosInstance.get(endpoint, config);
 
       setData(response.data);
+
+      // Return the response (to use with instant=false)
+      return response.data;
     } catch (err) {
       setError(err);
+
+      throw err;
     } finally {
       setLoading(false);
     }
@@ -62,7 +67,7 @@ export function useApiGet(endpoint, options = {}) {
   useEffect(() => {
     // Prevent sending multiple requests
     if (instant && !requestSent.current) {
-      fetchData();
+      fetchData().catch((err) => console.error("fetchData error", err));
     }
   }, [fetchData, instant]);
 

--- a/frontend/src/hooks/useApi.js
+++ b/frontend/src/hooks/useApi.js
@@ -55,7 +55,6 @@ export function useApiGet(endpoint, options = {}) {
       return response.data;
     } catch (err) {
       setError(err);
-
       throw err;
     } finally {
       setLoading(false);

--- a/frontend/src/router/pages/ExportPage.jsx
+++ b/frontend/src/router/pages/ExportPage.jsx
@@ -54,31 +54,21 @@ function ExportPage() {
     }
   }
 
-  // Adds or removes a feature ID from the selection array
-  function onExportFeaturesChange(event) {
-    const { checked } = event.target;
-    const value = +event.target.value;
+  // Returns a function to handle checkbox group changes
+  function onCheckboxGroupChange(setter) {
+    // Adds or removes an value from the selection array
+    return function (event) {
+      const { checked } = event.target;
+      const value = +event.target.value;
 
-    setExportFeatures((prevFeatures) => {
-      if (checked) {
-        return [...prevFeatures, value];
-      }
+      setter((previousValues) => {
+        if (checked) {
+          return [...previousValues, value];
+        }
 
-      return prevFeatures.filter((feature) => feature !== value);
-    });
-  }
-  // Adds or removes a date type ID from the selection array
-  function onExportDateTypesChange(event) {
-    const { checked } = event.target;
-    const value = +event.target.value;
-
-    setExportDateTypes((prevTypes) => {
-      if (checked) {
-        return [...prevTypes, value];
-      }
-
-      return prevTypes.filter((feature) => feature !== value);
-    });
+        return previousValues.filter((feature) => feature !== value);
+      });
+    };
   }
 
   // Fetches the CSV as plain text, and then saves it as a file.
@@ -117,6 +107,9 @@ function ExportPage() {
         <LoadingBar />
       </div>
     );
+
+  const disableButton =
+    exportFeatures.length === 0 || exportDateTypes.length === 0 || generating;
 
   return (
     <div className="page export">
@@ -203,7 +196,7 @@ function ExportPage() {
                   id={`features-${feature.id}`}
                   value={feature.id}
                   checked={exportFeatures.includes(feature.id)}
-                  onChange={onExportFeaturesChange}
+                  onChange={onCheckboxGroupChange(setExportFeatures)}
                 />
                 <label
                   className="form-check-label"
@@ -226,7 +219,7 @@ function ExportPage() {
                   id={`date-types-${dateType.id}`}
                   value={dateType.id}
                   checked={exportDateTypes.includes(dateType.id)}
-                  onChange={onExportDateTypesChange}
+                  onChange={onCheckboxGroupChange(setExportDateTypes)}
                 />
                 <label
                   className="form-check-label"
@@ -241,7 +234,7 @@ function ExportPage() {
             <button
               role="button"
               className={classNames("btn btn-primary", {
-                disabled: exportFeatures.length === 0,
+                disabled: disableButton,
               })}
               onClick={getCsv}
             >

--- a/frontend/src/router/pages/ExportPage.jsx
+++ b/frontend/src/router/pages/ExportPage.jsx
@@ -29,13 +29,16 @@ function ExportPage() {
     if (options?.years) {
       setExportYear(options.years.at(-1));
     }
+  }, [options]);
 
-    // Initially select all feature types
+  // Selects every feature type's ID
+  function selectAllFeatures() {
     if (options?.featureTypes?.length) {
       setExportFeatures(options.featureTypes.map((feature) => feature.id));
     }
-  }, [options]);
+  }
 
+  // Adds or removes a feature ID from the selection array
   function onExportFeaturesChange(event) {
     const { checked } = event.target;
     const value = +event.target.value;
@@ -140,6 +143,25 @@ function ExportPage() {
           </fieldset>
           <fieldset className="section-spaced">
             <legend className="append-required">Park features</legend>
+
+            <div className="mb-2">
+              <button
+                onClick={selectAllFeatures}
+                type="button"
+                className="btn btn-text-primary"
+              >
+                Select all
+              </button>
+              |
+              <button
+                onClick={() => setExportFeatures([])}
+                type="button"
+                className="btn btn-text-primary"
+              >
+                Clear all
+              </button>
+            </div>
+
             {options.featureTypes.map((feature) => (
               <div className="form-check" key={feature.id}>
                 <input

--- a/frontend/src/router/pages/ExportPage.jsx
+++ b/frontend/src/router/pages/ExportPage.jsx
@@ -79,8 +79,16 @@ function ExportPage() {
       // Build filename
       const displayType =
         exportType === "bcp-only" ? "BCP reservations only" : "All dates";
-      const dateTypes = "All types"; // @TODO: Make this dynamic when the date type selection is implemented
-      // (CMS-622: "Operating", "Reservations", "Winter fees", "All types")
+
+      let dateTypes = "All types";
+
+      // If any date types are unselected, display a list
+      if (exportDateTypes.length < options.dateTypes.length) {
+        dateTypes = exportDateTypes
+          .map((id) => options.dateTypes.find((t) => t.id === id).name)
+          .join(", ");
+      }
+
       const filename = `${exportYear} season - ${displayType} - ${dateTypes}.csv`;
 
       // Convert CSV string to blob and save in the browser

--- a/frontend/src/router/pages/ExportPage.jsx
+++ b/frontend/src/router/pages/ExportPage.jsx
@@ -26,6 +26,7 @@ function ExportPage() {
     { value: "all", label: "All dates" },
     { value: "bcp-only", label: "BCP reservations only" },
   ];
+  const [exportDateTypes, setExportDateTypes] = useState([]);
   const [exportType, setExportType] = useState("all");
 
   const { generating, fetchData: fetchCsv } = useApiGet("/export/csv", {
@@ -34,6 +35,7 @@ function ExportPage() {
       type: exportType,
       year: exportYear,
       "features[]": exportFeatures,
+      "dateTypes[]": exportDateTypes,
     },
   });
 
@@ -63,6 +65,19 @@ function ExportPage() {
       }
 
       return prevFeatures.filter((feature) => feature !== value);
+    });
+  }
+  // Adds or removes a date type ID from the selection array
+  function onExportDateTypesChange(event) {
+    const { checked } = event.target;
+    const value = +event.target.value;
+
+    setExportDateTypes((prevTypes) => {
+      if (checked) {
+        return [...prevTypes, value];
+      }
+
+      return prevTypes.filter((feature) => feature !== value);
     });
   }
 
@@ -195,6 +210,29 @@ function ExportPage() {
                   htmlFor={`features-${feature.id}`}
                 >
                   {feature.name}
+                </label>
+              </div>
+            ))}
+          </fieldset>
+          <fieldset className="section-spaced">
+            <legend className="append-required">Type of date</legend>
+
+            {options.dateTypes.map((dateType) => (
+              <div className="form-check" key={dateType.id}>
+                <input
+                  className="form-check-input"
+                  type="checkbox"
+                  name="features"
+                  id={`date-types-${dateType.id}`}
+                  value={dateType.id}
+                  checked={exportDateTypes.includes(dateType.id)}
+                  onChange={onExportDateTypesChange}
+                />
+                <label
+                  className="form-check-label"
+                  htmlFor={`date-types-${dateType.id}`}
+                >
+                  {dateType.name}
                 </label>
               </div>
             ))}


### PR DESCRIPTION
### Jira Ticket

CMS-622 (Implements small changes)
CMS-348 (Also fixes regressions that broke this one)

### Description
<!-- What did you change, and why? -->

We were just navigating straight to an API endpoint to get the CSV, and I forgot that the auth token check would break that.
This branch implements some small changes to the CSV export page:
- Don't pre-select all feature types
- Add "Select all/none" buttons
- Add selection for the date type: Operating, Reservation, Winter

...and it also changes how the PDF is requested:
- The API returns the CSV text, but without the "attachment" disposition header or the filename
- Filename is constructed on the frontend
- The frontend receives the data and downloads it as a blob with the computed filename

To allow that, I tweaked the API hook's `fetchData` method to return the response data so you don't have to make a useEffect hook when you're using `instant: false` mode to make requests on demand like we are here. (Almost exactly the pattern we're using for the POST method with `sendData`)
