### PR TITLE
CMS-467: Update winter fees frontend pages

### DIFF
--- a/frontend/src/router/pages/PreviewChanges.jsx
+++ b/frontend/src/router/pages/PreviewChanges.jsx
@@ -57,7 +57,7 @@ function PreviewChanges() {
   const missingDatesConfirmation = useMissingDatesConfirmation();
 
   function hasChanges() {
-    return notes !== "";
+    return notes !== "" || data.readyToPublish !== readyToPublish;
   }
 
   useNavigationGuard(hasChanges, openConfirmation);

--- a/frontend/src/router/pages/PreviewChanges.scss
+++ b/frontend/src/router/pages/PreviewChanges.scss
@@ -13,17 +13,14 @@
     }
   }
 
-  .type-column,
+  .current-date-column,
   .prev-date-column {
-    width: 33.33%;
-  }
-
-  .current-date-column {
-    width: 25%;
+    width: 32%;
+    min-width: 14em;
   }
 
   .actions-column {
-    width: 8.33%;
+    width: 7rem;
   }
 
   .table th,

--- a/frontend/src/router/pages/PreviewWinterFeesChanges.jsx
+++ b/frontend/src/router/pages/PreviewWinterFeesChanges.jsx
@@ -57,7 +57,7 @@ function PreviewChanges() {
   const missingDatesConfirmation = useMissingDatesConfirmation();
 
   function hasChanges() {
-    return notes !== "";
+    return notes !== "" || data.readyToPublish !== readyToPublish;
   }
 
   useNavigationGuard(hasChanges, openConfirmation);

--- a/frontend/src/router/pages/SubmitDates.jsx
+++ b/frontend/src/router/pages/SubmitDates.jsx
@@ -78,7 +78,9 @@ function SubmitDates() {
       ),
     );
 
-    return datesChanged || notes;
+    const readyChanged = readyToPublish !== data.readyToPublish;
+
+    return datesChanged || notes || readyChanged;
   }
 
   async function saveChanges(savingDraft) {

--- a/frontend/src/router/pages/SubmitWinterFeesDates.jsx
+++ b/frontend/src/router/pages/SubmitWinterFeesDates.jsx
@@ -409,7 +409,9 @@ export default function SubmitWinterFeesDates() {
       dateRanges.some((dateRange) => dateRange.changed),
     );
 
-    return datesChanged || notes;
+    const readyChanged = readyToPublish !== data.readyToPublish;
+
+    return datesChanged || notes || readyChanged;
   }
 
   useNavigationGuard(hasChanges, openConfirmation);


### PR DESCRIPTION
### Jira Ticket

CMS-467

### Description
<!-- What did you change, and why? -->

Minor changes from the design review feedback for winter fees:

- Tweaked the column widths on the preview page date tables. Now they'll tend to look a bit better on very big or very small screens
- Updated both Edit pages and both Preview pages to include the "Ready to publish" toggle when calculating the "hasChanges" logic. If you flip the switch but don't make any other edits, it will now count as a "change" and let you click save.