### PR TITLE
CMS-706: updatedAt timestamp on Season will be null on creation

### DIFF
--- a/backend/migrations/20250219192557-change-season-updatedAt.js
+++ b/backend/migrations/20250219192557-change-season-updatedAt.js
@@ -1,0 +1,18 @@
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    // allow null values for updatedAt
+    await queryInterface.changeColumn("Seasons", "updatedAt", {
+      type: Sequelize.DATE,
+      allowNull: true,
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    // disallow null values for updatedAt
+    await queryInterface.changeColumn("Seasons", "updatedAt", {
+      type: Sequelize.DATE,
+      allowNull: false,
+    });
+  },
+};

--- a/backend/models/season.js
+++ b/backend/models/season.js
@@ -37,10 +37,20 @@ export default (sequelize) => {
         allowNull: false,
         defaultValue: false,
       },
+      createdAt: DataTypes.DATE,
+      updatedAt: {
+        type: DataTypes.DATE,
+        allowNull: true,
+      },
     },
     {
       sequelize,
       modelName: "Season",
+      hooks: {
+        beforeCreate(season) {
+          season.updatedAt = null;
+        },
+      },
     },
   );
   return Season;

--- a/frontend/src/components/ParkDetailsSeason.jsx
+++ b/frontend/src/components/ParkDetailsSeason.jsx
@@ -64,7 +64,9 @@ export default function ParkSeason({
   // @TODO: implement logic to disable preview button
   const disablePreviewButton = true;
 
-  const updateDate = formatDate(season.updatedAt, "America/Vancouver");
+  const updateDate = season.updatedAt
+    ? formatDate(season.updatedAt, "America/Vancouver")
+    : "Never";
 
   async function navigateToEdit() {
     if (season.status === "pending review") {


### PR DESCRIPTION
### Jira Ticket

CMS-706

### Description
- updatedAt timestamp on Season will be null on creation because we want to show that a season has "never" been updated on the DOOT. 
- added a migration to allow null values on that field 
- added a hook on the Season model that sets the value to null on creation
