### PR TITLE
CMS-719: Hide pagination for empty results

### DIFF
--- a/frontend/src/router/pages/PaginationBar.jsx
+++ b/frontend/src/router/pages/PaginationBar.jsx
@@ -7,6 +7,11 @@ export default function PaginationBar({
   totalPages,
   onPageChange,
 }) {
+  // Hide the control if there are no results
+  if (totalPages === 0) {
+    return null;
+  }
+
   const isFirstPage = currentPage === 1;
   const isLastPage = currentPage === totalPages;
   const pageRange = range(1, totalPages + 1);


### PR DESCRIPTION
### Jira Ticket

CMS-719

### Description
<!-- What did you change, and why? -->

A small fix to hide the "Previous / Next" buttons on the main page when your other filters have no results. Previously, the buttons still showed with no page numbers, and the "Next" button was clickable.