### PR TITLE
CMS-658: Split up access context and provider

### DIFF
--- a/frontend/src/contexts/AccessContext.js
+++ b/frontend/src/contexts/AccessContext.js
@@ -1,0 +1,5 @@
+import { createContext } from "react";
+
+// Create a new context for access control,
+// to be used in the AccessProvider and ProtectedRoute components
+export default createContext();

--- a/frontend/src/hooks/useAccess.js
+++ b/frontend/src/hooks/useAccess.js
@@ -1,5 +1,5 @@
 import { useContext } from "react";
-import { AccessContext } from "@/router/AccessContext";
+import AccessContext from "@/contexts/AccessContext";
 import { ROLES } from "@/config/permissions";
 
 export function useAccess() {

--- a/frontend/src/router/AccessProvider.jsx
+++ b/frontend/src/router/AccessProvider.jsx
@@ -1,11 +1,10 @@
 import PropTypes from "prop-types";
-import { createContext } from "react";
 import getEnv from "@/config/getEnv";
 import { ROLES } from "@/config/permissions";
 
-export const AccessContext = createContext();
+import AccessContext from "@/contexts/AccessContext";
 
-export function AccessProvider({ children, auth }) {
+export default function AccessProvider({ children, auth }) {
   // Decode the token to get the user's roles
   const roles = [];
   const accessToken = auth?.user?.access_token;

--- a/frontend/src/router/ProtectedRoute.jsx
+++ b/frontend/src/router/ProtectedRoute.jsx
@@ -1,6 +1,6 @@
 import { useAuth, withAuthenticationRequired } from "react-oidc-context";
 import PropTypes from "prop-types";
-import { AccessProvider } from "@/router/AccessContext";
+import AccessProvider from "@/router/AccessProvider";
 
 // Higher-order component that wraps a route component for authentication
 // Wrap a "layout" component in this component to protect all of its children


### PR DESCRIPTION
### Jira Ticket

CMS-658

### Description
<!-- What did you change, and why? -->

There was a linter warning saying "quick refresh" only works if a jsx file exports nothing but a single component. I split the access context for user roles from router/AccessContext into contexts/AccessContext and router/AccessProvider

The context is usable from the useAccess hook, but that's not being used yet in this release anyway.