### PR TITLE
CMS-635: Adjust feature name 'All sites' to display proper name.

### DIFF
--- a/backend/routes/api/export.js
+++ b/backend/routes/api/export.js
@@ -10,6 +10,7 @@ import {
   Season,
   FeatureType,
   Feature,
+  Campground,
   DateType,
   DateRange,
   Dateable,
@@ -18,6 +19,21 @@ import {
 } from "../../models/index.js";
 
 const router = Router();
+
+function getFeatureName(feature) {
+  // if feature has a campground, and feature.name is "All sites", return campground name
+  // if feature has a campground, and feature.name is not "All sites", return "campgroundName: feature.name"
+  // if feature does not have a campground, return feature.name
+  const { campground, name } = feature;
+
+  if (campground) {
+    return name === "All sites"
+      ? campground.name
+      : `${campground.name}: ${name}`;
+  }
+
+  return name;
+}
 
 // Map date type names to a different name for display
 const dateTypeDisplayNames = new Map([
@@ -128,6 +144,12 @@ router.get(
           },
         },
         {
+          model: Campground,
+          as: "campground",
+          required: false,
+          attributes: ["id", "name"],
+        },
+        {
           model: Dateable,
           as: "dateable",
           attributes: ["id"],
@@ -202,7 +224,7 @@ router.get(
           .join(", "),
         ORCS: feature.park.orcs,
         "Park Name": feature.park.name,
-        "Sub-Area": feature.name,
+        "Sub-Area": getFeatureName(feature),
         "Sub-Area Type (Park feature)": feature.featureType.name,
         "Operating Year": dateRange.season.operatingYear,
         "Type of date": getDateTypeDisplay(dateRange.dateType.name),

--- a/backend/routes/api/seasons.js
+++ b/backend/routes/api/seasons.js
@@ -189,7 +189,10 @@ router.get(
           };
         }
 
-        campgroundsMap[feature.campground.id].features.push(feature);
+        campgroundsMap[feature.campground.id].features.push({
+          ...feature,
+          name: feature.name === "All sites" ? "" : feature.name,
+        });
       }
     });
 

--- a/frontend/src/components/ParkDetailsSeasonDates.jsx
+++ b/frontend/src/components/ParkDetailsSeasonDates.jsx
@@ -32,8 +32,7 @@ function CampGroundFeature({ feature }) {
 
   return (
     <div className="feature">
-      <h4>{feature.name}</h4>
-
+      {feature.name !== "" && <h4>{feature.name}</h4>}
       <table className="table table-striped dates mb-0">
         <tbody>
           {Object.entries(groupedDates).map(([dateTypeName, dateRanges]) => (

--- a/frontend/src/router/pages/PreviewChanges.jsx
+++ b/frontend/src/router/pages/PreviewChanges.jsx
@@ -129,8 +129,7 @@ function PreviewChanges() {
   function Feature({ feature }) {
     return (
       <div>
-        <h5>{feature.name}</h5>
-
+        {feature.name !== "" && <h5>{feature.name}</h5>}
         <div className="table-responsive">
           <table className="table table-striped">
             <thead>

--- a/frontend/src/router/pages/SubmitDates.jsx
+++ b/frontend/src/router/pages/SubmitDates.jsx
@@ -542,8 +542,7 @@ function SubmitDates() {
   function Feature({ feature }) {
     return (
       <section className="feature">
-        <h3>{feature.name}</h3>
-
+        {feature.name && <h3>{feature.name}</h3>}
         <div className="row">
           <div className="col-md-6">
             <div>
@@ -640,7 +639,6 @@ function SubmitDates() {
             </div>
           )}
         </div>
-
         {/* Show validation errors for the whole dateable feature */}
         {errors?.[feature.dateable.id] && (
           <div


### PR DESCRIPTION
### Jira Ticket

CMS-635

### Description
Backend changes
- the backend returns "" (empty string) for features that have "all sites" as their name for regular seasons (winter seasons are unaffected because they have different logic for the name)
- for export endpoint, use same logic as winter seasons to display "campground name: feature name" or just campground name when feature name is "All sites".

Frontend changes:
- for regular seasons, hide feature name when is empty string.

