### PR TITLE
CMS-711: Add offline_access token scope

### DIFF
--- a/frontend/src/config/keycloak.js
+++ b/frontend/src/config/keycloak.js
@@ -12,6 +12,9 @@ export const oidcConfig = {
   automaticSilentRenew: true,
   // Allow cross-tab login/logout detection
   monitorSession: true,
+
+  // Add offline access to the token scope, for long-lived refresh tokens
+  scope: "openid offline_access",
 };
 
 // Strips OIDC parameters from the URL after redirecting back to the app


### PR DESCRIPTION
### Jira Ticket

CMS-711

### Description
<!-- What did you change, and why? -->

#127 fixed the token refreshing, but the refresh token still expires after 6 hours and weird stuff happens. This branch adds "offline access" to the token scope, so the refresh token lasts a long time. It would let the user use the app all day without having to log back in after 5 or 6 hours. Currently still reading up on the consequences of "offline access"