### PR TITLE
CMS-671: Update "Save" control spacing on all pages

### DIFF
--- a/frontend/src/components/ReadyToPublishBox.jsx
+++ b/frontend/src/components/ReadyToPublishBox.jsx
@@ -5,7 +5,7 @@ export default function ReadyToPublishBox({
   setReadyToPublish,
 }) {
   return (
-    <div className="mb-12">
+    <div className="mb-4">
       <h2 className="mb-4">Ready to publish?</h2>
 
       <p>
@@ -15,7 +15,7 @@ export default function ReadyToPublishBox({
         dates are included in exported files.
       </p>
 
-      <div className="form-check form-switch mb-4">
+      <div className="form-check form-switch">
         <input
           checked={readyToPublish}
           onChange={() => setReadyToPublish(!readyToPublish)}

--- a/frontend/src/router/pages/PreviewChanges.jsx
+++ b/frontend/src/router/pages/PreviewChanges.jsx
@@ -305,7 +305,7 @@ function PreviewChanges() {
             setReadyToPublish={setReadyToPublish}
           />
 
-          <div className="controls d-flex mt-4">
+          <div className="controls d-flex flex-column flex-sm-row gap-2">
             <Link
               to={`/park/${parkId}/edit/${seasonId}`}
               type="button"

--- a/frontend/src/router/pages/PreviewChanges.scss
+++ b/frontend/src/router/pages/PreviewChanges.scss
@@ -1,4 +1,5 @@
-.page.review-changes {
+.page.review-changes,
+.page.review-winter-fees-changes {
   .feature-type {
     margin-bottom: var(--layout-margin-large);
     padding-block: var(--layout-padding-medium);
@@ -33,11 +34,5 @@
   // spacing between DateRange components
   td:not(:last-child) .date-range {
     margin-right: 1em;
-  }
-
-  .notes {
-    .controls {
-      gap: var(--layout-margin-medium);
-    }
   }
 }

--- a/frontend/src/router/pages/PreviewWinterFeesChanges.jsx
+++ b/frontend/src/router/pages/PreviewWinterFeesChanges.jsx
@@ -187,7 +187,7 @@ function PreviewChanges() {
   }
 
   return (
-    <div className="page review-changes">
+    <div className="page review-winter-fees-changes">
       <FlashMessage
         title={flashTitle}
         message={flashMessage}
@@ -258,7 +258,7 @@ function PreviewChanges() {
             setReadyToPublish={setReadyToPublish}
           />
 
-          <div className="controls d-flex mt-4">
+          <div className="controls d-flex flex-column flex-sm-row gap-2">
             <Link
               to={`/park/${parkId}/winter-fees/${seasonId}/edit`}
               type="button"

--- a/frontend/src/router/pages/SubmitDates.jsx
+++ b/frontend/src/router/pages/SubmitDates.jsx
@@ -783,7 +783,7 @@ function SubmitDates() {
             setReadyToPublish={setReadyToPublish}
           />
 
-          <div className="controls d-flex mt-4">
+          <div className="controls d-flex flex-column flex-sm-row gap-2">
             <Link
               to={`/park/${parkId}`}
               type="button"

--- a/frontend/src/router/pages/SubmitDates.scss
+++ b/frontend/src/router/pages/SubmitDates.scss
@@ -48,10 +48,6 @@
     }
   }
 
-  .controls {
-    gap: var(--layout-margin-medium);
-  }
-
   /* Arrow at the bottom of tooltip */
   .tooltip-text::after {
     content: "";
@@ -68,11 +64,5 @@
   .error-message {
     color: var(--support-border-color-danger);
     font-size: 0.875em;
-  }
-
-  .notes {
-    .controls {
-      gap: var(--layout-margin-medium);
-    }
   }
 }

--- a/frontend/src/router/pages/SubmitWinterFeesDates.jsx
+++ b/frontend/src/router/pages/SubmitWinterFeesDates.jsx
@@ -611,7 +611,7 @@ export default function SubmitWinterFeesDates() {
             setReadyToPublish={setReadyToPublish}
           />
 
-          <div className="controls d-flex mt-4">
+          <div className="controls d-flex flex-column flex-sm-row gap-2">
             <Link
               to={`/park/${parkId}`}
               type="button"

--- a/frontend/src/router/pages/SubmitWinterFeesDates.scss
+++ b/frontend/src/router/pages/SubmitWinterFeesDates.scss
@@ -27,8 +27,4 @@
       }
     }
   }
-
-  .controls {
-    gap: var(--layout-margin-medium);
-  }
 }


### PR DESCRIPTION
### Jira Ticket

CMS-671

### Description
<!-- What did you change, and why? -->

Style updates for the "Back/Save/Preview" buttons on all pages: On smaller screens, they display vertically stacked, full width. On wider screens, they show side-by-side like before. This is all done with Bootstrap classes, so I took out the custom CSS for it.

I also fixed some classes in the "Ready to publish" box above it, so that will be spaced correctly too.