### PR TITLE
CMS-467: Add endpoint to get winter season and import winter dates

### DIFF
--- a/backend/import-all-data.sh
+++ b/backend/import-all-data.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Exit immediately if any command fails
+set -e
+
+# Run commands sequentially
+npx sequelize-cli db:drop
+npx sequelize-cli db:create
+npm run migrate
+npm run sync-data
+npm run one-time-data-import
+npm run create-single-item-campgrounds
+npm run create-multiple-item-campgrounds
+
+echo "All commands executed successfully."

--- a/backend/index.js
+++ b/backend/index.js
@@ -10,6 +10,7 @@ import { admin, adminRouter, sessionMiddleware } from "./middleware/adminJs.js";
 import homeRoutes from "./routes/home.js";
 import parkRoutes from "./routes/api/parks.js";
 import seasonRoutes from "./routes/api/seasons.js";
+import winterSeasonRoutes from "./routes/api/winter-seasons.js";
 import exportRoutes from "./routes/api/export.js";
 
 if (!process.env.POSTGRES_SERVER || !process.env.ADMIN_PASSWORD) {
@@ -58,6 +59,7 @@ const apiRouter = express.Router();
 apiRouter.use("/parks", parkRoutes);
 apiRouter.use("/seasons", seasonRoutes);
 apiRouter.use("/export", exportRoutes);
+apiRouter.use("/winter-fees", winterSeasonRoutes);
 
 app.use("/api", checkJwt, apiRouter);
 

--- a/backend/migrations/20250130212845-add-has-winter-fees-dates-field.js
+++ b/backend/migrations/20250130212845-add-has-winter-fees-dates-field.js
@@ -1,0 +1,16 @@
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    // add hasWinterFeeDates field to Feature
+    await queryInterface.addColumn("Features", "hasWinterFeeDates", {
+      type: Sequelize.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    // remove hasWinterFeeDates field from Feature
+    await queryInterface.removeColumn("Features", "hasWinterFeeDates");
+  },
+};

--- a/backend/models/feature.js
+++ b/backend/models/feature.js
@@ -36,6 +36,7 @@ export default (sequelize) => {
       campgroundId: DataTypes.INTEGER,
       active: DataTypes.BOOLEAN,
       strapiId: DataTypes.INTEGER,
+      hasWinterFeeDates: DataTypes.BOOLEAN,
     },
     {
       sequelize,

--- a/backend/routes/api/winter-seasons.js
+++ b/backend/routes/api/winter-seasons.js
@@ -1,0 +1,201 @@
+import { Router } from "express";
+import asyncHandler from "express-async-handler";
+import { Op } from "sequelize";
+
+import {
+  Park,
+  Season,
+  FeatureType,
+  Feature,
+  DateType,
+  DateRange,
+  SeasonChangeLog,
+  User,
+  Campground,
+  Dateable,
+} from "../../models/index.js";
+
+function getFeatureName(feature) {
+  // if feature has a campground, and feature.name is "All sites", return campground name
+  // if feature has a campground, and feature.name is not "All sites", return "campgroundName: feature.name"
+  // if feature does not have a campground, return feature.name
+  const { campground, name } = feature;
+
+  if (campground) {
+    return name === "All sites"
+      ? campground.name
+      : `${campground.name}: ${name}`;
+  }
+
+  return name;
+}
+
+const router = Router();
+
+router.get(
+  "/:seasonId",
+  asyncHandler(async (req, res) => {
+    const { seasonId } = req.params;
+
+    const winterSeasonDetails = await Season.findByPk(seasonId, {
+      attributes: ["id", "operatingYear", "status", "readyToPublish"],
+      include: [
+        {
+          model: FeatureType,
+          as: "featureType",
+          attributes: ["id", "name", "icon"],
+        },
+        {
+          model: Park,
+          as: "park",
+          attributes: ["id", "name", "orcs"],
+        },
+        {
+          model: SeasonChangeLog,
+          as: "changeLogs",
+          attributes: ["id", "notes", "createdAt"],
+          // Filter out empty notes
+          where: {
+            notes: {
+              [Op.ne]: "",
+            },
+          },
+          required: false,
+          order: [["createdAt", "DESC"]],
+          include: [
+            {
+              model: User,
+              as: "user",
+              attributes: ["id", "name"],
+            },
+          ],
+        },
+      ],
+    });
+
+    const winterSeason = winterSeasonDetails.toJSON();
+
+    const { operatingYear } = winterSeason;
+    const parkId = winterSeason.park.id;
+
+    const featureList = await Feature.findAll({
+      attributes: ["id", "name", "active"],
+      where: {
+        parkId,
+        active: true,
+        hasWinterFeeDates: true,
+      },
+      include: [
+        {
+          model: FeatureType,
+          as: "featureType",
+          attributes: ["id", "name", "icon"],
+        },
+        {
+          model: Campground,
+          as: "campground",
+          required: false,
+          attributes: ["id", "name"],
+        },
+        {
+          model: Dateable,
+          as: "dateable",
+          attributes: ["id"],
+          include: [
+            {
+              model: DateRange,
+              as: "dateRanges",
+              attributes: ["id", "startDate", "endDate"],
+              include: [
+                {
+                  model: Season,
+                  as: "season",
+                  attributes: ["id", "operatingYear"],
+                  required: true,
+                  where: {
+                    operatingYear: {
+                      [Op.in]: [operatingYear, operatingYear - 1],
+                    },
+                  },
+                },
+                {
+                  model: DateType,
+                  as: "dateType",
+                  attributes: ["id", "name", "description"],
+                  required: true,
+                  where: {
+                    name: {
+                      [Op.in]: ["Winter fee", "Reservation"],
+                    },
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    const features = featureList.map((feature) => feature.toJSON());
+
+    // Map to group features by featureType
+    const featureTypeMap = {};
+
+    features.forEach((feature) => {
+      const featureType = feature.featureType;
+
+      // If featureType is not in the map, add it
+      if (!featureTypeMap[featureType.id]) {
+        featureTypeMap[featureType.id] = {
+          ...featureType,
+          features: [],
+        };
+      }
+
+      //
+      const featureData = {
+        id: feature.id,
+        name: getFeatureName(feature),
+        dateableId: feature.dateable.id,
+        currentWinterDates: [],
+        previousWinterDates: [],
+        currentReservationDates: [],
+      };
+
+      // group dateRanges by operatingYear and type
+      feature.dateable.dateRanges.forEach((dateRange) => {
+        const dateRangeItem = {
+          id: dateRange.id,
+          startDate: dateRange.startDate,
+          endDate: dateRange.endDate,
+        };
+
+        if (dateRange.dateType.name === "Winter fee") {
+          if (dateRange.season.operatingYear === operatingYear) {
+            featureData.currentWinterDates.push(dateRangeItem);
+          } else {
+            featureData.previousWinterDates.push(dateRangeItem);
+          }
+        } else if (
+          dateRange.dateType.name === "Reservation" &&
+          dateRange.season.operatingYear === operatingYear
+        ) {
+          featureData.currentReservationDates.push(dateRangeItem);
+        }
+      });
+
+      featureTypeMap[featureType.id].features.push(featureData);
+    });
+
+    const featureTypeList = Object.values(featureTypeMap);
+
+    const payload = {
+      ...winterSeason,
+      featureTypes: featureTypeList,
+    };
+
+    res.json(payload);
+  }),
+);
+
+export default router;

--- a/backend/routes/api/winter-seasons.js
+++ b/backend/routes/api/winter-seasons.js
@@ -141,6 +141,8 @@ router.get(
     // Map to group features by featureType
     const featureTypeMap = {};
 
+    let winterFeeDateType = null;
+
     features.forEach((feature) => {
       const featureType = feature.featureType;
 
@@ -176,6 +178,10 @@ router.get(
           } else {
             featureData.previousWinterDates.push(dateRangeItem);
           }
+
+          if (!winterFeeDateType) {
+            winterFeeDateType = dateRange.dateType;
+          }
         } else if (
           dateRange.dateType.name === "Reservation" &&
           dateRange.season.operatingYear === operatingYear
@@ -191,6 +197,8 @@ router.get(
 
     const payload = {
       ...winterSeason,
+      name: `${operatingYear} - ${operatingYear + 1}`,
+      winterFeeDateType,
       featureTypes: featureTypeList,
     };
 


### PR DESCRIPTION
### Jira Ticket

CMS-467

### Description
- added endpoint to get winter season details
- added sh script to run all commands needed to restart your db and import all the data
- added boolean field `hasWinterFeeDates` to `Feature`
- import winter dates from strapi during the `one-time-data-import` command.
