### PR TITLE
CMS-721: Allow users to clear dates data from a group of seasons.

### DIFF
--- a/backend/middleware/adminJs.js
+++ b/backend/middleware/adminJs.js
@@ -1,8 +1,10 @@
 import AdminJSExpress from "@adminjs/express";
 import AdminJS from "adminjs";
+import { ComponentLoader } from "adminjs";
 import * as AdminJSSequelize from "@adminjs/sequelize";
 import Connect from "connect-pg-simple";
 import session from "express-session";
+import { Op } from "sequelize";
 
 import {
   Dateable,
@@ -38,8 +40,108 @@ async function authenticate(email, password) {
   return null;
 }
 
+const SeasonResource = {
+  resource: Season,
+
+  options: {
+    actions: {
+      resetData: {
+        actionType: "bulk",
+        icon: "RefreshCw",
+        label: "Reset dates data",
+        component: false,
+        async handler(request, response, context) {
+          const { records } = context;
+
+          for (const record of records) {
+            const seasonId = record.params.id;
+
+            // set status to requested for this season
+            await Season.update(
+              {
+                status: "requested",
+              },
+              {
+                where: {
+                  id: seasonId,
+                },
+              },
+            );
+
+            // set startDate and endDate to null for every daterange in this season
+            await DateRange.update(
+              {
+                startDate: null,
+                endDate: null,
+              },
+              {
+                where: {
+                  seasonId,
+                },
+              },
+            );
+
+            // get all seasonChangeLogs in this season
+            const seasonChangeLogs = await SeasonChangeLog.findAll({
+              where: {
+                seasonId,
+              },
+              attributes: ["id"],
+            });
+
+            const seasonChangeLogIds = seasonChangeLogs.map((log) => log.id);
+
+            // delete every dateChangeLog in this season
+            await DateChangeLog.destroy({
+              where: {
+                seasonChangeLogId: {
+                  [Op.in]: seasonChangeLogIds,
+                },
+              },
+            });
+
+            // delete every seasonChangeLog in this season
+            await SeasonChangeLog.destroy({
+              where: {
+                seasonId,
+              },
+            });
+          }
+
+          try {
+            return {
+              records: records.map((record) => record.toJSON()),
+              notice: {
+                message: "Successfully reset dates data",
+                type: "success",
+              },
+            };
+          } catch (error) {
+            return {
+              notice: {
+                message: error.toString(),
+                type: "error",
+              },
+            };
+          }
+        },
+      },
+    },
+  },
+};
+
+function getSeasonResource() {
+  if (process.env.NODE_ENV === "production") {
+    return Season;
+  }
+  return SeasonResource;
+}
+
+const componentLoader = new ComponentLoader();
+
 const adminOptions = {
   // We pass Category to `resources`
+  componentLoader,
   resources: [
     Dateable,
     Park,
@@ -48,7 +150,7 @@ const adminOptions = {
     FeatureType,
     Feature,
     DateType,
-    Season,
+    getSeasonResource(),
     DateRange,
     SeasonChangeLog,
     DateChangeLog,


### PR DESCRIPTION
### Jira Ticket

CMS-721

### Description
From the ticket comments:
Updating the sync script to make all 2025 dates “empty” can have other implications and it would mean that none of the 2025 season dates would be imported from Strapi. So, any important dates that were already created for that season would be missing in the DOOT and there wouldn’t be a way to import them unless we created a separate script. Additionally, if updated the sync script that would remove that from all environments even if it’s useful for QA or devs in other environments. 

So, instead of updating the script I added an action button to the seasons in the Admin.js dashboard that lets you clear the data for a group of seasons. That way, you can choose to clear the data for:

 an individual season you want to test

all the seasons for a given park and feature type

all the seasons for a given operating year

all the winter seasons for a park

any other condition.

As the season’s data is reset and the season has empty dates. The seasons' statuses will be set to “requested“ and all the existing notes and change logs would be deleted for that season.

This feature would NOT be available in prod. 

Video demo on the ticket. 
