### PR TITLE
CMS-670: Update global styles: header wrap and horizontal padding

### DIFF
--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -6,11 +6,21 @@
 // https://www2.gov.bc.ca/gov/content/digital/design-system/foundations/design-tokens
 @use "@bcgov/design-tokens/css/variables.css" as *;
 
+// Break inside words on when nevessary on top-level headings
+h1 {
+  overflow-wrap: break-word;
+}
+
 // Custom styles
 header.page-header {
   padding-block: var(--layout-padding-medium);
   margin-bottom: var(--layout-padding-xlarge);
   border-bottom: 1px solid var(--surface-color-border-default);
+}
+
+// Increase bootstrap x-padding for containers to 16px
+.container {
+  --bs-gutter-x: 2rem;
 }
 
 // append search icon appended


### PR DESCRIPTION
### Jira Ticket

CMS-670

### Description
<!-- What did you change, and why? -->

Some global style rules to address display issues from QA. On pages with long headers, such as "Anhluut'ukwsim Lax̱mihl Angwinga'asanskwhl Nisg̱a'a Park [a.k.a. Nisg̱a'a Memorial Lava Bed Park] 2025 season dates" it will wrap on whitespace as usual when possible, and then wrap inside long words as a last resort, so long words like "Angwinga'asanskwhl" won't overflow the container and break the layout.

QA also requested making the horizontal padding on the page container 16px (1rem) so I tweaked that here too by increasing the gutter-x bootstrap variable from 1.5rem to 2rem. (It gets divided in half for each side)