### PR TITLE
CMS-739: Update PropTypes for optional icons

### DIFF
--- a/frontend/src/components/FeatureIcon.jsx
+++ b/frontend/src/components/FeatureIcon.jsx
@@ -141,5 +141,5 @@ export default function FeatureIcon({ iconName }) {
 
 // props validation
 FeatureIcon.propTypes = {
-  iconName: PropTypes.string.isRequired,
+  iconName: PropTypes.string,
 };

--- a/frontend/src/components/ParkDetailsFeatureType.jsx
+++ b/frontend/src/components/ParkDetailsFeatureType.jsx
@@ -23,7 +23,7 @@ export default function FeatureType({ title, icon, seasons, seasonProps }) {
 
 FeatureType.propTypes = {
   title: PropTypes.string.isRequired,
-  icon: PropTypes.string.isRequired,
+  icon: PropTypes.string,
   seasons: PropTypes.arrayOf(PropTypes.object).isRequired,
 
   // Props to pass to the ParkSeason child component


### PR DESCRIPTION
### Jira Ticket

CMS-739

### Description
<!-- What did you change, and why? -->

Updated the PropTypes for the `FeatureIcon` component to make the `icon` prop optional. It will show a default icon for feature types with a "null" icon (such as "Trail")