### PR TITLE
CMS-517: Update labels and info notes on modal windows.

### DIFF
--- a/frontend/src/components/ConfirmationDialog.scss
+++ b/frontend/src/components/ConfirmationDialog.scss
@@ -64,3 +64,19 @@
   color: var(--icons-color-secondary);
   font-size: 32px;
 }
+
+.required-message {
+  color: var(--support-border-color-danger);
+  font-size: var(--typography-regular-small-body);
+}
+
+.word-count {
+  font-size: var(--typography-regular-small-body);
+  color: var(--typography-color-placeholder);
+  text-align: right;
+}
+
+.info-row {
+  display: flex;
+  justify-content: space-between;
+}

--- a/frontend/src/components/MissingDatesConfirmationDialog.jsx
+++ b/frontend/src/components/MissingDatesConfirmationDialog.jsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import PropTypes from "prop-types";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faClose } from "@fa-kit/icons/classic/regular";
@@ -11,7 +12,14 @@ function ConfirmationDialog({
   onConfirm,
   isOpen,
 }) {
+  const wordCount = useMemo(
+    () => inputMessage.split(" ").filter((word) => word).length,
+    [inputMessage],
+  );
+
   if (!isOpen) return null;
+
+  const maxWords = 250;
 
   return (
     <div className="confirmation-dialog-overlay">
@@ -44,18 +52,24 @@ function ConfirmationDialog({
             onChange={(e) => setInputMessage(e.target.value)}
             className="form-control"
           ></textarea>
+          <div className="info-row mt-1">
+            <div className="required-message">Required</div>
+            <div className="word-count">
+              {wordCount}/{maxWords}
+            </div>
+          </div>
         </div>
 
         <div className="confirmation-dialog-actions">
           <button className="btn btn-outline-primary" onClick={onCancel}>
-            Cancel
+            Continue editing
           </button>
           <button
             className="btn btn-primary"
             onClick={onConfirm}
-            disabled={!inputMessage}
+            disabled={!inputMessage || wordCount > maxWords}
           >
-            Confirm
+            Submit
           </button>
         </div>
       </div>

--- a/frontend/src/components/ParkDetailsSeason.jsx
+++ b/frontend/src/components/ParkDetailsSeason.jsx
@@ -86,7 +86,7 @@ export default function ParkSeason({
       const confirm = await openConfirmation(
         "Edit submitted dates?",
         "A review may already be in progress and all dates will need to be reviewed again.",
-        "Edit",
+        "Continue to edit",
       );
 
       if (confirm) {
@@ -96,7 +96,7 @@ export default function ParkSeason({
       const confirm = await openConfirmation(
         "Edit approved dates?",
         "Dates will need to be reviewed again to be approved.",
-        "Edit",
+        "Continue to edit",
       );
 
       if (confirm) {
@@ -106,7 +106,7 @@ export default function ParkSeason({
       const confirm = await openConfirmation(
         "Edit public dates on API?",
         "Dates will need to be reviewed again to be approved and published. If reservations have already begun, visitors will be affected.",
-        "Edit",
+        "Continue to edit",
       );
 
       if (confirm) {

--- a/frontend/src/router/pages/ExportPage.jsx
+++ b/frontend/src/router/pages/ExportPage.jsx
@@ -92,7 +92,7 @@ function ExportPage() {
 
       successFlash.openFlashMessage(
         "Export complete",
-        "Check your Downloads for the Excel document.",
+        "Check your downloads for the Excel document.",
       );
     } catch (csvError) {
       console.error("Error generating CSV", csvError);

--- a/frontend/src/router/pages/PreviewChanges.jsx
+++ b/frontend/src/router/pages/PreviewChanges.jsx
@@ -141,7 +141,7 @@ function PreviewChanges() {
                 ? campground.name
                 : `${campground.name}: ${feature.name}`;
 
-            featureNameList.push(name);
+            featureNameList.push(`${name} operating dates`);
           }
 
           if (feature.hasReservations) {
@@ -158,7 +158,7 @@ function PreviewChanges() {
                   ? campground.name
                   : `${campground.name}: ${feature.name}`;
 
-              featureNameList.push(name);
+              featureNameList.push(`${name} reservation dates`);
             }
           }
         }
@@ -175,7 +175,7 @@ function PreviewChanges() {
         );
 
         if (operatingDates.length === 0) {
-          featureNameList.push(feature.name);
+          featureNameList.push(`${feature.name} operating dates`);
         }
 
         if (feature.hasReservations) {
@@ -187,7 +187,7 @@ function PreviewChanges() {
           );
 
           if (reservationDates.length === 0) {
-            featureNameList.push(feature.name);
+            featureNameList.push(`${feature.name} reservation dates`);
           }
         }
       }


### PR DESCRIPTION
### Jira Ticket

CMS-517 and CMS-743

### Description
Mostly changing labels and some other info displayed on modals.

For CMS-517: 
- For export:
    - ‘Check your downloads for the Excel document.’ < lowercase ‘downloads’ request from Rob

- For ‘Edit public dates on API?’
    - Updated button to ‘Continue to edit’ < the team would prefer the longer version of this

For CMS-743, it's all about the confirmation dialog when approving a season with missing dates: 
- Incorrect button labels displayed as “Cancel” and “ Confirm”
- Missing the word count for the text field
- Missing the date type information along with the subarea details in the bullet point. 
- Should show the Subarea name and the date type
- Missing the required field indication
