### PR TITLE
CMS-735: Add missing dates and seasons

### DIFF
--- a/backend/import-all-data.sh
+++ b/backend/import-all-data.sh
@@ -11,5 +11,6 @@ npm run sync-data
 npm run one-time-data-import
 npm run create-single-item-campgrounds
 npm run create-multiple-item-campgrounds
+npm run create-missing-dates-and-seasons
 
 echo "All commands executed successfully."

--- a/backend/package.json
+++ b/backend/package.json
@@ -13,7 +13,8 @@
     "sync-data": "node strapi-sync/syncData.js",
     "one-time-data-import": "node strapi-sync/oneTimeDataImport.js",
     "create-single-item-campgrounds": "node strapi-sync/create-single-item-campgrounds.js",
-    "create-multiple-item-campgrounds": "node strapi-sync/create-multiple-item-campgrounds.js"
+    "create-multiple-item-campgrounds": "node strapi-sync/create-multiple-item-campgrounds.js",
+    "create-missing-dates-and-seasons": "node strapi-sync/create-missing-dates-and-seasons.js"
   },
   "author": "",
   "license": "ISC",

--- a/backend/strapi-sync/create-missing-dates-and-seasons.js
+++ b/backend/strapi-sync/create-missing-dates-and-seasons.js
@@ -1,0 +1,154 @@
+import {
+  FeatureType,
+  Feature,
+  Dateable,
+  DateType,
+  Season,
+  DateRange,
+} from "../models/index.js";
+import { createModel } from "./utils.js";
+
+async function createMissingDatesAndSeasons() {
+  const [seasons2025, dateTypes, winterFeatureType, features] =
+    await Promise.all([
+      Season.findAll({
+        where: { operatingYear: 2025 },
+        attributes: ["id", "operatingYear", "parkId", "featureTypeId"],
+      }),
+      DateType.findAll(),
+      FeatureType.findOne({
+        attributes: ["id", "name"],
+        where: { name: "Winter fee" },
+      }),
+      Feature.findAll({
+        attributes: [
+          "id",
+          "name",
+          "strapiId",
+          "parkId",
+          "featureTypeId",
+          "hasReservations",
+          "hasWinterFeeDates",
+        ],
+        include: [
+          {
+            model: Dateable,
+            as: "dateable",
+            attributes: ["id"],
+            include: [
+              {
+                model: DateRange,
+                as: "dateRanges",
+                attributes: [
+                  "id",
+                  "startDate",
+                  "endDate",
+                  "seasonId",
+                  "dateTypeId",
+                ],
+              },
+            ],
+          },
+        ],
+      }),
+    ]);
+
+  const seasonMap = new Map(
+    seasons2025.map((season) => [
+      `${season.parkId}-${season.featureTypeId}`,
+      season,
+    ]),
+  );
+
+  const dateTypeMap = new Map(
+    dateTypes.map((dateType) => [dateType.name, dateType]),
+  );
+
+  const datesToCreate = [];
+
+  // Helper function to get or create a season
+  async function getOrCreateSeason(parkId, featureTypeId) {
+    const key = `${parkId}-${featureTypeId}`;
+
+    if (!seasonMap.has(key)) {
+      // create season right away becase we need the id
+      const newSeason = await createModel(Season, {
+        status: "requested",
+        readyToPublish: true,
+        parkId,
+        featureTypeId,
+        operatingYear: 2025,
+      });
+
+      seasonMap.set(key, newSeason);
+    }
+    return seasonMap.get(key);
+  }
+
+  for (const feature of features) {
+    const season = await getOrCreateSeason(
+      feature.parkId,
+      feature.featureTypeId,
+    );
+
+    // existing dates for this feature-season
+    const existingDateTypes = new Set(
+      feature.dateable.dateRanges
+        .filter((dateRange) => dateRange.seasonId === season.id)
+        .map((dateRange) => dateRange.dateTypeId),
+    );
+
+    // add missing operation dates
+    if (!existingDateTypes.has(dateTypeMap.get("Operation")?.id)) {
+      datesToCreate.push({
+        startDate: null,
+        endDate: null,
+        dateTypeId: dateTypeMap.get("Operation").id,
+        dateableId: feature.dateable.id,
+        seasonId: season.id,
+      });
+    }
+
+    // add missing reservation dates
+    if (
+      feature.hasReservations &&
+      !existingDateTypes.has(dateTypeMap.get("Reservation")?.id)
+    ) {
+      datesToCreate.push({
+        startDate: null,
+        endDate: null,
+        dateTypeId: dateTypeMap.get("Reservation").id,
+        dateableId: feature.dateable.id,
+        seasonId: season.id,
+      });
+    }
+
+    // add winter fee seasons
+    if (feature.hasWinterFeeDates) {
+      const winterSeason = await getOrCreateSeason(
+        feature.parkId,
+        winterFeatureType.id,
+      );
+
+      const existingWinterDates = feature.dateable.dateRanges.filter(
+        (dateRange) => dateRange.seasonId === winterSeason.id,
+      );
+
+      if (existingWinterDates.length === 0) {
+        datesToCreate.push({
+          startDate: null,
+          endDate: null,
+          dateTypeId: dateTypeMap.get("Winter fee").id,
+          dateableId: feature.dateable.id,
+          seasonId: winterSeason.id,
+        });
+      }
+    }
+  }
+
+  if (datesToCreate.length > 0) {
+    await DateRange.bulkCreate(datesToCreate);
+  }
+}
+
+createMissingDatesAndSeasons();

