### PR TITLE
CMS-673: Add "save winter dates" endpoint

### DIFF
--- a/backend/routes/api/winter-seasons.js
+++ b/backend/routes/api/winter-seasons.js
@@ -206,4 +206,13 @@ router.get(
   }),
 );
 
+router.post(
+  "/:seasonId/save/",
+  asyncHandler(async (req, res) => {
+    console.log("save endpoint hit");
+
+    res.sendStatus(200);
+  }),
+);
+
 export default router;

--- a/frontend/src/router/pages/SubmitDates.jsx
+++ b/frontend/src/router/pages/SubmitDates.jsx
@@ -104,11 +104,21 @@ function SubmitDates() {
         (acc, dateType) => acc.concat(dateType.Operation, dateType.Reservation),
         [],
       )
-      // Filter out any blank ranges
-      .filter(
-        (dateRange) =>
-          dateRange.startDate !== null && dateRange.endDate !== null,
-      );
+      // Filter out any blank ranges or unchanged dates
+      .filter((dateRange) => {
+        // if either date is null, skip this range
+        if (dateRange.startDate === null || dateRange.endDate === null) {
+          return false;
+        }
+
+        // if the range is unchanged, skip this range
+        return dateRange.changed;
+      })
+      // Add dateTypeId to the date ranges
+      .map((dateRange) => ({
+        ...dateRange,
+        dateTypeId: dateRange.dateType.id,
+      }));
 
     const payload = {
       notes,

--- a/frontend/src/router/pages/SubmitWinterFeesDates.jsx
+++ b/frontend/src/router/pages/SubmitWinterFeesDates.jsx
@@ -371,7 +371,7 @@ export default function SubmitWinterFeesDates() {
     sendData,
     // error: saveError, // @TODO: handle save errors
     loading: saving,
-  } = useApiPost(`/winter-fees/${seasonId}/save/`);
+  } = useApiPost(`/seasons/${seasonId}/save/`);
 
   const {
     flashTitle,

--- a/frontend/src/router/pages/SubmitWinterFeesDates.jsx
+++ b/frontend/src/router/pages/SubmitWinterFeesDates.jsx
@@ -413,10 +413,11 @@ export default function SubmitWinterFeesDates() {
     // Turn the `dates` structure into a flat array of date ranges
     const flattenedDates = Object.entries(dates).flatMap(
       ([dateableId, dateRanges]) =>
-        // Add the dateable ID to each date range
+        // Add the dateable ID and winter date type ID to each date range
         dateRanges.map((dateRange) => ({
           ...dateRange,
           dateableId: Number(dateableId),
+          dateTypeId: season.winterFeeDateType.id,
         })),
     );
 

--- a/frontend/src/router/pages/SubmitWinterFeesDates.jsx
+++ b/frontend/src/router/pages/SubmitWinterFeesDates.jsx
@@ -413,11 +413,12 @@ export default function SubmitWinterFeesDates() {
     // Turn the `dates` structure into a flat array of date ranges
     const flattenedDates = Object.entries(dates).flatMap(
       ([dateableId, dateRanges]) =>
-        // Add the dateable ID and winter date type ID to each date range
+        // Add foreign keys to the date ranges
         dateRanges.map((dateRange) => ({
           ...dateRange,
           dateableId: Number(dateableId),
           dateTypeId: season.winterFeeDateType.id,
+          seasonId,
         })),
     );
 


### PR DESCRIPTION
### Jira Ticket

CMS-673

### Description
<!-- What did you change, and why? -->

Added the "save" endpoint for winter dates, and the related frontend stuff (flash messages, confirmations, and save functions).

53fbb21 pretty much copies the code from the normal season endpoint, and then I discovered we can use `bulkCreate` with `updateOnDuplicate` to potentially cut down on the number of INSERT/UPDATE queries by a lot, so a35a0c3 updates the endpoint code to use that. Check it out and let me know what you think!