### PR TITLE
CMS-740: Fix feature-year row key

### DIFF
--- a/frontend/src/router/pages/PublishPage.jsx
+++ b/frontend/src/router/pages/PublishPage.jsx
@@ -104,7 +104,7 @@ function PublishPage() {
           </thead>
           <tbody>
             {data?.features.map((feature) => (
-              <tr key={feature.id}>
+              <tr key={`${feature.id}-${feature.season}`}>
                 <td>{feature.park.name}</td>
                 <td>{feature.name}</td>
                 <td>


### PR DESCRIPTION
### Jira Ticket

CMS-740

### Description
<!-- What did you change, and why? -->

A quick fix for a duplicate key console error. I added the season to make the key more specific to the table row.