--- a/frontend/src/components/DateRange.jsx
+++ b/frontend/src/components/DateRange.jsx
@@ -6,7 +6,11 @@ import "./DateRange.scss";
 // Displays a date range in a table cell
 export default function DateRange({ start, end, formatWithYear = false }) {
   if (!start || !end) {
-    return "Not submitted";
+    return (
+      <div className="date-range">
+        <span className="date">Not submitted</span>
+      </div>
+    );
   }
 
   const formatFunction = formatWithYear

--- a/frontend/src/components/ParkDetailsSeason.jsx
+++ b/frontend/src/components/ParkDetailsSeason.jsx
@@ -180,7 +180,7 @@ ParkSeason.propTypes = {
     id: PropTypes.number.isRequired,
     operatingYear: PropTypes.number.isRequired,
     status: PropTypes.string.isRequired,
-    updatedAt: PropTypes.string.isRequired,
+    updatedAt: PropTypes.string,
     readyToPublish: PropTypes.bool.isRequired,
   }),
 

--- a/frontend/src/lib/utils.js
+++ b/frontend/src/lib/utils.js
@@ -75,6 +75,10 @@ export function formatDateShortWithYear(date) {
  * @returns {string} formatted date range
  */
 export function formatDateRange(dateRange) {
+  if (dateRange.startDate === null || dateRange.endDate === null) {
+    return "Not submitted";
+  }
+
   const startDate = isoToFormattedString(
     dateRange.startDate,
     DATE_FORMAT_SHORT_WITH_YEAR,


### PR DESCRIPTION
### Jira Ticket

CMS-735

### Description
- Added a script to create missing dates and seasons for 2025, this ensure that users can add dates for 2025 for every feature. Basically, the script will go through every feature:
    - check that a corresponding 2025 season exists for that feature, if it doesn't exist, create it
    - create an operation date for that feature-season if there's none
    - create  a reservation date for that feature-season if there's none and that feature allows for reservations
    - same process for winter fee seasons
 - when there's a previous dateRange that has null values for `startDate` or `endDate`, "Not submitted" will be displayed consistent with the wireframes. 
 - fixed small bug in which "not available" was displayed side by side with no spacing instead of different lines.
 
See the ticket for screenshots of where this is an issue. 
