### PR TITLE
CMS-650: Add error flash messages

### DIFF
--- a/frontend/src/components/FlashMessage.jsx
+++ b/frontend/src/components/FlashMessage.jsx
@@ -23,6 +23,7 @@ function FlashMessage({
     ["error", faOctagonExclamation],
   ]);
 
+  // Allow custom icons, or use the variant / default
   const displayIcon = icon ?? variantIcons.get(variant) ?? faCheck;
 
   return (

--- a/frontend/src/components/FlashMessage.jsx
+++ b/frontend/src/components/FlashMessage.jsx
@@ -2,28 +2,37 @@
 import PropTypes from "prop-types";
 import "./FlashMessage.scss";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faClose, faCheck } from "@fa-kit/icons/classic/regular";
+import {
+  faClose,
+  faCheck,
+  faOctagonExclamation,
+} from "@fa-kit/icons/classic/regular";
 
 function FlashMessage({
   title,
-  message,
+  message = "",
   isVisible,
   onClose,
-  icon = faCheck,
+  icon = null,
   variant = "success",
 }) {
   if (!isVisible) return null;
 
+  const variantIcons = new Map([
+    ["success", faCheck],
+    ["error", faOctagonExclamation],
+  ]);
+
+  const displayIcon = icon ?? variantIcons.get(variant) ?? faCheck;
+
   return (
     <div className={`flash-message ${variant}`}>
       <span className="flash-message__icon">
-        <FontAwesomeIcon icon={icon} />
+        <FontAwesomeIcon icon={displayIcon} />
       </span>
       <div className="flash-message__content">
         <div className="flash-message__title">{title}</div>
-        {variant === "success" && (
-          <div className="flash-message__subtitle">{message}</div>
-        )}
+        {message && <div className="flash-message__subtitle">{message}</div>}
       </div>
       <button onClick={onClose} className="flash-message__close">
         <FontAwesomeIcon icon={faClose} />
@@ -37,7 +46,7 @@ export default FlashMessage;
 // add propTypes for FlashMessage
 FlashMessage.propTypes = {
   title: PropTypes.string.isRequired,
-  message: PropTypes.string.isRequired,
+  message: PropTypes.string,
   isVisible: PropTypes.bool.isRequired,
   onClose: PropTypes.func.isRequired,
   icon: PropTypes.string,

--- a/frontend/src/components/FlashMessage.scss
+++ b/frontend/src/components/FlashMessage.scss
@@ -23,6 +23,10 @@
     background-color: var(--support-border-color-success);
   }
 
+  &.error {
+    background-color: var(--support-border-color-danger);
+  }
+
   &.info {
     background-color: var(--support-border-color-info);
   }

--- a/frontend/src/components/ParkDetailsSeason.jsx
+++ b/frontend/src/components/ParkDetailsSeason.jsx
@@ -10,9 +10,11 @@ import { useApiGet } from "@/hooks/useApi";
 import ExpandableContent from "@/components/ExpandableContent";
 import NotReadyFlag from "@/components/NotReadyFlag";
 import StatusBadge from "@/components/StatusBadge";
+import ConfirmationDialog from "@/components/ConfirmationDialog";
+import FlashMessage from "@/components/FlashMessage";
 
 import { useConfirmation } from "@/hooks/useConfirmation";
-import ConfirmationDialog from "@/components/ConfirmationDialog";
+import { useFlashMessage } from "@/hooks/useFlashMessage";
 
 export default function ParkSeason({
   season,
@@ -23,6 +25,8 @@ export default function ParkSeason({
   DetailsComponent,
 }) {
   const navigate = useNavigate();
+
+  const errorFlashMessage = useFlashMessage();
 
   const [expanded, setExpanded] = useState(false);
 
@@ -52,7 +56,16 @@ export default function ParkSeason({
 
     // If the panel is about to expand, fetch the data
     if (!expanded && datesData === null) {
-      fetchData();
+      fetchData().catch((expandFetchError) => {
+        console.error("Failed to fetch season dates", expandFetchError);
+
+        errorFlashMessage.openFlashMessage(
+          "Failed to fetch season dates",
+          "There was a problem loading the data. Please try again.",
+        );
+
+        setExpanded(false);
+      });
     }
 
     setExpanded(!expanded);
@@ -110,6 +123,14 @@ export default function ParkSeason({
 
   return (
     <div className={classNames("season expandable", { expanded })}>
+      <FlashMessage
+        title={errorFlashMessage.flashTitle}
+        message={errorFlashMessage.flashMessage}
+        isVisible={errorFlashMessage.isFlashOpen}
+        onClose={errorFlashMessage.handleFlashClose}
+        variant="error"
+      />
+
       <ConfirmationDialog
         title={title}
         message={message}

--- a/frontend/src/hooks/useValidation.js
+++ b/frontend/src/hooks/useValidation.js
@@ -289,6 +289,9 @@ export default function useValidation(dates, notes, season) {
     return validateFeatureDates(dateableId, datesObj);
   }
 
+  // Export a special non-fatal error for handling validation errors
+  class ValidationError extends Error {}
+
   return {
     errors,
     setErrors,
@@ -303,5 +306,6 @@ export default function useValidation(dates, notes, season) {
     validateFeatureDates,
     validateForm,
     onUpdateDateRange,
+    ValidationError,
   };
 }

--- a/frontend/src/router/pages/ExportPage.jsx
+++ b/frontend/src/router/pages/ExportPage.jsx
@@ -10,13 +10,8 @@ import FlashMessage from "@/components/FlashMessage";
 import "./ExportPage.scss";
 
 function ExportPage() {
-  const {
-    flashTitle,
-    flashMessage,
-    openFlashMessage,
-    handleFlashClose,
-    isFlashOpen,
-  } = useFlashMessage();
+  const successFlash = useFlashMessage();
+  const errorFlash = useFlashMessage();
 
   const { data: options, loading, error } = useApiGet("/export/options");
   const [exportYear, setExportYear] = useState();
@@ -95,12 +90,17 @@ function ExportPage() {
 
       saveAs(blob, filename);
 
-      openFlashMessage(
+      successFlash.openFlashMessage(
         "Export complete",
         "Check your Downloads for the Excel document.",
       );
     } catch (csvError) {
       console.error("Error generating CSV", csvError);
+
+      errorFlash.openFlashMessage(
+        "Export failed",
+        "There was an error generating the Excel document. Please try again.",
+      );
     }
   }
 
@@ -121,10 +121,18 @@ function ExportPage() {
   return (
     <div className="page export">
       <FlashMessage
-        title={flashTitle}
-        message={flashMessage}
-        isVisible={isFlashOpen}
-        onClose={handleFlashClose}
+        title={successFlash.flashTitle}
+        message={successFlash.flashMessage}
+        isVisible={successFlash.isFlashOpen}
+        onClose={successFlash.handleFlashClose}
+      />
+
+      <FlashMessage
+        title={errorFlash.flashTitle}
+        message={errorFlash.flashMessage}
+        isVisible={errorFlash.isFlashOpen}
+        onClose={errorFlash.handleFlashClose}
+        variant="error"
       />
       <p>Select the format of your export:</p>
 

--- a/frontend/src/router/pages/PreviewWinterFeesChanges.jsx
+++ b/frontend/src/router/pages/PreviewWinterFeesChanges.jsx
@@ -5,6 +5,7 @@ import { useApiGet, useApiPost } from "@/hooks/useApi";
 import { useNavigationGuard } from "@/hooks/useNavigationGuard";
 import { useConfirmation } from "@/hooks/useConfirmation";
 import { useMissingDatesConfirmation } from "@/hooks/useMissingDatesConfirmation";
+import { useFlashMessage } from "@/hooks/useFlashMessage";
 
 import { faPen } from "@fa-kit/icons/classic/solid";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -18,6 +19,7 @@ import DateRange from "@/components/DateRange";
 import ChangeLogsList from "@/components/ChangeLogsList";
 import ConfirmationDialog from "@/components/ConfirmationDialog";
 import MissingDatesConfirmationDialog from "@/components/MissingDatesConfirmationDialog";
+import FlashMessage from "@/components/FlashMessage";
 
 import { Link } from "react-router-dom";
 
@@ -32,15 +34,15 @@ function PreviewChanges() {
 
   const { data, loading, error } = useApiGet(`/winter-fees/${seasonId}`);
 
-  const {
-    sendData: saveData,
-    // error: saveError, // @TODO: handle save errors
-    loading: saving,
-  } = useApiPost(`/seasons/${seasonId}/save/`);
+  const { sendData: saveData, loading: saving } = useApiPost(
+    `/seasons/${seasonId}/save/`,
+  );
 
   const { sendData: approveData, loading: savingApproval } = useApiPost(
     `/seasons/${seasonId}/approve/`,
   );
+
+  const errorFlashMessage = useFlashMessage();
 
   const {
     title,
@@ -80,14 +82,27 @@ function PreviewChanges() {
     ));
   }
 
-  async function savePreview() {
-    await saveData({
-      notes,
-      dates: [],
-      readyToPublish,
-    });
+  function showErrorFlash() {
+    errorFlashMessage.openFlashMessage(
+      "Unable to save changes",
+      "There was a problem saving these changes. Please try again.",
+    );
+  }
 
-    navigate(`/park/${parkId}?saved=${data.id}`);
+  async function savePreview() {
+    try {
+      await saveData({
+        notes,
+        dates: [],
+        readyToPublish,
+      });
+
+      navigate(`/park/${parkId}?saved=${data.id}`);
+    } catch (err) {
+      console.error("Error saving preview", err);
+
+      showErrorFlash();
+    }
   }
 
   function getFeaturesWithMissingDates() {
@@ -103,31 +118,37 @@ function PreviewChanges() {
   async function approve() {
     const featuresWithMissingDates = getFeaturesWithMissingDates();
 
-    if (featuresWithMissingDates.length > 0) {
-      const { confirm, confirmationMessage } =
-        await missingDatesConfirmation.openConfirmation(
-          featuresWithMissingDates,
-        );
+    try {
+      if (featuresWithMissingDates.length > 0) {
+        const { confirm, confirmationMessage } =
+          await missingDatesConfirmation.openConfirmation(
+            featuresWithMissingDates,
+          );
 
-      if (confirm) {
+        if (confirm) {
+          await approveData({
+            notes: [notes, confirmationMessage],
+            readyToPublish,
+          });
+
+          missingDatesConfirmation.setInputMessage("");
+          // Redirect back to the Park Details page on success.
+          // Use the "approved" query param to show a flash message.
+          navigate(`/park/${parkId}?approved=${data.id}`);
+        }
+      } else {
         await approveData({
-          notes: [notes, confirmationMessage],
+          notes: [notes],
           readyToPublish,
         });
-
-        missingDatesConfirmation.setInputMessage("");
         // Redirect back to the Park Details page on success.
         // Use the "approved" query param to show a flash message.
         navigate(`/park/${parkId}?approved=${data.id}`);
       }
-    } else {
-      await approveData({
-        notes: [notes],
-        readyToPublish,
-      });
-      // Redirect back to the Park Details page on success.
-      // Use the "approved" query param to show a flash message.
-      navigate(`/park/${parkId}?approved=${data.id}`);
+    } catch (err) {
+      console.error("Error approving preview", err);
+
+      showErrorFlash();
     }
   }
 
@@ -208,6 +229,14 @@ function PreviewChanges() {
 
   return (
     <div className="page review-winter-fees-changes">
+      <FlashMessage
+        title={errorFlashMessage.flashTitle}
+        message={errorFlashMessage.flashMessage}
+        isVisible={errorFlashMessage.isFlashOpen}
+        onClose={errorFlashMessage.handleFlashClose}
+        variant="error"
+      />
+
       <ConfirmationDialog
         title={title}
         message={message}

--- a/frontend/src/router/pages/PublishPage.jsx
+++ b/frontend/src/router/pages/PublishPage.jsx
@@ -20,28 +20,21 @@ function PublishPage() {
     isConfirmationOpen,
   } = useConfirmation();
 
-  const {
-    flashTitle,
-    flashMessage,
-    openFlashMessage,
-    handleFlashClose,
-    isFlashOpen,
-  } = useFlashMessage();
+  const successFlash = useFlashMessage();
+  const errorFlash = useFlashMessage();
 
   const { data, loading, error } = useApiGet("/publish/ready-to-publish/");
 
-  const {
-    sendData: publishData,
-    // error: saveError, // @TODO: handle save errors
-    loading: saving,
-  } = useApiPost("/publish/publish-to-api/");
+  const { sendData: publishData, loading: saving } = useApiPost(
+    "/publish/publish-to-api/",
+  );
 
   if (loading) {
     return <LoadingBar />;
   }
 
   if (error) {
-    return <div>Error: {error.message}</div>;
+    return <div>Error loading data: {error.message}</div>;
   }
 
   async function publishToApi() {
@@ -54,23 +47,41 @@ function PublishPage() {
     );
 
     if (confirm) {
-      await publishData();
+      try {
+        await publishData();
 
-      openFlashMessage(
-        "Dates publishing to API",
-        "Approved dates publishing may take up to one hour.",
-      );
+        successFlash.openFlashMessage(
+          "Dates publishing to API",
+          "Approved dates publishing may take up to one hour.",
+        );
+      } catch (publishError) {
+        console.error("Error publishing to API", publishError);
+
+        errorFlash.openFlashMessage(
+          "Publishing failed",
+          "There was an error publishing data to the API. Please try again.",
+        );
+      }
     }
   }
 
   return (
     <div className="page publish">
       <FlashMessage
-        title={flashTitle}
-        message={flashMessage}
-        isVisible={isFlashOpen}
-        onClose={handleFlashClose}
+        title={successFlash.flashTitle}
+        message={successFlash.flashMessage}
+        isVisible={successFlash.isFlashOpen}
+        onClose={successFlash.handleFlashClose}
       />
+
+      <FlashMessage
+        title={errorFlash.flashTitle}
+        message={errorFlash.flashMessage}
+        isVisible={errorFlash.isFlashOpen}
+        onClose={errorFlash.handleFlashClose}
+        variant="error"
+      />
+
       <ConfirmationDialog
         isOpen={isConfirmationOpen}
         onConfirm={handleConfirm}


### PR DESCRIPTION
### Jira Ticket

CMS-650

### Description
<!-- What did you change, and why? -->

This adds flash messages for incidental errors caused by calls to `fetchData` or `sendData`. In most of these places, we were just using console.error to print the error and there was no indication to the user. I left the console lines in, but added a red flash message.

I also left room for a third kind of flash message to alert the user when validation fails. (To be discussed with UX)