### PR TITLE
CMS-467: Add winter dates to Park Details page

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -11,6 +11,7 @@ import homeRoutes from "./routes/home.js";
 import parkRoutes from "./routes/api/parks.js";
 import seasonRoutes from "./routes/api/seasons.js";
 import exportRoutes from "./routes/api/export.js";
+import winterFeesRoutes from "./routes/api/winterFees.js";
 
 if (!process.env.POSTGRES_SERVER || !process.env.ADMIN_PASSWORD) {
   throw new Error("Required environment variables are not set");
@@ -58,6 +59,7 @@ const apiRouter = express.Router();
 apiRouter.use("/parks", parkRoutes);
 apiRouter.use("/seasons", seasonRoutes);
 apiRouter.use("/export", exportRoutes);
+apiRouter.use("/winter-fees", winterFeesRoutes);
 
 app.use("/api", checkJwt, apiRouter);
 

--- a/backend/routes/api/parks.js
+++ b/backend/routes/api/parks.js
@@ -147,10 +147,19 @@ router.get(
       (group) => _.orderBy(group, ["operatingYear"], ["desc"]),
     );
 
+    const winterFees = [];
+
+    // move winter fees to the root object
+    // so the frontend can treat it differently
+    if ("Winter fees" in subAreas) {
+      winterFees.push(...subAreas["Winter fees"]);
+      delete subAreas["Winter fees"];
+    }
+
     // remove unused season key
     delete parkJson.seasons;
 
-    res.json({ ...parkJson, subAreas });
+    res.json({ ...parkJson, subAreas, winterFees });
   }),
 );
 

--- a/backend/routes/api/winterFees.js
+++ b/backend/routes/api/winterFees.js
@@ -119,7 +119,7 @@ router.get(
     });
 
     // Split the season IDs into winter and non-winter
