### PR TITLE
CMS-624: Show month dropdown instead of header

### DIFF
--- a/frontend/src/router/pages/SubmitDates.jsx
+++ b/frontend/src/router/pages/SubmitDates.jsx
@@ -442,6 +442,7 @@ function SubmitDates() {
                   }
                 }}
                 dateFormat="EEE, MMM d, yyyy"
+                showMonthYearDropdown
               />
 
               {/* Show the calendar icon unless the error icon is showing */}
@@ -496,6 +497,7 @@ function SubmitDates() {
                   }
                 }}
                 dateFormat="EEE, MMM d, yyyy"
+                showMonthYearDropdown
               />
 
               {/* Show the calendar icon unless the error icon is showing */}

--- a/frontend/src/router/pages/SubmitDates.scss
+++ b/frontend/src/router/pages/SubmitDates.scss
@@ -1,5 +1,5 @@
 .page.submit-dates {
-  h2 {
+  h2:not(.react-datepicker h2) {
     margin-bottom: var(--layout-margin-xlarge);
 
     .feature-icon {

--- a/frontend/src/router/pages/SubmitWinterFeesDates.jsx
+++ b/frontend/src/router/pages/SubmitWinterFeesDates.jsx
@@ -146,6 +146,7 @@ function DateRange({ dateableId, dateRange, index, updateDateRange }) {
                 }
               }}
               dateFormat="EEE, MMM d, yyyy"
+              showMonthYearDropdown
             />
 
             {/* Show the calendar icon unless the error icon is showing */}
@@ -197,6 +198,7 @@ function DateRange({ dateableId, dateRange, index, updateDateRange }) {
                 }
               }}
               dateFormat="EEE, MMM d, yyyy"
+              showMonthYearDropdown
             />
 
             {/* Show the calendar icon unless the error icon is showing */}

--- a/frontend/src/styles/_datepicker.scss
+++ b/frontend/src/styles/_datepicker.scss
@@ -1,0 +1,32 @@
+// Overrides for the react-datepicker component package
+
+// overrides for the datepicker component package
+.react-datepicker {
+  // prevent the bootstrap theme from making the month name huge
+  h2 {
+    font-size: var(--typography-font-size-body) !important;
+  }
+}
+
+// For datepickers with the month selection,
+// hide the month name header and just show the dropdown
+.react-datepicker:has(.react-datepicker__current-month--hasMonthYearDropdown) {
+  .react-datepicker__header {
+    .react-datepicker__current-month {
+      display: none;
+    }
+
+    .react-datepicker__header__dropdown {
+      // Prevent the dropdown from being hidden on click
+      .react-datepicker__month-year-read-view {
+        visibility: visible !important;
+      }
+
+      // Make the dropdown styles bigger to show as a header
+      .react-datepicker__month-year-read-view--selected-month-year {
+        font-size: var(--typography-font-size-body) !important;
+        font-weight: bold;
+      }
+    }
+  }
+}

--- a/frontend/src/styles/_datepicker.scss
+++ b/frontend/src/styles/_datepicker.scss
@@ -28,5 +28,31 @@
         font-weight: bold;
       }
     }
+
+    // Make the dropdown and options bigger
+    .react-datepicker__month-year-dropdown {
+      $width: 10rem;
+      width: $width;
+      left: calc(50% - $width/2);
+      padding: 0.4em;
+      font-size: 1rem;
+
+      // Make the dropdown options bigger
+      .react-datepicker__month-year-option,
+      .react-datepicker__month-year-option--selected_month-year {
+        line-height: 1.5;
+        white-space: nowrap;
+        border-radius: 0.3rem;
+      }
+
+      // Highlight the selected option and hide the checkmark icon
+      .react-datepicker__month-year-option--selected_month-year {
+        font-weight: bold;
+
+        .react-datepicker__month-year-option--selected {
+          display: none;
+        }
+      }
+    }
   }
 }

--- a/frontend/src/styles/_datepicker.scss
+++ b/frontend/src/styles/_datepicker.scss
@@ -1,8 +1,6 @@
 // Overrides for the react-datepicker component package
-
-// overrides for the datepicker component package
 .react-datepicker {
-  // prevent the bootstrap theme from making the month name huge
+  // Prevent the bootstrap theme from making the month name huge
   h2 {
     font-size: var(--typography-font-size-body) !important;
   }

--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -6,6 +6,9 @@
 // https://www2.gov.bc.ca/gov/content/digital/design-system/foundations/design-tokens
 @use "@bcgov/design-tokens/css/variables.css" as *;
 
+// DatePicker component custom styles
+@use "datepicker";
+
 // Break inside words on when nevessary on top-level headings
 h1 {
   overflow-wrap: break-word;
@@ -103,15 +106,6 @@ a:not(.btn):focus {
 // override bootstrap theme styles: don't shrink radio/checkbox labels
 label.form-check-label {
   font-size: var(--typography-font-size-body) !important;
-}
-
-// overrides for the datepicker component package
-.react-datepicker {
-  // prevent the bootstrap theme from making the month name huge
-  h2 {
-    font-size: var(--typography-font-size-body) !important;
-    display: block !important;
-  }
 }
 
 // custom style for validation error alert


### PR DESCRIPTION
### Jira Ticket

CMS-624

### Description
<!-- What did you change, and why? -->

Overriding some styles in the DatePicker component to show the Month/Year dropdown in place of the Month/Year header text. (Normally they'd both show, which looks kinda awkward)