### PR TITLE
CMS-517: Update modal button labels and fix modal workflow issues

### DIFF
--- a/backend/routes/api/seasons.js
+++ b/backend/routes/api/seasons.js
@@ -318,15 +318,18 @@ router.post(
       throw error;
     }
 
-    // create season change log
-    await SeasonChangeLog.create({
-      seasonId,
-      userId: req.user.id,
-      notes,
-      statusOldValue: season.status,
-      statusNewValue: "approved",
-      readyToPublishOldValue: season.readyToPublish,
-      readyToPublishNewValue: readyToPublish,
+    // Approving a season can have more than one note
+    // if the approved season has some empty dates
+    notes.forEach((note) => {
+      SeasonChangeLog.create({
+        seasonId,
+        userId: req.user.id,
+        notes: note,
+        statusOldValue: season.status,
+        statusNewValue: "approved",
+        readyToPublishOldValue: season.readyToPublish,
+        readyToPublishNewValue: readyToPublish,
+      });
     });
 
     // update season

--- a/backend/routes/api/seasons.js
+++ b/backend/routes/api/seasons.js
@@ -320,8 +320,9 @@ router.post(
 
     // Approving a season can have more than one note
     // if the approved season has some empty dates
-    notes.forEach((note) => {
-      SeasonChangeLog.create({
+    const notesToCreate = notes
+      .filter((n) => n !== "")
+      .map((note) => ({
         seasonId,
         userId: req.user.id,
         notes: note,
@@ -329,8 +330,10 @@ router.post(
         statusNewValue: "approved",
         readyToPublishOldValue: season.readyToPublish,
         readyToPublishNewValue: readyToPublish,
-      });
-    });
+      }));
+
+    // bulk create season change logs
+    SeasonChangeLog.bulkCreate(notesToCreate);
 
     // update season
     Season.update(

--- a/frontend/src/components/ConfirmationDialog.jsx
+++ b/frontend/src/components/ConfirmationDialog.jsx
@@ -6,6 +6,8 @@ import "./ConfirmationDialog.scss";
 function ConfirmationDialog({
   title,
   message,
+  confirmButtonText,
+  cancelButtonText,
   notes,
   onCancel,
   onConfirm,
@@ -27,10 +29,10 @@ function ConfirmationDialog({
         <p className="confirmation-dialog-message">{notes}</p>
         <div className="confirmation-dialog-actions">
           <button className="btn btn-outline-primary" onClick={onCancel}>
-            Cancel
+            {cancelButtonText}
           </button>
           <button className="btn btn-primary" onClick={onConfirm}>
-            Confirm
+            {confirmButtonText}
           </button>
         </div>
       </div>
@@ -41,6 +43,8 @@ function ConfirmationDialog({
 ConfirmationDialog.propTypes = {
   title: PropTypes.string.isRequired,
   message: PropTypes.string.isRequired,
+  confirmButtonText: PropTypes.string.isRequired,
+  cancelButtonText: PropTypes.string.isRequired,
   notes: PropTypes.string.isRequired,
   onCancel: PropTypes.func.isRequired,
   onConfirm: PropTypes.func.isRequired,

--- a/frontend/src/components/ConfirmationDialog.scss
+++ b/frontend/src/components/ConfirmationDialog.scss
@@ -48,6 +48,10 @@
   margin-bottom: var(--layout-margin-large);
 }
 
+.missing-dates-confirmation-dialog-message {
+  margin-bottom: var(--layout-margin-small);
+}
+
 .confirmation-dialog-actions {
   display: flex;
   justify-content: space-between;

--- a/frontend/src/components/MissingDatesConfirmationDialog.jsx
+++ b/frontend/src/components/MissingDatesConfirmationDialog.jsx
@@ -1,0 +1,75 @@
+import PropTypes from "prop-types";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faClose } from "@fa-kit/icons/classic/regular";
+import "./ConfirmationDialog.scss";
+
+function ConfirmationDialog({
+  featureNames,
+  inputMessage,
+  setInputMessage,
+  onCancel,
+  onConfirm,
+  isOpen,
+}) {
+  if (!isOpen) return null;
+
+  return (
+    <div className="confirmation-dialog-overlay">
+      <div className="confirmation-dialog-container">
+        <div className="confirmation-dialog-header">
+          <h3 className="confirmation-dialog-title">
+            Submit with missing dates?
+          </h3>
+          <button onClick={onCancel} className="confirmation-dialog-close">
+            <FontAwesomeIcon icon={faClose} />
+          </button>
+        </div>
+
+        <div className="missing-dates-confirmation-dialog-message">
+          The following dates are missing:{" "}
+        </div>
+
+        <ul>
+          {featureNames.map((feature, index) => (
+            <li key={index}>{feature}</li>
+          ))}
+        </ul>
+
+        <div className="missing-dates-confirmation-dialog-message">
+          Please explain why the missing dates are not available:{" "}
+        </div>
+        <div className="form-group mb-4">
+          <textarea
+            value={inputMessage}
+            onChange={(e) => setInputMessage(e.target.value)}
+            className="form-control"
+          ></textarea>
+        </div>
+
+        <div className="confirmation-dialog-actions">
+          <button className="btn btn-outline-primary" onClick={onCancel}>
+            Cancel
+          </button>
+          <button
+            className="btn btn-primary"
+            onClick={onConfirm}
+            disabled={!inputMessage}
+          >
+            Confirm
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+ConfirmationDialog.propTypes = {
+  featureNames: PropTypes.array.isRequired,
+  inputMessage: PropTypes.string.isRequired,
+  setInputMessage: PropTypes.func.isRequired,
+  onCancel: PropTypes.func.isRequired,
+  onConfirm: PropTypes.func.isRequired,
+  isOpen: PropTypes.bool.isRequired,
+};
+
+export default ConfirmationDialog;

--- a/frontend/src/components/ParkDetailsSeason.jsx
+++ b/frontend/src/components/ParkDetailsSeason.jsx
@@ -89,7 +89,7 @@ export default function ParkSeason({
       }
     } else if (season.status === "on API") {
       const confirm = await openConfirmation(
-        "Edit published dates?",
+        "Edit public dates on API?",
         "Dates will need to be reviewed again to be approved and published. If reservations have already begun, visitors will be affected.",
         "Edit",
       );

--- a/frontend/src/components/ParkDetailsSeason.jsx
+++ b/frontend/src/components/ParkDetailsSeason.jsx
@@ -38,6 +38,8 @@ export default function ParkSeason({
   const {
     title,
     message,
+    confirmButtonText,
+    cancelButtonText,
     openConfirmation,
     handleConfirm,
     handleCancel,
@@ -69,6 +71,7 @@ export default function ParkSeason({
       const confirm = await openConfirmation(
         "Edit submitted dates?",
         "A review may already be in progress and all dates will need to be reviewed again.",
+        "Edit",
       );
 
       if (confirm) {
@@ -78,6 +81,7 @@ export default function ParkSeason({
       const confirm = await openConfirmation(
         "Edit approved dates?",
         "Dates will need to be reviewed again to be approved.",
+        "Edit",
       );
 
       if (confirm) {
@@ -87,6 +91,7 @@ export default function ParkSeason({
       const confirm = await openConfirmation(
         "Edit published dates?",
         "Dates will need to be reviewed again to be approved and published. If reservations have already begun, visitors will be affected.",
+        "Edit",
       );
 
       if (confirm) {
@@ -106,6 +111,8 @@ export default function ParkSeason({
       <ConfirmationDialog
         title={title}
         message={message}
+        confirmButtonText={confirmButtonText}
+        cancelButtonText={cancelButtonText}
         notes=""
         onCancel={handleCancel}
         onConfirm={handleConfirm}

--- a/frontend/src/hooks/useConfirmation.js
+++ b/frontend/src/hooks/useConfirmation.js
@@ -5,17 +5,23 @@ export function useConfirmation() {
   const [title, setTitle] = useState("");
   const [message, setMessage] = useState("");
   const [notes, setNotes] = useState("");
+  const [confirmButtonText, setConfirmButtonText] = useState("");
+  const [cancelButtonText, setCancelButtonText] = useState("");
   const [resolvePromise, setResolvePromise] = useState(null);
 
   function openConfirmation(
     confirmationTitle,
     confirmationMessage,
+    confirmText = "Confirm",
+    cancelText = "Cancel",
     notesParam = "",
   ) {
     return new Promise((resolve) => {
       setTitle(confirmationTitle);
       setMessage(confirmationMessage);
       setNotes(notesParam);
+      setConfirmButtonText(confirmText);
+      setCancelButtonText(cancelText);
       setResolvePromise(() => resolve); // Store the resolve function
       setIsOpen(true);
     });
@@ -38,6 +44,8 @@ export function useConfirmation() {
   return {
     title,
     message,
+    confirmButtonText,
+    cancelButtonText,
     confirmationDialogNotes: notes,
     openConfirmation,
     handleConfirm,

--- a/frontend/src/hooks/useMissingDatesConfirmation.js
+++ b/frontend/src/hooks/useMissingDatesConfirmation.js
@@ -1,4 +1,3 @@
-import { set } from "lodash";
 import { useState } from "react";
 
 export function useMissingDatesConfirmation() {
@@ -7,7 +6,7 @@ export function useMissingDatesConfirmation() {
   const [inputMessage, setInputMessage] = useState("");
   const [resolvePromise, setResolvePromise] = useState(null);
 
-  function openMisingDatesConfirmation(featureNameList) {
+  function openConfirmation(featureNameList) {
     return new Promise((resolve) => {
       setFeatureNames(featureNameList);
       setResolvePromise(() => resolve); // Store the resolve function
@@ -15,14 +14,14 @@ export function useMissingDatesConfirmation() {
     });
   }
 
-  function handleMissingDatesConfirm() {
+  function handleConfirm() {
     if (resolvePromise) {
       resolvePromise({ confirm: true, confirmationMessage: inputMessage }); // Resolve with true
     }
     setIsOpen(false);
   }
 
-  function handleMissingDatesCancel() {
+  function handleCancel() {
     if (resolvePromise) {
       resolvePromise({ confirm: false, confirmationMessage: inputMessage }); // Resolve with false
     }
@@ -35,9 +34,9 @@ export function useMissingDatesConfirmation() {
     inputMessage,
     setInputMessage,
 
-    openMisingDatesConfirmation,
-    handleMissingDatesConfirm,
-    handleMissingDatesCancel,
-    isMissingDatesConfirmationOpen: isOpen,
+    openConfirmation,
+    handleConfirm,
+    handleCancel,
+    isOpen,
   };
 }

--- a/frontend/src/hooks/useMissingDatesConfirmation.js
+++ b/frontend/src/hooks/useMissingDatesConfirmation.js
@@ -1,0 +1,43 @@
+import { set } from "lodash";
+import { useState } from "react";
+
+export function useMissingDatesConfirmation() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [featureNames, setFeatureNames] = useState([]);
+  const [inputMessage, setInputMessage] = useState("");
+  const [resolvePromise, setResolvePromise] = useState(null);
+
+  function openMisingDatesConfirmation(featureNameList) {
+    return new Promise((resolve) => {
+      setFeatureNames(featureNameList);
+      setResolvePromise(() => resolve); // Store the resolve function
+      setIsOpen(true);
+    });
+  }
+
+  function handleMissingDatesConfirm() {
+    if (resolvePromise) {
+      resolvePromise({ confirm: true, confirmationMessage: inputMessage }); // Resolve with true
+    }
+    setIsOpen(false);
+  }
+
+  function handleMissingDatesCancel() {
+    if (resolvePromise) {
+      resolvePromise({ confirm: false, confirmationMessage: inputMessage }); // Resolve with false
+    }
+    setIsOpen(false);
+  }
+
+  return {
+    featureNames,
+    setFeatureNames,
+    inputMessage,
+    setInputMessage,
+
+    openMisingDatesConfirmation,
+    handleMissingDatesConfirm,
+    handleMissingDatesCancel,
+    isMissingDatesConfirmationOpen: isOpen,
+  };
+}

--- a/frontend/src/hooks/useNavigationGuard.js
+++ b/frontend/src/hooks/useNavigationGuard.js
@@ -23,6 +23,8 @@ export function useNavigationGuard(hasChanges, openConfirmation) {
         const proceed = await openConfirmation(
           "Discard changes?",
           "Discarded changes will be permanently deleted.",
+          "Discard changes",
+          "Continue editing",
         );
 
         if (proceed) {

--- a/frontend/src/hooks/useNavigationGuard.js
+++ b/frontend/src/hooks/useNavigationGuard.js
@@ -11,7 +11,11 @@ export function useNavigationGuard(hasChanges, openConfirmation) {
     const queryString = new URLSearchParams(nextLocation.search);
 
     // Bypass the blocker when saving or approving
-    if (nextPath === `${currentPath}/preview` || queryString.has("approved")) {
+    if (
+      nextPath === `${currentPath}/preview` ||
+      queryString.has("approved") ||
+      queryString.has("saved")
+    ) {
       return false;
     }
     return hasChanges();

--- a/frontend/src/hooks/useNavigationGuard.js
+++ b/frontend/src/hooks/useNavigationGuard.js
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useCallback } from "react";
 import { useBlocker } from "react-router-dom";
 import { removeTrailingSlash } from "@/lib/utils";
 
@@ -13,6 +13,7 @@ export function useNavigationGuard(hasChanges, openConfirmation) {
     // Bypass the blocker when saving or approving
     if (
       nextPath === `${currentPath}/preview` ||
+      nextPath === `${currentPath.replace("edit", "preview")}` ||
       queryString.has("approved") ||
       queryString.has("saved")
     ) {
@@ -42,17 +43,19 @@ export function useNavigationGuard(hasChanges, openConfirmation) {
     handleBlocker();
   }, [blocker, openConfirmation]);
 
-  useEffect(() => {
-    async function handleBeforeUnload(e) {
+  const handleBeforeUnload = useCallback(
+    async (e) => {
       if (hasChanges()) {
         e.preventDefault();
       }
-    }
+    },
+    [hasChanges],
+  );
 
+  useEffect(() => {
     window.addEventListener("beforeunload", handleBeforeUnload);
-
     return () => {
       window.removeEventListener("beforeunload", handleBeforeUnload);
     };
-  }, [hasChanges, openConfirmation]);
+  }, [handleBeforeUnload]);
 }

--- a/frontend/src/router/pages/ParkDetails.jsx
+++ b/frontend/src/router/pages/ParkDetails.jsx
@@ -28,13 +28,23 @@ function ParkDetails() {
   useEffect(() => {
     if (isFlashOpen) return;
 
-    let seasonId = searchParams.get("approved");
+    const approvedSeasonId = searchParams.get("approved");
+    const savedSeasonId = searchParams.get("saved");
+
+    let seasonId = null;
+
+    if (approvedSeasonId !== null) {
+      seasonId = approvedSeasonId;
+    } else if (savedSeasonId !== null) {
+      seasonId = savedSeasonId;
+    }
 
     if (!park || seasonId === null) return;
     seasonId = Number(seasonId);
 
     // Remove the query string so the flash message won't show again
     searchParams.delete("approved");
+    searchParams.delete("saved");
     setSearchParams(searchParams);
 
     // Find the season in the park data by its ID
@@ -42,14 +52,21 @@ function ParkDetails() {
       ...Object.values(park.featureTypes).flat(),
       ...park.winterFees,
     ];
-    const approvedSeason = allSeasons.find((season) => season.id === seasonId);
+    const season = allSeasons.find((item) => item.id === seasonId);
 
-    if (!approvedSeason) return;
+    if (!season) return;
 
-    openFlashMessage(
-      "Dates approved",
-      `${park.name} ${approvedSeason.featureType.name} ${approvedSeason.operatingYear} season dates marked as approved`,
-    );
+    if (approvedSeasonId !== null) {
+      openFlashMessage(
+        "Dates approved",
+        `${park.name} ${season.featureType.name} ${season.operatingYear} season dates marked as approved`,
+      );
+    } else if (savedSeasonId !== null) {
+      openFlashMessage(
+        "Dates saved as draft",
+        `${park.name} ${season.featureType.name} ${season.operatingYear} season details saved`,
+      );
+    }
   }, [isFlashOpen, park, searchParams, setSearchParams, openFlashMessage]);
 
   if (loading) {

--- a/frontend/src/router/pages/ParkDetails.jsx
+++ b/frontend/src/router/pages/ParkDetails.jsx
@@ -48,7 +48,7 @@ function ParkDetails() {
 
     openFlashMessage(
       "Dates approved",
-      `${park.name} ${approvedSeason.featureType.name} ${approvedSeason.operatingYear} season dates marked approved`,
+      `${park.name} ${approvedSeason.featureType.name} ${approvedSeason.operatingYear} season dates marked as approved`,
     );
   }, [isFlashOpen, park, searchParams, setSearchParams, openFlashMessage]);
 

--- a/frontend/src/router/pages/PreviewChanges.jsx
+++ b/frontend/src/router/pages/PreviewChanges.jsx
@@ -53,6 +53,8 @@ function PreviewChanges() {
   const {
     title,
     message,
+    confirmButtonText,
+    cancelButtonText,
     confirmationDialogNotes,
     openConfirmation,
     handleConfirm,
@@ -244,6 +246,8 @@ function PreviewChanges() {
       <ConfirmationDialog
         title={title}
         message={message}
+        confirmButtonText={confirmButtonText}
+        cancelButtonText={cancelButtonText}
         notes={confirmationDialogNotes}
         onCancel={handleCancel}
         onConfirm={handleConfirm}

--- a/frontend/src/router/pages/PreviewChanges.jsx
+++ b/frontend/src/router/pages/PreviewChanges.jsx
@@ -30,7 +30,7 @@ function PreviewChanges() {
   const [notes, setNotes] = useState("");
   const [readyToPublish, setReadyToPublish] = useState(false);
 
-  const { data, loading, error, fetchData } = useApiGet(`/seasons/${seasonId}`);
+  const { data, loading, error } = useApiGet(`/seasons/${seasonId}`);
 
   const {
     sendData: saveData,
@@ -54,16 +54,7 @@ function PreviewChanges() {
     isConfirmationOpen,
   } = useConfirmation();
 
-  const {
-    featureNames,
-    inputMessage,
-    setInputMessage,
-
-    openMisingDatesConfirmation,
-    handleMissingDatesConfirm,
-    handleMissingDatesCancel,
-    isMissingDatesConfirmationOpen,
-  } = useMissingDatesConfirmation();
+  const missingDatesConfirmation = useMissingDatesConfirmation();
 
   function hasChanges() {
     return notes !== "";
@@ -187,7 +178,7 @@ function PreviewChanges() {
       }
     });
 
-    return featureNames;
+    return featureNameList;
   }
 
   async function approve() {
@@ -195,7 +186,9 @@ function PreviewChanges() {
 
     if (featuresWithMissingDates.length > 0) {
       const { confirm, confirmationMessage } =
-        await openMisingDatesConfirmation(featuresWithMissingDates);
+        await missingDatesConfirmation.openConfirmation(
+          featuresWithMissingDates,
+        );
 
       if (confirm) {
         await approveData({
@@ -203,7 +196,7 @@ function PreviewChanges() {
           readyToPublish,
         });
 
-        setInputMessage("");
+        missingDatesConfirmation.setInputMessage("");
         // Redirect back to the Park Details page on success.
         // Use the "approved" query param to show a flash message.
         navigate(`/park/${parkId}?approved=${data.id}`);
@@ -339,12 +332,12 @@ function PreviewChanges() {
       />
 
       <MissingDatesConfirmationDialog
-        featureNames={featureNames}
-        inputMessage={inputMessage}
-        setInputMessage={setInputMessage}
-        isOpen={isMissingDatesConfirmationOpen}
-        onCancel={handleMissingDatesCancel}
-        onConfirm={handleMissingDatesConfirm}
+        featureNames={missingDatesConfirmation.featureNames}
+        inputMessage={missingDatesConfirmation.inputMessage}
+        setInputMessage={missingDatesConfirmation.setInputMessage}
+        isOpen={missingDatesConfirmation.isOpen}
+        onCancel={missingDatesConfirmation.handleCancel}
+        onConfirm={missingDatesConfirmation.handleConfirm}
       />
       <NavBack routePath={`/park/${parkId}/edit/${seasonId}`}>
         Back to {data?.park.name} dates

--- a/frontend/src/router/pages/PreviewWinterFeesChanges.jsx
+++ b/frontend/src/router/pages/PreviewWinterFeesChanges.jsx
@@ -2,7 +2,6 @@ import PropTypes from "prop-types";
 import { useNavigate, useParams } from "react-router-dom";
 import { useEffect, useState } from "react";
 import { useApiGet, useApiPost } from "@/hooks/useApi";
-import { useFlashMessage } from "@/hooks/useFlashMessage";
 import { useNavigationGuard } from "@/hooks/useNavigationGuard";
 import { useConfirmation } from "@/hooks/useConfirmation";
 
@@ -14,7 +13,6 @@ import FeatureIcon from "@/components/FeatureIcon";
 import LoadingBar from "@/components/LoadingBar";
 import ContactBox from "@/components/ContactBox";
 import ReadyToPublishBox from "@/components/ReadyToPublishBox";
-import FlashMessage from "@/components/FlashMessage";
 import DateRange from "@/components/DateRange";
 import ChangeLogsList from "@/components/ChangeLogsList";
 import ConfirmationDialog from "@/components/ConfirmationDialog";
@@ -29,14 +27,6 @@ function PreviewChanges() {
 
   const [notes, setNotes] = useState("");
   const [readyToPublish, setReadyToPublish] = useState(false);
-
-  const {
-    flashTitle,
-    flashMessage,
-    openFlashMessage,
-    handleFlashClose,
-    isFlashOpen,
-  } = useFlashMessage();
 
   const { data, loading, error, fetchData } = useApiGet(
     `/winter-fees/${seasonId}`,
@@ -92,12 +82,8 @@ function PreviewChanges() {
       dates: [],
       readyToPublish,
     });
-    setNotes("");
-    fetchData();
-    openFlashMessage(
-      "Dates saved as draft",
-      `${data?.park.name} ${data?.featureType.name} ${data?.operatingYear} season details saved`,
-    );
+
+    navigate(`/park/${parkId}?saved=${data.id}`);
   }
 
   async function approve() {
@@ -188,13 +174,6 @@ function PreviewChanges() {
 
   return (
     <div className="page review-winter-fees-changes">
-      <FlashMessage
-        title={flashTitle}
-        message={flashMessage}
-        isVisible={isFlashOpen}
-        onClose={handleFlashClose}
-      />
-
       <ConfirmationDialog
         title={title}
         message={message}

--- a/frontend/src/router/pages/PublishPage.jsx
+++ b/frontend/src/router/pages/PublishPage.jsx
@@ -11,6 +11,8 @@ function PublishPage() {
   const {
     title,
     message,
+    confirmButtonText,
+    cancelButtonText,
     confirmationDialogNotes,
     openConfirmation,
     handleConfirm,
@@ -46,6 +48,8 @@ function PublishPage() {
     const confirm = await openConfirmation(
       "Publish dates to API?",
       "All parks that are not flagged will be made public. This cannot be undone.",
+      "Publish",
+      "Cancel",
       "Publishing may take up to one hour.",
     );
 
@@ -73,6 +77,8 @@ function PublishPage() {
         onCancel={handleCancel}
         title={title}
         message={message}
+        confirmButtonText={confirmButtonText}
+        cancelButtonText={cancelButtonText}
         notes={confirmationDialogNotes}
       />
       <div className="d-flex justify-content-end mb-2">

--- a/frontend/src/router/pages/SubmitDates.jsx
+++ b/frontend/src/router/pages/SubmitDates.jsx
@@ -54,6 +54,8 @@ function SubmitDates() {
   const {
     title,
     message,
+    confirmButtonText,
+    cancelButtonText,
     confirmationDialogNotes,
     openConfirmation,
     handleConfirm,
@@ -145,6 +147,8 @@ function SubmitDates() {
       const confirm = await openConfirmation(
         "Move back to draft?",
         "The dates will be moved back to draft and need to be submitted again to be reviewed.",
+        "Move to draft",
+        "Cancel",
         "If dates have already been published, they will not be updated until new dates are submitted, approved, and published.",
       );
 
@@ -696,6 +700,8 @@ function SubmitDates() {
       <ConfirmationDialog
         title={title}
         message={message}
+        confirmButtonText={confirmButtonText}
+        cancelButtonText={cancelButtonText}
         notes={confirmationDialogNotes}
         onCancel={handleCancel}
         onConfirm={handleConfirm}

--- a/frontend/src/router/pages/SubmitDates.jsx
+++ b/frontend/src/router/pages/SubmitDates.jsx
@@ -61,7 +61,7 @@ function SubmitDates() {
     isConfirmationOpen,
   } = useConfirmation();
 
-  const { data, loading, error, fetchData } = useApiGet(`/seasons/${seasonId}`);
+  const { data, loading, error } = useApiGet(`/seasons/${seasonId}`);
   const {
     sendData,
     // error: saveError, // @TODO: handle save errors

--- a/frontend/src/router/pages/SubmitDates.jsx
+++ b/frontend/src/router/pages/SubmitDates.jsx
@@ -16,7 +16,6 @@ import NavBack from "@/components/NavBack";
 import ContactBox from "@/components/ContactBox";
 import ReadyToPublishBox from "@/components/ReadyToPublishBox";
 import LoadingBar from "@/components/LoadingBar";
-import FlashMessage from "@/components/FlashMessage";
 import TooltipWrapper from "@/components/TooltipWrapper";
 import ChangeLogsList from "@/components/ChangeLogsList";
 import ConfirmationDialog from "@/components/ConfirmationDialog";
@@ -24,7 +23,6 @@ import FeatureIcon from "@/components/FeatureIcon";
 
 import useValidation from "@/hooks/useValidation";
 import { useConfirmation } from "@/hooks/useConfirmation";
-import { useFlashMessage } from "@/hooks/useFlashMessage";
 import { useNavigationGuard } from "@/hooks/useNavigationGuard";
 import { useApiGet, useApiPost } from "@/hooks/useApi";
 import {
@@ -62,14 +60,6 @@ function SubmitDates() {
     handleCancel,
     isConfirmationOpen,
   } = useConfirmation();
-
-  const {
-    flashTitle,
-    flashMessage,
-    openFlashMessage,
-    handleFlashClose,
-    isFlashOpen,
-  } = useFlashMessage();
 
   const { data, loading, error, fetchData } = useApiGet(`/seasons/${seasonId}`);
   const {
@@ -131,12 +121,7 @@ function SubmitDates() {
     const response = await sendData(payload);
 
     if (savingDraft) {
-      setNotes("");
-      fetchData();
-      openFlashMessage(
-        "Dates saved as draft",
-        `${season?.park.name} ${season?.featureType.name} ${season?.operatingYear} season details saved`,
-      );
+      navigate(`/park/${parkId}?saved=${data.id}`);
     }
 
     return response;
@@ -691,12 +676,6 @@ function SubmitDates() {
 
   return (
     <div className="page submit-dates">
-      <FlashMessage
-        title={flashTitle}
-        message={flashMessage}
-        isVisible={isFlashOpen}
-        onClose={handleFlashClose}
-      />
       <ConfirmationDialog
         title={title}
         message={message}
@@ -811,7 +790,7 @@ function SubmitDates() {
               onClick={continueToPreview}
               disabled={!hasChanges()}
             >
-              Continue to preview
+              Save and continue to preview
             </button>
 
             {saving && (

--- a/frontend/src/router/pages/SubmitWinterFeesDates.jsx
+++ b/frontend/src/router/pages/SubmitWinterFeesDates.jsx
@@ -362,9 +362,7 @@ export default function SubmitWinterFeesDates() {
   const [notes, setNotes] = useState("");
   const [readyToPublish, setReadyToPublish] = useState(false);
 
-  const { data, loading, error, fetchData } = useApiGet(
-    `/winter-fees/${seasonId}`,
-  );
+  const { data, loading, error } = useApiGet(`/winter-fees/${seasonId}`);
 
   const {
     sendData,

--- a/frontend/src/router/pages/SubmitWinterFeesDates.jsx
+++ b/frontend/src/router/pages/SubmitWinterFeesDates.jsx
@@ -19,12 +19,11 @@ import FeatureIcon from "@/components/FeatureIcon";
 import ChangeLogsList from "@/components/ChangeLogsList";
 import ContactBox from "@/components/ContactBox";
 import ReadyToPublishBox from "@/components/ReadyToPublishBox";
-import FlashMessage from "@/components/FlashMessage";
 import ConfirmationDialog from "@/components/ConfirmationDialog";
 
 import { useApiGet, useApiPost } from "@/hooks/useApi";
-import { useFlashMessage } from "@/hooks/useFlashMessage";
 import { useConfirmation } from "@/hooks/useConfirmation";
+import { useNavigationGuard } from "@/hooks/useNavigationGuard";
 
 import {
   formatDateRange,
@@ -374,16 +373,10 @@ export default function SubmitWinterFeesDates() {
   } = useApiPost(`/seasons/${seasonId}/save/`);
 
   const {
-    flashTitle,
-    flashMessage,
-    openFlashMessage,
-    handleFlashClose,
-    isFlashOpen,
-  } = useFlashMessage();
-
-  const {
     title,
     message,
+    confirmButtonText,
+    cancelButtonText,
     confirmationDialogNotes,
     openConfirmation,
     handleConfirm,
@@ -406,6 +399,8 @@ export default function SubmitWinterFeesDates() {
 
     return datesChanged || notes;
   }
+
+  useNavigationGuard(hasChanges, openConfirmation);
 
   async function saveChanges(savingDraft) {
     // @TODO: Validate form state before saving
@@ -442,12 +437,7 @@ export default function SubmitWinterFeesDates() {
     const response = await sendData(payload);
 
     if (savingDraft) {
-      setNotes("");
-      fetchData();
-      openFlashMessage(
-        "Dates saved as draft",
-        `${season.park.name} ${season.name} winter fee season details saved`,
-      );
+      navigate(`/park/${parkId}?saved=${data.id}`);
     }
 
     return response;
@@ -458,6 +448,8 @@ export default function SubmitWinterFeesDates() {
       const confirm = await openConfirmation(
         "Move back to draft?",
         "The dates will be moved back to draft and need to be submitted again to be reviewed.",
+        "Move to draft",
+        "Cancel",
         "If dates have already been published, they will not be updated until new dates are submitted, approved, and published.",
       );
 
@@ -523,16 +515,11 @@ export default function SubmitWinterFeesDates() {
 
   return (
     <div className="page submit-winter-fees-dates">
-      <FlashMessage
-        title={flashTitle}
-        message={flashMessage}
-        isVisible={isFlashOpen}
-        onClose={handleFlashClose}
-      />
-
       <ConfirmationDialog
         title={title}
         message={message}
+        confirmButtonText={confirmButtonText}
+        cancelButtonText={cancelButtonText}
         notes={confirmationDialogNotes}
         onCancel={handleCancel}
         onConfirm={handleConfirm}
@@ -635,7 +622,7 @@ export default function SubmitWinterFeesDates() {
               onClick={continueToPreview}
               disabled={!hasChanges()}
             >
-              Continue to preview
+              Save and continue to preview
             </button>
 
             {saving && (


### PR DESCRIPTION
### Jira Ticket

CMS-517

### Description
- changing button labels specific to each modal
- changing some titles that were updated in the wireframes
- navigate to park details page when user saves draft
- create new confirmation dialog with text input that will be added to the notes


Copied from my comment on https://bcparksdigital.atlassian.net/browse/CMS-517

- The modal for “Edit public dates on API?” appears twice on the wireframes with different titles “Edit published dates?“. But according to this ticket, the title should be “Edit public dates on API?“.

- I don’t know if there’s a difference between the “Exit without saving?” modal and the “Discard changes?“ modal. Some notes on this.

     - Navigating away by clicking the back button next to “save draft“ or by clicking the BC parks logo would show the “Discard changes?“ modal.

     - Actions like: closing the tab, clicking the back button on the browser, and reloading the page are browser-level events and we cannot guarantee that the custom modal would be displayed for those. So, only the browser alert would be displayed. Like this:


- When the user clicks the “save draft“ button either in the form or the preview page. A flash message should be displayed with “Dates saved as draft“. This ticket mentions that we should navigate back to the park details page. However, the wireframes show the “Dates saved as draft“ flash message on the Form and Preview pages. Since we couldn’t show the flash message and then navigate right away to the park details page, the “Dates saved as draft“ will be displayed in the park details page. (Similar to the “Dates approved” flash message).

- For now, I updated the label of the button “Continue to preview“ to – > “Save and continue to preview“. This change is temporary for this current version and would be changed back when this ticket is implemented. This related to the confusion between preview and review pages. 

https://bcparksdigital.atlassian.net/browse/CMS-577 
