### PR TITLE
CMS-639: Use disabled attribute instead of class

### DIFF
--- a/frontend/src/router/pages/ExportPage.jsx
+++ b/frontend/src/router/pages/ExportPage.jsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from "react";
-import classNames from "classnames";
 import { saveAs } from "file-saver";
 import { faCalendarCheck } from "@fa-kit/icons/classic/regular";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -241,9 +240,8 @@ function ExportPage() {
           <fieldset className="d-flex">
             <button
               role="button"
-              className={classNames("btn btn-primary", {
-                disabled: disableButton,
-              })}
+              className="btn btn-primary"
+              disabled={disableButton}
               onClick={getCsv}
             >
               Export report

--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -102,7 +102,8 @@ a:not(.btn):focus {
 }
 
 // override bootstrap button disabled styles
-.btn:disabled {
+.btn:disabled,
+.btn.disabled {
   // allow pointer events so the cursor can change
   pointer-events: inherit;
   cursor: not-allowed;


### PR DESCRIPTION
### Jira Ticket

CMS-639

### Description
<!-- What did you change, and why? -->

A small fix for the disabled styles on one button on the Export page. I switched it to use the "disabled" attribute instead of the CSS class. But then I also updated the styles to apply to the class anyway.