### PR TITLE
CMS-732: Correct hasWinterFeeDates flag name on sync script

### DIFF
--- a/backend/strapi-sync/sync.js
+++ b/backend/strapi-sync/sync.js
@@ -572,7 +572,7 @@ export async function createDatesAndSeasons(datesData) {
   await DateRange.bulkCreate(winterDatesToCreate);
   await Feature.update(
     {
-      hasWinterFees: true,
+      hasWinterFeeDates: true,
     },
     {
       where: {


### PR DESCRIPTION
### Jira Ticket

CMS-732

### Description
Incorrect flag name on sync script prevented winter fee features from being fetched.
