### PR TITLE
CMS-467: Sort features in API endpoints

### DIFF
--- a/backend/routes/api/seasons.js
+++ b/backend/routes/api/seasons.js
@@ -163,7 +163,7 @@ router.get(
       dateTypes[dateType.name] = dateType.toJSON();
     });
 
-    const features = parkFeatures.map((featureObj) => {
+    let features = parkFeatures.map((featureObj) => {
       const feature = featureObj.toJSON();
 
       // each feature will have an array of date ranges for the current season and the previous season
@@ -184,6 +184,9 @@ router.get(
       delete feature.dateable.dateRanges;
       return feature;
     });
+
+    // Order features alphabetically before grouping by campground
+    features = _.orderBy(features, ["name"], ["asc"]);
 
     const campgroundsMap = {};
 

--- a/backend/routes/api/winter-seasons.js
+++ b/backend/routes/api/winter-seasons.js
@@ -1,4 +1,5 @@
 import { Router } from "express";
+import _ from "lodash";
 import asyncHandler from "express-async-handler";
 import { Op } from "sequelize";
 
@@ -136,7 +137,10 @@ router.get(
       ],
     });
 
-    const features = featureList.map((feature) => feature.toJSON());
+    let features = featureList.map((feature) => feature.toJSON());
+
+    // Order features alphabetically before grouping by campground
+    features = _.orderBy(features, ["name"], ["asc"]);
 
     // Map to group features by featureType
     const featureTypeMap = {};


### PR DESCRIPTION
### Jira Ticket

CMS-467

### Description
<!-- What did you change, and why? -->

Manually sorting the features array in JS, because I couldn't get the sequelize "order" to work here (?)

Using Elk Lake Park as an example, frontcountry campgrounds with more than one feature were sometimes listed out of order. This will fix them for winter and non-winter seasons, on the Park details page and the edit and preview pages since they all use the same endpoints.