-    const { winterSeasons, nonWinterSeasons } = _.groupBy(
+    const { winterSeasons = [], nonWinterSeasons = [] } = _.groupBy(
       seasonIdRows,
       (row) =>
         row.featureType.id === winterFeeFeatureTypeId
@@ -128,7 +128,7 @@ router.get(
     );
 
     // Split the non-winter season Ids into current and previous years
-    const { currentSeasons, previousSeasons } = _.groupBy(
+    const { currentSeasons = [], previousSeasons = [] } = _.groupBy(
       nonWinterSeasons,
       (row) =>
         row.operatingYear === currentYear
@@ -172,8 +172,6 @@ router.get(
 
     // Organize the features into the FeatureType->Campground->Feature hierarchy
     const featureTypes = currentSeasons.map((season) => {
-      console.log("\n\nseason", season.toJSON());
-
       // Attach date ranges to features
       const features = season.featureType.features.map((feature) => {
         const featureDateRanges = dateRanges.filter(
@@ -195,7 +193,13 @@ router.get(
 
         return {
           ...feature.toJSON(),
-          dateRanges: groupedSeasonDates,
+
+          // Make sure the grouped dates object has both keys
+          dateRanges: {
+            currentSeasonDates: [],
+            previousSeasonDates: [],
+            ...groupedSeasonDates,
+          },
         };
       });
 
@@ -210,7 +214,6 @@ router.get(
         name: season.featureType.name,
         icon: season.featureType.icon,
         campgrounds,
-        // features,
       };
     });
 

--- a/backend/routes/api/winterFees.js
+++ b/backend/routes/api/winterFees.js
@@ -1,0 +1,230 @@
+import { Router } from "express";
+import {
+  Park,
+  Season,
+  FeatureType,
+  Feature,
+  DateType,
+  DateRange,
+  SeasonChangeLog,
+  User,
+  Campground,
+} from "../../models/index.js";
+import asyncHandler from "express-async-handler";
+import { Op, Sequelize } from "sequelize";
+import _ from "lodash";
+
+const router = Router();
+
+// Look up the winter fees "season" by its ID
+router.get(
+  "/:seasonId",
+  asyncHandler(async (req, res) => {
+    const { seasonId } = req.params;
+
+    // Get IDs related to the winter fees season
+    const winterSeasonDetails = await Season.findByPk(seasonId, {
+      attributes: ["id", "operatingYear", "status", "readyToPublish"],
+      include: [
+        {
+          model: FeatureType,
+          as: "featureType",
+          attributes: ["id", "name", "icon"],
+        },
+        {
+          model: Park,
+          as: "park",
+          attributes: ["id", "name", "orcs"],
+        },
+        {
+          model: SeasonChangeLog,
+          as: "changeLogs",
+          attributes: ["id", "notes", "createdAt"],
+          // Filter out empty notes
+          where: {
+            notes: {
+              [Op.ne]: "",
+            },
+          },
+          required: false,
+          order: [["createdAt", "DESC"]],
+          include: [
+            {
+              model: User,
+              as: "user",
+              attributes: ["id", "name"],
+            },
+          ],
+        },
+      ],
+    });
+
+    if (!winterSeasonDetails) {
+      const error = new Error("Winter fee season not found");
+
+      error.status = 404;
+      throw error;
+    }
+
+    const parkId = winterSeasonDetails.park.id;
+    const winterFeeFeatureTypeId = winterSeasonDetails.featureType.id;
+    const currentYear = winterSeasonDetails.operatingYear;
+    const previousYear = currentYear - 1;
+
+    // Get all the Park's Seasons for the operating year and the previous year
+    const seasonIdRows = await Season.findAll({
+      attributes: ["id", "operatingYear"],
+
+      where: {
+        parkId,
+
+        // @TODO: filter on a flag, TBD: "hasWinterFees"
+
+        // Fetch this operating year,  and the previous year
+        operatingYear: {
+          [Op.in]: [currentYear, previousYear],
+        },
+      },
+
+      order: [[Sequelize.col("featureType.name"), "ASC"]],
+
+      include: [
+        {
+          model: FeatureType,
+          as: "featureType",
+          attributes: ["id", "name", "icon"],
+
+          include: [
+            {
+              model: Feature,
+              as: "features",
+              attributes: ["id", "name", "featureTypeId", "dateableId"],
+              where: {
+                parkId,
+                active: true,
+              },
+              required: false,
+
+              include: [
+                {
+                  model: Campground,
+                  as: "campground",
+                  attributes: ["id", "name"],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    // Split the season IDs into winter and non-winter
+    const { winterSeasons, nonWinterSeasons } = _.groupBy(
+      seasonIdRows,
+      (row) =>
+        row.featureType.id === winterFeeFeatureTypeId
+          ? "winterSeasons"
+          : "nonWinterSeasons",
+    );
+
+    // Split the non-winter season Ids into current and previous years
+    const { currentSeasons, previousSeasons } = _.groupBy(
+      nonWinterSeasons,
+      (row) =>
+        row.operatingYear === currentYear
+          ? "currentSeasons"
+          : "previousSeasons",
+    );
+    const currentSeasonIds = currentSeasons.map((row) => row.id);
+    const previousSeasonIds = previousSeasons.map((row) => row.id);
+    const currentWinterSeasonId = Number(seasonId);
+    const previousWinterSeasonId = winterSeasons
+      .map((row) => row.id)
+      .find((id) => id !== currentWinterSeasonId);
+
+    // Get dates for all the current and previous (non-winter) seasons
+    const dateableIds = nonWinterSeasons.flatMap((row) =>
+      row.featureType.features.map((feature) => feature.dateableId),
+    );
+    const dateRanges = await DateRange.findAll({
+      where: {
+        dateableId: {
+          [Op.in]: dateableIds,
+        },
+        seasonId: {
+          [Op.in]: [
+            currentWinterSeasonId,
+            previousWinterSeasonId,
+            ...currentSeasonIds,
+            ...previousSeasonIds,
+          ],
+        },
+      },
+
+      include: [
+        {
+          model: DateType,
+          as: "dateType",
+          attributes: ["id", "name", "description"],
+        },
+      ],
+    });
+
+    // Organize the features into the FeatureType->Campground->Feature hierarchy
+    const featureTypes = currentSeasons.map((season) => {
+      console.log("\n\nseason", season.toJSON());
+
+      // Attach date ranges to features
+      const features = season.featureType.features.map((feature) => {
+        const featureDateRanges = dateRanges.filter(
+          (dateRange) => dateRange.dateableId === feature.dateableId,
+        );
+
+        // Group date ranges into current and previous seasons
+        const groupedSeasonDates = _.groupBy(featureDateRanges, (dateRange) => {
+          if (
+            [currentWinterSeasonId, ...currentSeasonIds].includes(
+              dateRange.seasonId,
+            )
+          ) {
+            return "currentSeasonDates";
+          }
+
+          return "previousSeasonDates";
+        });
+
+        return {
+          ...feature.toJSON(),
+          dateRanges: groupedSeasonDates,
+        };
+      });
+
+      // Group features by campground
+      const campgrounds = _.groupBy(
+        features,
+        (feature) => feature.campground?.name ?? "All sites",
+      );
+
+      return {
+        id: season.featureType.id,
+        name: season.featureType.name,
+        icon: season.featureType.icon,
+        campgrounds,
+        // features,
+      };
+    });
+
+    res.json({
+      name: `${currentYear} – ${currentYear + 1}`,
+      id: currentWinterSeasonId,
+      operatingYear: currentYear,
+      featureTypes,
+      changeLogs: winterSeasonDetails.changeLogs,
+      park: winterSeasonDetails.park,
+      status: winterSeasonDetails.status,
+      readyToPublish: winterSeasonDetails.readyToPublish,
+    });
+  }),
+);
+
+export default router;

--- a/frontend/src/components/ExpandableContent.jsx
+++ b/frontend/src/components/ExpandableContent.jsx
@@ -1,0 +1,39 @@
+import LoadingBar from "@/components/LoadingBar";
+import PropTypes from "prop-types";
+
+export default function ExpandableContent({
+  expanded,
+  loading,
+  error,
+  errorMsg = "Error loading dates: ",
+  children,
+}) {
+  if (!expanded) return null;
+
+  if (loading)
+    return (
+      <div className="p-3 pt-0">
+        <LoadingBar />
+      </div>
+    );
+
+  if (error)
+    return (
+      <p className="px-3">
+        {errorMsg}
+        {error.message}
+      </p>
+    );
+
+  return children;
+}
+
+ExpandableContent.propTypes = {
+  expanded: PropTypes.bool.isRequired,
+  loading: PropTypes.bool.isRequired,
+  error: PropTypes.shape({
+    message: PropTypes.string.isRequired,
+  }),
+  errorMsg: PropTypes.string,
+  children: PropTypes.node,
+};

--- a/frontend/src/components/ParkDetailsWinterFees.jsx
+++ b/frontend/src/components/ParkDetailsWinterFees.jsx
@@ -8,16 +8,14 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { formatDate } from "@/lib/utils";
 import { useApiGet } from "@/hooks/useApi";
 import ExpandableContent from "@/components/ExpandableContent";
+import FeatureIcon from "@/components/FeatureIcon";
 import NotReadyFlag from "@/components/NotReadyFlag";
-import SeasonDates from "@/components/ParkDetailsSeasonDates";
 import StatusBadge from "@/components/StatusBadge";
+import WinterFeesDates from "@/components/ParkDetailsWinterFeesDates";
 
-import { useConfirmation } from "@/hooks/useConfirmation";
-import ConfirmationDialog from "@/components/ConfirmationDialog";
-
-export default function ParkSeason({ season }) {
-  const { parkId } = useParams();
+function WinterSeason({ season }) {
   const navigate = useNavigate();
+  const { parkId } = useParams();
 
   const [expanded, setExpanded] = useState(false);
 
@@ -26,18 +24,15 @@ export default function ParkSeason({ season }) {
     loading,
     error,
     fetchData,
-  } = useApiGet(`/seasons/${season.id}`, {
+  } = useApiGet(`/winter-fees/${season.id}`, {
     instant: false,
   });
 
-  const {
-    title,
-    message,
-    openConfirmation,
-    handleConfirm,
-    handleCancel,
-    isConfirmationOpen,
-  } = useConfirmation();
+  // @TODO: implement logic to show/hide preview button
+  const showPreviewButton = true;
+
+  // @TODO: implement logic to disable preview button
+  const disablePreviewButton = true;
 
   function toggleExpand(event) {
     // Prevent button click events from bubbling up to the clickable parent
@@ -51,64 +46,23 @@ export default function ParkSeason({ season }) {
     setExpanded(!expanded);
   }
 
-  // @TODO: implement logic to show/hide preview button
-  const showPreviewButton = true;
-
-  // @TODO: implement logic to disable preview button
-  const disablePreviewButton = true;
-
-  const updateDate = formatDate(season.updatedAt, "America/Vancouver");
-
-  async function navigateToEdit() {
-    if (season.status === "pending review") {
-      const confirm = await openConfirmation(
-        "Edit submitted dates?",
-        "A review may already be in progress and all dates will need to be reviewed again.",
-      );
-
-      if (confirm) {
-        navigate(`/park/${parkId}/edit/${season.id}`);
-      }
-    } else if (season.status === "approved") {
-      const confirm = await openConfirmation(
-        "Edit approved dates?",
-        "Dates will need to be reviewed again to be approved.",
-      );
-
-      if (confirm) {
-        navigate(`/park/${parkId}/edit/${season.id}`);
-      }
-    } else if (season.status === "published") {
-      const confirm = openConfirmation(
-        "Edit published dates?",
-        "Dates will need to be reviewed again to be approved and published. If reservations have already begun, visitors will be affected.",
-      );
-
-      if (confirm) {
-        navigate(`/park/${parkId}/edit/${season.id}`);
-      }
-    } else {
-      navigate(`/park/${parkId}/edit/${season.id}`);
-    }
+  function navigateToEdit() {
+    navigate(`/park/${parkId}/winter-fees/${season.id}/edit`);
   }
 
   function navigateToPreview() {
-    navigate(`/park/${parkId}/edit/${season.id}/preview`);
+    navigate(`/park/${parkId}/winter-fees/${season.id}/preview`);
   }
 
+  const updateDate = formatDate(season.updatedAt, "America/Vancouver");
+
+  const title = `${season.operatingYear} – ${season.operatingYear + 1}`;
+
   return (
-    <div className={classNames("season expandable", { expanded })}>
-      <ConfirmationDialog
-        title={title}
-        message={message}
-        notes=""
-        onCancel={handleCancel}
-        onConfirm={handleConfirm}
-        isOpen={isConfirmationOpen}
-      />
+    <div className={classNames("winter-fees season expandable", { expanded })}>
       <div className={classNames("details", { expanded })}>
         <header role="button" onClick={toggleExpand}>
-          <h3>{season.operatingYear} season</h3>
+          <h3>{title}</h3>
 
           <StatusBadge status={season.status} />
           <NotReadyFlag show={!season.readyToPublish} />
@@ -126,7 +80,7 @@ export default function ParkSeason({ season }) {
         </header>
 
         <ExpandableContent expanded={expanded} loading={loading} error={error}>
-          <SeasonDates data={datesData} />
+          <WinterFeesDates data={datesData} />
         </ExpandableContent>
       </div>
 
@@ -159,12 +113,40 @@ export default function ParkSeason({ season }) {
 }
 
 // prop validation
-ParkSeason.propTypes = {
+WinterSeason.propTypes = {
   season: PropTypes.shape({
     id: PropTypes.number.isRequired,
     operatingYear: PropTypes.number.isRequired,
     status: PropTypes.string.isRequired,
     updatedAt: PropTypes.string.isRequired,
     readyToPublish: PropTypes.bool.isRequired,
-  }),
+  }).isRequired,
+};
+
+export default function WinterFees({ data }) {
+  return (
+    <section className="winter-fees">
+      <h2>
+        <FeatureIcon iconName="winter-recreation" />
+        Winter fees
+      </h2>
+
+      {data.map((season) => (
+        <WinterSeason key={season.id} season={season} />
+      ))}
+    </section>
+  );
+}
+
+// prop validation
+WinterFees.propTypes = {
+  data: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.number.isRequired,
+      operatingYear: PropTypes.number.isRequired,
+      status: PropTypes.string.isRequired,
+      updatedAt: PropTypes.string.isRequired,
+      readyToPublish: PropTypes.bool.isRequired,
+    }),
+  ).isRequired,
 };

--- a/frontend/src/components/ParkDetailsWinterFeesDates.jsx
+++ b/frontend/src/components/ParkDetailsWinterFeesDates.jsx
@@ -20,7 +20,7 @@ function DateTypeRow({ dateTypeName, dateRanges }) {
 }
 
 // "Dateable" features: Campsite groupings, etc.
-function CampGroundFeature({ feature }) {
+function CampGroundFeature({ feature, campgroundName }) {
   const currentSeasonDates = feature?.dateRanges?.currentSeasonDates;
 
   if (!currentSeasonDates) return null;
@@ -36,9 +36,19 @@ function CampGroundFeature({ feature }) {
 
   if (!winterFeesDates) return null;
 
+  let headerText = "";
+
+  if (campgroundName !== "All sites" && feature.name !== "All sites") {
+    headerText = `${campgroundName}: ${feature.name}`;
+  } else if (campgroundName !== "All sites") {
+    headerText = campgroundName;
+  } else if (feature.name !== "All sites") {
+    headerText = feature.name;
+  }
+
   return (
     <div className="feature">
-      <h5>{feature.name}</h5>
+      <h4>{headerText}</h4>
 
       <table className="table table-striped sub-area-dates mb-0">
         <tbody>
@@ -65,10 +75,12 @@ export default function SeasonDates({ data }) {
             {Object.entries(featureType.campgrounds).map(
               ([campgroundName, features]) => (
                 <div key={campgroundName} className="campground mb-4">
-                  {campgroundName !== "All sites" && <h4>{campgroundName}</h4>}
-
                   {features.map((feature) => (
-                    <CampGroundFeature key={feature.id} feature={feature} />
+                    <CampGroundFeature
+                      key={feature.id}
+                      campgroundName={campgroundName}
+                      feature={feature}
+                    />
                   ))}
                 </div>
               ),
@@ -122,6 +134,7 @@ SeasonDates.propTypes = {
 };
 
 CampGroundFeature.propTypes = {
+  campgroundName: PropTypes.string.isRequired,
   feature: campgroundFeaturePropShape,
 };
 

--- a/frontend/src/components/ParkDetailsWinterFeesDates.jsx
+++ b/frontend/src/components/ParkDetailsWinterFeesDates.jsx
@@ -1,0 +1,131 @@
+import groupBy from "lodash/groupBy";
+import PropTypes from "prop-types";
+import DateRange from "@/components/DateRange";
+import ChangeLogsList from "@/components/ChangeLogsList.jsx";
+import FeatureIcon from "@/components/FeatureIcon";
+
+import "./ParkDetailsWinterFeesDates.scss";
+
+function DateTypeRow({ dateTypeName, dateRanges }) {
+  return (
+    <tr>
+      <td>{dateTypeName} dates</td>
+      <td>
+        {dateRanges.map((date) => (
+          <DateRange key={date.id} start={date.startDate} end={date.endDate} />
+        ))}
+      </td>
+    </tr>
+  );
+}
+
+// "Dateable" features: Campsite groupings, etc.
+function CampGroundFeature({ feature }) {
+  const currentSeasonDates = feature?.dateRanges?.currentSeasonDates;
+
+  if (!currentSeasonDates) return null;
+
+  // Group current season dates by date type
+  const groupedDates = groupBy(
+    currentSeasonDates,
+    (dateType) => dateType.dateType.name,
+  );
+
+  // Show only winter fees dates
+  const winterFeesDates = groupedDates?.["Winter fees"];
+
+  if (!winterFeesDates) return null;
+
+  return (
+    <div className="feature">
+      <h5>{feature.name}</h5>
+
+      <table className="table table-striped sub-area-dates mb-0">
+        <tbody>
+          <DateTypeRow
+            dateTypeName="Winter fees"
+            dateRanges={winterFeesDates}
+          />
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export default function SeasonDates({ data }) {
+  return (
+    <div className="park-details-winter-fees-dates details-content">
+      <div className="winter-fee-seasons">
+        {data.featureTypes.map((featureType) => (
+          <div key={featureType.id} className="winter-fees-season mb-4">
+            <h3 className="header-with-icon">
+              <FeatureIcon iconName={featureType.icon} />
+              {featureType.name}
+            </h3>
+            {Object.entries(featureType.campgrounds).map(
+              ([campgroundName, features]) => (
+                <div key={campgroundName} className="campground mb-4">
+                  {campgroundName !== "All sites" && <h4>{campgroundName}</h4>}
+
+                  {features.map((feature) => (
+                    <CampGroundFeature key={feature.id} feature={feature} />
+                  ))}
+                </div>
+              ),
+            )}
+          </div>
+        ))}
+      </div>
+
+      {data.changeLogs.length > 0 && (
+        <div className="notes">
+          <h4>Notes</h4>
+          <ChangeLogsList changeLogs={data.changeLogs} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+// prop validation
+const dateRangePropShape = PropTypes.shape({
+  id: PropTypes.number.isRequired,
+  startDate: PropTypes.string,
+  endDate: PropTypes.string,
+  dateType: PropTypes.shape({
+    name: PropTypes.string.isRequired,
+  }).isRequired,
+});
+
+const campgroundFeaturePropShape = PropTypes.shape({
+  id: PropTypes.number.isRequired,
+  name: PropTypes.string.isRequired,
+  dateRanges: PropTypes.shape({
+    currentSeasonDates: PropTypes.arrayOf(dateRangePropShape),
+  }),
+});
+
+SeasonDates.propTypes = {
+  data: PropTypes.shape({
+    featureTypes: PropTypes.arrayOf(
+      PropTypes.shape({
+        id: PropTypes.number.isRequired,
+        name: PropTypes.string.isRequired,
+        icon: PropTypes.string.isRequired,
+        campgrounds: PropTypes.objectOf(
+          PropTypes.arrayOf(campgroundFeaturePropShape),
+        ).isRequired,
+      }),
+    ).isRequired,
+    changeLogs: PropTypes.array.isRequired,
+  }),
+};
+
+CampGroundFeature.propTypes = {
+  feature: campgroundFeaturePropShape,
+};
+
+DateTypeRow.propTypes = {
+  dateTypeName: PropTypes.string.isRequired,
+  dateRanges: PropTypes.arrayOf(dateRangePropShape),
+};

--- a/frontend/src/components/ParkDetailsWinterFeesDates.scss
+++ b/frontend/src/components/ParkDetailsWinterFeesDates.scss
@@ -1,0 +1,11 @@
+.park-details-winter-fees-dates {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+
+  .notes {
+    p:last-child {
+      margin-bottom: 0;
+    }
+  }
+}

--- a/frontend/src/router/index.jsx
+++ b/frontend/src/router/index.jsx
@@ -6,7 +6,9 @@ import PublishPage from "./pages/PublishPage";
 import ExportPage from "./pages/ExportPage";
 import ParkDetails from "./pages/ParkDetails";
 import SubmitDates from "./pages/SubmitDates";
+import SubmitWinterFeesDates from "./pages/SubmitWinterFeesDates";
 import PreviewChanges from "./pages/PreviewChanges";
+import PreviewWinterFeesChanges from "./pages/PreviewWinterFeesChanges";
 import MainLayout from "./layouts/MainLayout";
 import LandingPageTabs from "./layouts/LandingPageTabs";
 import ErrorPage from "./pages/Error";
@@ -71,6 +73,18 @@ const RouterConfig = createBrowserRouter(
         {
           path: "/park/:parkId/edit/:seasonId/preview",
           element: <PreviewChanges />,
+        },
+
+        // edit/submit winter fees dates
+        {
+          path: "/park/:parkId/winter-fees/:seasonId/edit",
+          element: <SubmitWinterFeesDates />,
+        },
+
+        // review winter fees dates
+        {
+          path: "/park/:parkId/winter-fees/:seasonId/preview",
+          element: <PreviewWinterFeesChanges />,
         },
       ],
     },

--- a/frontend/src/router/pages/ParkDetails.jsx
+++ b/frontend/src/router/pages/ParkDetails.jsx
@@ -5,17 +5,9 @@ import { useFlashMessage } from "@/hooks/useFlashMessage";
 import NavBack from "@/components/NavBack";
 import LoadingBar from "@/components/LoadingBar";
 import SubArea from "@/components/ParkDetailsSubArea";
+import WinterFees from "@/components/ParkDetailsWinterFees";
 import FlashMessage from "@/components/FlashMessage";
 import "./ParkDetails.scss";
-
-// Returns an array of sub-area components
-function getSubAreas(park) {
-  if (!park) return [];
-
-  return Object.entries(park.subAreas).map(([title, subAreaSeason]) => (
-    <SubArea key={title} title={title} seasons={subAreaSeason} />
-  ));
-}
 
 function ParkDetails() {
   const { parkId } = useParams();
@@ -30,18 +22,6 @@ function ParkDetails() {
     handleFlashClose,
     isFlashOpen,
   } = useFlashMessage();
-
-  function renderSubAreas() {
-    if (loading) {
-      return <LoadingBar />;
-    }
-
-    if (error) {
-      return <p>Error loading parks data: {error.message}</p>;
-    }
-
-    return getSubAreas(park);
-  }
 
   // Show a flash message if the user just approved dates
   useEffect(() => {
@@ -70,6 +50,14 @@ function ParkDetails() {
     );
   }, [isFlashOpen, park, searchParams, setSearchParams, openFlashMessage]);
 
+  if (loading) {
+    return <LoadingBar />;
+  }
+
+  if (error) {
+    return <p>Error loading parks data: {error.message}</p>;
+  }
+
   return (
     <div className="page park-details">
       <FlashMessage
@@ -85,7 +73,11 @@ function ParkDetails() {
         <h1>{park?.name}</h1>
       </header>
 
-      {renderSubAreas()}
+      {Object.entries(park.subAreas).map(([title, subAreaSeasons]) => (
+        <SubArea key={title} title={title} seasons={subAreaSeasons} />
+      ))}
+
+      <WinterFees data={park.winterFees} />
     </div>
   );
 }

--- a/frontend/src/router/pages/ParkDetails.scss
+++ b/frontend/src/router/pages/ParkDetails.scss
@@ -1,5 +1,6 @@
 .page.park-details {
-  .sub-area {
+  .sub-area,
+  .winter-fees {
     &:not(:last-of-type) {
       margin-bottom: var(--layout-margin-xxlarge);
     }
@@ -15,7 +16,7 @@
     }
   }
 
-  .season {
+  .expandable {
     display: flex;
     flex-direction: column-reverse;
     margin-bottom: var(--layout-margin-medium);

--- a/frontend/src/router/pages/PreviewWinterFeesChanges.jsx
+++ b/frontend/src/router/pages/PreviewWinterFeesChanges.jsx
@@ -1,0 +1,15 @@
+import { useParams } from "react-router-dom";
+
+export default function SubmitWinterFeesDates() {
+  const { seasonId } = useParams();
+
+  return (
+    <div className="page preview-winter-fees-changes">
+      <p>Preview winter fees changes page</p>
+
+      <p>
+        Winter fee season ID: <code>{seasonId}</code>
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/router/pages/SubmitWinterFeesDates.jsx
+++ b/frontend/src/router/pages/SubmitWinterFeesDates.jsx
@@ -1,0 +1,15 @@
+import { useParams } from "react-router-dom";
+
+export default function SubmitWinterFeesDates() {
+  const { seasonId } = useParams();
+
+  return (
+    <div className="page submit-winter-fees-dates">
+      <p>Submit winter fees dates page</p>
+
+      <p>
+        Winter fee season ID: <code>{seasonId}</code>
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -128,5 +128,5 @@ label.form-check-label {
 .header-with-icon {
   display: flex;
   align-items: center;
-  gap: 0.25em;
+  gap: 0.5em;
 }

--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -123,3 +123,10 @@ label.form-check-label {
     transform: rotate(180deg);
   }
 }
+
+// styles for header elements with icons
+.header-with-icon {
+  display: flex;
+  align-items: center;
+  gap: 0.25em;
+}


### PR DESCRIPTION
### Jira Ticket

CMS-467

### Description
<!-- What did you change, and why? -->

The first of several branches to implement the Winter Fees Dates. This adds the GET endpoint to return a "Winter Fees Season" with all of its feature types / campgrounds / features and changelogs.

On the frontend, it adds the winter fees to the Park Details page, and placeholders for the "Submit" and "Preview" pages.

I manually added some winter seasons/dates/changelogs to my DB to develop it. We'll have to add a mechanism for filtering non-applicable seasons/features that don't have winter dates. (Right now it just shows everything)

<img width="964" alt="image" src="https://github.com/user-attachments/assets/4994b759-41af-4017-954e-83f0b9f76de0" />