### PR TITLE
CMS-708: Increase bottom margin on winter feature header

### DIFF
--- a/frontend/src/components/ParkDetailsWinterFeesDates.jsx
+++ b/frontend/src/components/ParkDetailsWinterFeesDates.jsx
@@ -48,7 +48,7 @@ export default function SeasonDates({ data }) {
       <div className="winter-fee-seasons">
         {data.featureTypes.map((featureType) => (
           <div key={featureType.id} className="winter-fees-season mb-4">
-            <h3 className="header-with-icon">
+            <h3 className="header-with-icon mb-4">
               <FeatureIcon iconName={featureType.icon} />
               {featureType.name}
             </h3>


### PR DESCRIPTION
### Jira Ticket

CMS-708

### Description
<!-- What did you change, and why? -->

Small CSS tweak to increase the spacing between the feature type and the feature name under Winter Fees. Using the same "mb-4" spacing as everything else on that page.