### PR TITLE
CMS-622: Use display names for date types on Export page

### DIFF
--- a/backend/routes/api/export.js
+++ b/backend/routes/api/export.js
@@ -19,6 +19,17 @@ import {
 
 const router = Router();
 
+// Map date type names to a different name for display
+const dateTypeDisplayNames = new Map([
+  ["Operation", "Operating"],
+  // "Reservation" displays as-is
+]);
+
+// Returns a display string for a date type
+function getDateTypeDisplay(dateType) {
+  return dateTypeDisplayNames.get(dateType) ?? dateType;
+}
+
 // Get options for the export form
 router.get(
   "/options",
@@ -31,7 +42,13 @@ router.get(
     const dateTypes = DateType.findAll({
       attributes: ["id", "name"],
       order: [["name", "ASC"]],
-    });
+    }).then((dateTypesArray) =>
+      // Update display names for date types
+      dateTypesArray.map((dateType) => ({
+        id: dateType.id,
+        name: getDateTypeDisplay(dateType.name),
+      })),
+    );
 
     const years = (
       await Season.findAll({
@@ -188,7 +205,7 @@ router.get(
         "Sub-Area": feature.name,
         "Sub-Area Type (Park feature)": feature.featureType.name,
         "Operating Year": dateRange.season.operatingYear,
-        "Type of date": dateRange.dateType.name,
+        "Type of date": getDateTypeDisplay(dateRange.dateType.name),
         "Start date": formatDate(dateRange.startDate),
         "End date": formatDate(dateRange.endDate),
         Status: dateRange.season.status,

--- a/backend/strapi-sync/sync.js
+++ b/backend/strapi-sync/sync.js
@@ -258,7 +258,7 @@ export async function createDateTypes() {
       description: "Dates where reservations are available.",
     },
     {
-      name: "Off Season",
+      name: "Winter fees",
       startDateLabel: "Winter start date",
       endDateLabel: "Winter end date",
       description: "Reduced services and reduced legislated winter fees.",


### PR DESCRIPTION
### Jira Ticket

CMS-622

### Description
<!-- What did you change, and why? -->

A quick fix to update the display name for the DateTypes on the CSV page (and in the CSV file). 
In the future, we can update the values in the DB but for now let's just translate the values on the frontend until the values are finalized.

I updated the name for "Winter fees" in the sync script; rather than re-running it, I'm just going to update the value in AdminJS on Alpha-Dev/Alpha-Test/etc.