### PR TITLE
Cms 721 reset udpated at timestamp

### DIFF
--- a/backend/middleware/adminJs.js
+++ b/backend/middleware/adminJs.js
@@ -57,16 +57,16 @@ const SeasonResource = {
             const seasonId = record.params.id;
 
             // set status to requested for this season
-            await Season.update(
-              {
-                status: "requested",
-              },
-              {
-                where: {
-                  id: seasonId,
-                },
-              },
-            );
+            const season = await Season.findByPk(seasonId);
+
+            season.status = "requested";
+            season.readyToPublish = true;
+            season.updatedAt = null;
+
+            // updatedAt can only be set to null if we call save(), not with bulkUpdate
+            await season.save({
+              fields: ["status", "readyToPublish", "updatedAt"],
+            });
 
             // set startDate and endDate to null for every daterange in this season
             await DateRange.update(

--- a/backend/models/season.js
+++ b/backend/models/season.js
@@ -55,6 +55,9 @@ export default (sequelize) => {
         },
         beforeBulkUpdate(seasons) {
           // set updatedAt to current date
+          // updatedAt timeStamp will only be updated with bulkUpdate
+          // we need to use individual save() for when we want to set it to null
+          seasons.fields.push("updatedAt");
           seasons.attributes.updatedAt = new Date();
         },
       },

--- a/backend/models/season.js
+++ b/backend/models/season.js
@@ -26,6 +26,7 @@ export default (sequelize) => {
       });
     }
   }
+
   Season.init(
     {
       operatingYear: DataTypes.INTEGER,
@@ -46,9 +47,15 @@ export default (sequelize) => {
     {
       sequelize,
       modelName: "Season",
+      timestamps: false,
       hooks: {
         beforeCreate(season) {
           season.updatedAt = null;
+          season.createdAt = new Date();
+        },
+        beforeBulkUpdate(seasons) {
+          // set updatedAt to current date
+          seasons.attributes.updatedAt = new Date();
         },
       },
     },

--- a/backend/routes/api/publish.js
+++ b/backend/routes/api/publish.js
@@ -260,10 +260,16 @@ async function markFeatureDatesInactive(dates) {
  * @returns {void}
  */
 async function markSeasonPublished(seasonId) {
-  const season = await Season.findByPk(seasonId);
-
-  season.status = "on API";
-  season.save();
+  Season.update(
+    {
+      status: "on API",
+    },
+    {
+      where: {
+        id: seasonId,
+      },
+    },
+  );
 }
 
 /**
@@ -395,13 +401,19 @@ router.post(
       ],
     });
 
-    Promise.all(
-      approvedSeasons.map(async (season) => {
-        season.status = "on API";
-        await season.save();
+    const seasonIds = approvedSeasons.map((season) => season.id);
 
-        console.log(season.status);
-      }),
+    Season.update(
+      {
+        status: "on API",
+      },
+      {
+        where: {
+          id: {
+            [Op.in]: seasonIds,
+          },
+        },
+      },
     );
 
     // TODO: commenting out the code below to not update strapi until new strucutre is in place


### PR DESCRIPTION
### Jira Ticket

CMS-721

### Description
Update Season to not have automatic timestamps and created custom hooks to manage them.
We need:
- updatedAt to be null on creation
- updatedAt to be the current time whenever a season is updated for any reason
- updatedAt to be null again when the season data is reset

The only way to manage this is to disable automatic timestamps and manage manually.

I added hooks that will update the updatedAt flag for every bulkupdate on seasons. 
We need individual season updates to be unaffected by the hook, because we need to set updatedAt to null when the season is reset. 
