### PR TITLE
CMS-623: Update date order, park page

### DIFF
--- a/frontend/src/components/ParkDetailsSeason.jsx
+++ b/frontend/src/components/ParkDetailsSeason.jsx
@@ -118,13 +118,14 @@ export default function ParkSeason({
           <StatusBadge status={season.status} />
           <NotReadyFlag show={!season.readyToPublish} />
 
+          <span className="ms-auto">Last updated: {updateDate}</span>
+
           <button
             onClick={toggleExpand}
             className="btn btn-text-primary expand-toggle"
           >
-            <span>Last updated: {updateDate}</span>
             <FontAwesomeIcon
-              className="append-content ms-2"
+              className="append-content"
               icon={expanded ? faChevronUp : faChevronDown}
             />
           </button>

--- a/frontend/src/components/ParkDetailsSeasonDates.jsx
+++ b/frontend/src/components/ParkDetailsSeasonDates.jsx
@@ -1,4 +1,5 @@
 import groupBy from "lodash/groupBy";
+import orderBy from "lodash/orderBy";
 import PropTypes from "prop-types";
 import DateRange from "@/components/DateRange";
 import ChangeLogsList from "@/components/ChangeLogsList.jsx";
@@ -26,8 +27,11 @@ function CampGroundFeature({ feature }) {
 
   // Group current season dates by date type
   const groupedDates = groupBy(
-    currentSeasonDates,
-    (dateType) => dateType.dateType.name,
+    // Sort by date type name
+    orderBy(currentSeasonDates, "dateType.name"),
+
+    // Group by date type name
+    "dateType.name",
   );
 
   return (

--- a/frontend/src/router/pages/ParkDetails.scss
+++ b/frontend/src/router/pages/ParkDetails.scss
@@ -99,7 +99,7 @@
       .divider {
         border-right: var(--layout-border-width-small) solid
           var(--surface-color-primary-default);
-        margin-inline: var(--layout-margin-xsmall);
+        margin-inline: var(--layout-margin-medium);
         height: 2rem;
       }
     }

--- a/frontend/src/router/pages/ParkDetails.scss
+++ b/frontend/src/router/pages/ParkDetails.scss
@@ -63,10 +63,6 @@
         }
       }
 
-      .expand-toggle {
-        margin-left: auto;
-      }
-
       .details-content {
         padding: 0 var(--layout-padding-large) var(--layout-padding-large);
 

--- a/frontend/src/router/pages/SubmitDates.jsx
+++ b/frontend/src/router/pages/SubmitDates.jsx
@@ -567,7 +567,7 @@ function SubmitDates() {
                   .filter((date) => date.dateType.name === "Operation")
                   .map((dateRange, index) => (
                     <div
-                      key={formatDateRange(dateRange)}
+                      key={dateRange.id}
                       className={index > 0 ? "my-2" : "mb-2"}
                     >
                       {formatDateRange(dateRange)}
@@ -613,7 +613,10 @@ function SubmitDates() {
                   {feature.dateable.previousSeasonDates
                     .filter((date) => date.dateType.name === "Reservation")
                     .map((dateRange, index) => (
-                      <div key={index} className={index > 0 ? "my-2" : "mb-2"}>
+                      <div
+                        key={dateRange.id}
+                        className={index > 0 ? "my-2" : "mb-2"}
+                      >
                         {formatDateRange(dateRange)}
                       </div>
                     ))}


### PR DESCRIPTION
### Jira Ticket

CMS-623

### Description
<!-- What did you change, and why? -->

Minor updates to the Park details page to order the date types so Operating dates are always listed first, plus some layout and style changes.

This branch also includes a minor fix to the `key` on the Edit page, to fix a console error when two date ranges have the same dates. It came up while I was fixing the date order so I included it here.