### PR TITLE
CMS-657: run sync script from dashboard

### DIFF
--- a/backend/import-all-data.sh
+++ b/backend/import-all-data.sh
@@ -7,10 +7,7 @@ set -e
 npx sequelize-cli db:drop
 npx sequelize-cli db:create
 npm run migrate
-npm run sync-data
-npm run one-time-data-import
-npm run create-single-item-campgrounds
-npm run create-multiple-item-campgrounds
-npm run create-missing-dates-and-seasons
+
+npm run import-data
 
 echo "All commands executed successfully."

--- a/backend/middleware/adminJs.js
+++ b/backend/middleware/adminJs.js
@@ -143,11 +143,8 @@ const ParkResource = {
         component: false,
         // eslint-disable-next-line no-unused-vars -- required by AdminJS
         async handler(request, response, context) {
-          // const { currentAdmin } = context;
-
           try {
-            // Call your backend function to reset the DB
-            await resetScript(); // Replace with your actual function
+            await resetScript();
             console.log("Resetting database...");
 
             return {

--- a/backend/middleware/adminJs.js
+++ b/backend/middleware/adminJs.js
@@ -5,6 +5,7 @@ import * as AdminJSSequelize from "@adminjs/sequelize";
 import Connect from "connect-pg-simple";
 import session from "express-session";
 import { Op } from "sequelize";
+import { resetScript } from "../strapi-sync/reset-and-import-data.js";
 
 import {
   Dateable,
@@ -130,11 +131,58 @@ const SeasonResource = {
   },
 };
 
+const ParkResource = {
+  resource: Park,
+  options: {
+    actions: {
+      resetDatabase: {
+        actionType: "resource",
+        icon: "RefreshCw",
+        label: "Reset Database",
+        guard:
+          "Are you sure you want to reset the database? This action cannot be undone.",
+        component: false,
+        // eslint-disable-next-line no-unused-vars -- required by AdminJS
+        async handler(request, response, context) {
+          // const { currentAdmin } = context;
+
+          try {
+            // Call your backend function to reset the DB
+            // await resetScript(); // Replace with your actual function
+            console.log("Resetting database...");
+
+            return {
+              notice: {
+                message: "Database has been successfully reset!",
+                type: "success",
+              },
+            };
+          } catch (error) {
+            return {
+              notice: {
+                message: error.toString(),
+                type: "error",
+              },
+            };
+          }
+        },
+      },
+    },
+  },
+};
+
 function getSeasonResource() {
   if (process.env.DEV_TEST_MODE === "true") {
     return SeasonResource;
   }
   return Season;
+}
+
+function getParkResource() {
+  if (process.env.DEV_TEST_MODE === "true") {
+    return ParkResource;
+  }
+  return Park;
 }
 
 const componentLoader = new ComponentLoader();
@@ -144,7 +192,7 @@ const adminOptions = {
   componentLoader,
   resources: [
     Dateable,
-    Park,
+    getParkResource(),
     User,
     Campground,
     FeatureType,

--- a/backend/middleware/adminJs.js
+++ b/backend/middleware/adminJs.js
@@ -139,8 +139,7 @@ const ParkResource = {
         actionType: "resource",
         icon: "RefreshCw",
         label: "Reset Database",
-        guard:
-          "Are you sure you want to reset the database? This action cannot be undone.",
+        guard: "Are you sure you want to reset the database?.",
         component: false,
         // eslint-disable-next-line no-unused-vars -- required by AdminJS
         async handler(request, response, context) {
@@ -148,7 +147,7 @@ const ParkResource = {
 
           try {
             // Call your backend function to reset the DB
-            // await resetScript(); // Replace with your actual function
+            await resetScript(); // Replace with your actual function
             console.log("Resetting database...");
 
             return {

--- a/backend/package.json
+++ b/backend/package.json
@@ -10,11 +10,7 @@
     "lint": "eslint .",
     "migrate": "sequelize-cli db:migrate",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "sync-data": "node strapi-sync/syncData.js",
-    "one-time-data-import": "node strapi-sync/oneTimeDataImport.js",
-    "create-single-item-campgrounds": "node strapi-sync/create-single-item-campgrounds.js",
-    "create-multiple-item-campgrounds": "node strapi-sync/create-multiple-item-campgrounds.js",
-    "create-missing-dates-and-seasons": "node strapi-sync/create-missing-dates-and-seasons.js"
+    "import-data": "node strapi-sync/import-data.js"
   },
   "author": "",
   "license": "ISC",

--- a/backend/routes/api/publish.js
+++ b/backend/routes/api/publish.js
@@ -175,12 +175,29 @@ router.get(
   }),
 );
 
+async function getStrapiFeaturesByFeatureId(featureId) {
+  try {
+    // filter by featureId and operatingYear
+    const endpoint = `/api/park-feature-dates?filters[parkOperationSubArea]=${featureId}&filters[operatingYear]=${operatingYear}`;
+
+    const response = await get(endpoint);
+
+    return response.data;
+  } catch (error) {
+    console.error(
+      `Error fetching dates for featureId ${featureId} and year ${operatingYear}`,
+      error,
+    );
+    return [];
+  }
+}
+
 /**
  * Dates added in the staff portal will be sent to the Strapi API - new records will be created
  * @param {Array<Object>} datesToPublish list of dates that will be published to the API
  * @returns {Promise<any>} Promise that resolves when all the records are created in the API
  */
-async function createRecordsInStrapi(datesToPublish) {
+async function createParkOperationSubAreaDatesInStrapi(datesToPublish) {
   // create new records in the strapi API
   const endpoint = "/api/park-operation-sub-area-dates";
 
@@ -202,16 +219,65 @@ async function createRecordsInStrapi(datesToPublish) {
   );
 }
 
+async function createParkFeatureDatesInStrapi(dates) {
+  // create new records in the strapi API
+  const endpoint = "/api/park-feature-dates";
+
+  return Promise.all(
+    dates.map(async (date) => {
+      try {
+        const data = {
+          data: date,
+        };
+
+        await post(endpoint, data);
+      } catch (error) {
+        console.error(
+          `Error creating date for featureId ${date.parkOperationSubArea} and year ${date.operatingYear}`,
+          error,
+        );
+      }
+    }),
+  );
+}
+
+// TODO: create function to create new dates in Strapi using new structure
+// fetch all features using global featureId, then create map of featureId to strapiId
+// use strapiId to create new dates
+
 /**
  * For each featureId and operatingYear pair, get all the dates from the Strapi API - these will be marked as inactive
  * @param {number} featureId id of the feature
  * @param {any} operatingYear operating year of the date object
  * @returns {Promise<Object>} Promise that resolves with the dates from the Strapi API
  */
-async function getFeatureStrapiDates(featureId, operatingYear) {
+async function getStrapiParkOperationSubAreaDates(featureId, operatingYear) {
   try {
     // filter by featureId and operatingYear
     const endpoint = `/api/park-operation-sub-area-dates?filters[parkOperationSubArea]=${featureId}&filters[operatingYear]=${operatingYear}`;
+
+    const response = await get(endpoint);
+
+    return response.data;
+  } catch (error) {
+    console.error(
+      `Error fetching dates for featureId ${featureId} and year ${operatingYear}`,
+      error,
+    );
+    return [];
+  }
+}
+
+/**
+ * For each featureId and operatingYear pair, get all the dates from the Strapi API - these will be marked as inactive
+ * @param {number} featureId id of the feature
+ * @param {any} operatingYear operating year of the date object
+ * @returns {Promise<Object>} Promise that resolves with the dates from the Strapi API
+ */
+async function getStrapiParkFeatureDates(featureId, operatingYear) {
+  try {
+    // filter by featureId and operatingYear
+    const endpoint = `/api/park-feature-dates?filters[parkOperationSubArea]=${featureId}&filters[operatingYear]=${operatingYear}`;
 
     const response = await get(endpoint);
 
@@ -230,7 +296,7 @@ async function getFeatureStrapiDates(featureId, operatingYear) {
  * @param {Array<Object>} dates list of dates to be marked as inactive
  * @returns {Promise<any>} Promise that resolves when all the dates are marked as inactive
  */
-async function markFeatureDatesInactive(dates) {
+async function markStrapiParkOperationSubAreaDatesInactive(dates) {
   return Promise.all(
     dates.map(async (date) => {
       try {
@@ -243,6 +309,35 @@ async function markFeatureDatesInactive(dates) {
         };
 
         const endpoint = `/api/park-operation-sub-area-dates/${date.id}`;
+        const response = await put(endpoint, data);
+
+        return response.data;
+      } catch (error) {
+        console.error(`Error marking date ${date.id} as inactive`, error);
+        return null;
+      }
+    }),
+  );
+}
+
+/**
+ * Mark all the dates for this feature-year pair as inactive
+ * @param {Array<Object>} dates list of dates to be marked as inactive
+ * @returns {Promise<any>} Promise that resolves when all the dates are marked as inactive
+ */
+async function markStrapiParkFeatureDatesInactive(dates) {
+  return Promise.all(
+    dates.map(async (date) => {
+      try {
+        // send the entire object with isActive set to false
+        const data = {
+          data: {
+            ...date.attributes,
+            isActive: false,
+          },
+        };
+
+        const endpoint = `/api/park-feature-dates/${date.id}`;
         const response = await put(endpoint, data);
 
         return response.data;
@@ -280,81 +375,94 @@ async function markSeasonPublished(seasonId) {
 async function publishToAPI(seasonTable) {
   // using this instead of Object.entries because we want to only update the data of one season at a time
   // to not overload the Strapi API and to make sure that a each season either succeeds or not
-  for (const [seasonId, { operatingYear, features }] of Object.entries(
-    seasonTable,
-  )) {
-    // everything inside this loop iteration is related to a single season
-    await Promise.all(
+  for (const [
+    seasonId,
+    { operatingYear, featureType, features },
+  ] of Object.entries(seasonTable)) {
+    if (featureType.name === "Winter fee") {
       Object.entries(features).map(async ([featureId, dateRanges]) => {
-        // everything in this loop iteration is related to a single feature in a season
+        // get strapi dates
+        const dates = await getStrapiParkFeatureDates(featureId, operatingYear);
 
         // mark all the dates for this feature-year pair as inactive in Strapi
-        const dates = await getFeatureStrapiDates(featureId, operatingYear);
+        await markStrapiParkFeatureDatesInactive(dates.data);
 
-        await markFeatureDatesInactive(dates.data);
+        // send the new dates to the API
+        const dateRangesToPublish = dateRanges.map((dateRange) => ({
+          isActive: true,
+          operatingYear,
+          startDate: new Date(dateRange.startDate).toISOString().split("T")[0],
+          endDate: new Date(dateRange.endDate).toISOString().split("T")[0],
+          dateType: "Winter fee",
+          parkOperationSubArea: featureId,
+        }));
 
-        // The date object in strapi contains both the operating and reservation dates for a feature - operatingYear pair
-        // we'll group all the date ranges by feature and operating year and then we'll group them if possible
-        // If there are remaining dates, we'll create a new date object with the remaining dates
-        const operatingDates = dateRanges
-          .filter((dateRange) => dateRange.dateType.name === "Operation")
-          .sort((a, b) => new Date(a.startDate) - new Date(b.startDate));
-
-        const reservationDates = dateRanges
-          .filter((dateRange) => dateRange.dateType.name === "Reservation")
-          .sort((a, b) => new Date(a.startDate) - new Date(b.startDate));
-
-        // determine how many date objects we need to create
-        const maxIndex = Math.max(
-          operatingDates.length,
-          reservationDates.length,
-        );
-        const groupedSeasonDates = [];
-
-        for (let i = 0; i < maxIndex; i++) {
-          const obj = {
-            operatingYear,
-            parkOperationSubArea: featureId,
-            isActive: true,
-            openDate: null,
-            closeDate: null,
-            serviceStartDate: null,
-            serviceEndDate: null,
-            reservationStartDate: null,
-            reservationEndDate: null,
-            offSeasonStartDate: null,
-            offSeasonEndDate: null,
-            adminNote: null,
-          };
-
-          const operatingDate = operatingDates[i];
-          const reservationDate = reservationDates[i];
-
-          if (operatingDate) {
-            obj.serviceStartDate = new Date(operatingDate.startDate)
-              .toISOString()
-              .split("T")[0];
-            obj.serviceEndDate = new Date(operatingDate.endDate)
-              .toISOString()
-              .split("T")[0];
-          }
-
-          if (reservationDate) {
-            obj.reservationStartDate = new Date(reservationDate.startDate)
-              .toISOString()
-              .split("T")[0];
-            obj.reservationEndDate = new Date(reservationDate.endDate)
-              .toISOString()
-              .split("T")[0];
-          }
-
-          groupedSeasonDates.push(obj);
-        }
-
-        // add all the dates for this feature in Strapi
-        await createRecordsInStrapi(groupedSeasonDates);
-      }),
-    );
+        await createParkFeatureDatesInStrapi(dateRangesToPublish);
+      });
+    } else {
+      // TODO: commenting out the code below to not update strapi until new strucutre is in place
+      // everything inside this loop iteration is related to a single season
+      // await Promise.all(
+      //   Object.entries(features).map(async ([featureId, dateRanges]) => {
+      //     // everything in this loop iteration is related to a single feature in a season
+      //     // mark all the dates for this feature-year pair as inactive in Strapi
+      //     const dates = await getStrapiParkOperationSubAreaDates(featureId, operatingYear);
+      //     await markStrapiParkOperationSubAreaDatesInactive(dates.data);
+      //     // The date object in strapi contains both the operating and reservation dates for a feature - operatingYear pair
+      //     // we'll group all the date ranges by feature and operating year and then we'll group them if possible
+      //     // If there are remaining dates, we'll create a new date object with the remaining dates
+      //     const operatingDates = dateRanges
+      //       .filter((dateRange) => dateRange.dateType.name === "Operation")
+      //       .sort((a, b) => new Date(a.startDate) - new Date(b.startDate));
+      //     const reservationDates = dateRanges
+      //       .filter((dateRange) => dateRange.dateType.name === "Reservation")
+      //       .sort((a, b) => new Date(a.startDate) - new Date(b.startDate));
+      //     // determine how many date objects we need to create
+      //     const maxIndex = Math.max(
+      //       operatingDates.length,
+      //       reservationDates.length,
+      //     );
+      //     const groupedSeasonDates = [];
+      //     for (let i = 0; i < maxIndex; i++) {
+      //       const obj = {
+      //         operatingYear,
+      //         parkOperationSubArea: featureId,
+      //         isActive: true,
+      //         openDate: null,
+      //         closeDate: null,
+      //         serviceStartDate: null,
+      //         serviceEndDate: null,
+      //         reservationStartDate: null,
+      //         reservationEndDate: null,
+      //         offSeasonStartDate: null,
+      //         offSeasonEndDate: null,
+      //         adminNote: null,
+      //       };
+      //       const operatingDate = operatingDates[i];
+      //       const reservationDate = reservationDates[i];
+      //       if (operatingDate) {
+      //         obj.serviceStartDate = new Date(operatingDate.startDate)
+      //           .toISOString()
+      //           .split("T")[0];
+      //         obj.serviceEndDate = new Date(operatingDate.endDate)
+      //           .toISOString()
+      //           .split("T")[0];
+      //       }
+      //       if (reservationDate) {
+      //         obj.reservationStartDate = new Date(reservationDate.startDate)
+      //           .toISOString()
+      //           .split("T")[0];
+      //         obj.reservationEndDate = new Date(reservationDate.endDate)
+      //           .toISOString()
+      //           .split("T")[0];
+      //       }
+      //       groupedSeasonDates.push(obj);
+      //     }
+      //     // add all the dates for this feature in Strapi
+      //     await createRecordsInStrapi(groupedSeasonDates);
+      //   }),
+      // );
+    }
 
     // mark this season as published when everything related to it is done
     markSeasonPublished(seasonId);
@@ -374,6 +482,11 @@ router.post(
       },
       attributes: ["id", "parkId", "featureTypeId", "operatingYear"],
       include: [
+        {
+          model: FeatureType,
+          as: "featureType",
+          attributes: ["id", "name"],
+        },
         {
           model: DateRange,
           as: "dateRanges",
@@ -401,6 +514,49 @@ router.post(
       ],
     });
 
+    // we need to group dateranges by season and then feature
+    // we'll create a table that looks
+    // {
+    //   seasonId: {
+    //     operatingYear: 2024,
+    //     featureTYpe: { name: "Winter fee" },
+    //     features: {
+    //       1: [dateRange, dateRange],
+    //       2: [dateRange, dateRange],
+    //     },
+    //   }
+    // }
+
+    const seasonTable = {};
+
+    approvedSeasons.forEach((season) => {
+      const { operatingYear } = season;
+
+      seasonTable[season.id] = {
+        operatingYear,
+        featureType: season.featureType,
+        features: {},
+      };
+
+      const { dateRanges } = season;
+
+      dateRanges.forEach((dateRange) => {
+        const { dateable } = dateRange;
+        const { feature } = dateable;
+
+        // feature is always an array with one element
+        const strapiId = feature[0].strapiId;
+
+        if (!seasonTable[season.id].features[strapiId]) {
+          seasonTable[season.id].features[strapiId] = [];
+        }
+
+        seasonTable[season.id].features[strapiId].push(dateRange);
+      });
+    });
+
+    publishToAPI(seasonTable);
+
     const seasonIds = approvedSeasons.map((season) => season.id);
 
     Season.update(
@@ -415,48 +571,6 @@ router.post(
         },
       },
     );
-
-    // TODO: commenting out the code below to not update strapi until new strucutre is in place
-    // we need to group dateranges by season and then feature
-    // we'll create a table that looks
-    // {
-    //   seasonId: {
-    //     operatingYear: 2024,
-    //     features: {
-    //       1: [dateRange, dateRange],
-    //       2: [dateRange, dateRange],
-    //     },
-    //   }
-    // }
-
-    // const seasonTable = {};
-
-    // seasons.forEach((season) => {
-    //   const { operatingYear } = season;
-
-    //   seasonTable[season.id] = {
-    //     operatingYear,
-    //     features: {},
-    //   };
-
-    //   const { dateRanges } = season;
-
-    //   dateRanges.forEach((dateRange) => {
-    //     const { dateable } = dateRange;
-    //     const { feature } = dateable;
-
-    //     // feature is always an array with one element
-    //     const strapiId = feature[0].strapiId;
-
-    //     if (!seasonTable[season.id].features[strapiId]) {
-    //       seasonTable[season.id].features[strapiId] = [];
-    //     }
-
-    //     seasonTable[season.id].features[strapiId].push(dateRange);
-    //   });
-    // });
-
-    // publishToAPI(seasonTable);
 
     // send 200 OK response with empty body
     res.send();

--- a/backend/strapi-sync/create-missing-dates-and-seasons.js
+++ b/backend/strapi-sync/create-missing-dates-and-seasons.js
@@ -150,5 +150,3 @@ export async function createMissingDatesAndSeasons() {
     await DateRange.bulkCreate(datesToCreate);
   }
 }
-
-// createMissingDatesAndSeasons();

--- a/backend/strapi-sync/create-missing-dates-and-seasons.js
+++ b/backend/strapi-sync/create-missing-dates-and-seasons.js
@@ -8,7 +8,7 @@ import {
 } from "../models/index.js";
 import { createModel } from "./utils.js";
 
-async function createMissingDatesAndSeasons() {
+export async function createMissingDatesAndSeasons() {
   const [seasons2025, dateTypes, winterFeatureType, features] =
     await Promise.all([
       Season.findAll({
@@ -151,4 +151,4 @@ async function createMissingDatesAndSeasons() {
   }
 }
 
-createMissingDatesAndSeasons();
+// createMissingDatesAndSeasons();

--- a/backend/strapi-sync/create-missing-dates-and-seasons.js
+++ b/backend/strapi-sync/create-missing-dates-and-seasons.js
@@ -50,6 +50,9 @@ export async function createMissingDatesAndSeasons() {
             ],
           },
         ],
+        where: {
+          active: true,
+        },
       }),
     ]);
 

--- a/backend/strapi-sync/create-multiple-item-campgrounds.js
+++ b/backend/strapi-sync/create-multiple-item-campgrounds.js
@@ -517,8 +517,8 @@ async function createCampground(item) {
   );
 }
 
-export async function createCampgrounds(items) {
-  await Promise.all(items.map(async (item) => createCampground(item)));
+export async function createMultipleItemsCampgrounds() {
+  await Promise.all(campgrounds.map(async (item) => createCampground(item)));
 }
 
 // createCampgrounds(campgrounds);

--- a/backend/strapi-sync/create-multiple-item-campgrounds.js
+++ b/backend/strapi-sync/create-multiple-item-campgrounds.js
@@ -480,16 +480,16 @@ const campgrounds = [
 ];
 
 async function updateFeature(item, campgroundId) {
-  const strapiId = parseInt(item.featureId.split("_")[1], 10);
+  // const strapiId = parseInt(item.featureId.split("_")[1], 10);
 
   // get feature by featureId
-  // const feature = await getItemByAttributes(Feature, {
-  //   strapiFeatureId: item.featureId,
-  // });
-
   const feature = await getItemByAttributes(Feature, {
-    strapiId,
+    strapiFeatureId: item.featureId,
   });
+
+  // const feature = await getItemByAttributes(Feature, {
+  //   strapiId,
+  // });
 
   // set campgroundId and name
   feature.campgroundId = campgroundId;
@@ -517,8 +517,8 @@ async function createCampground(item) {
   );
 }
 
-async function createCampgrounds(items) {
+export async function createCampgrounds(items) {
   await Promise.all(items.map(async (item) => createCampground(item)));
 }
 
-createCampgrounds(campgrounds);
+// createCampgrounds(campgrounds);

--- a/backend/strapi-sync/create-multiple-item-campgrounds.js
+++ b/backend/strapi-sync/create-multiple-item-campgrounds.js
@@ -518,7 +518,5 @@ async function createCampground(item) {
 }
 
 export async function createMultipleItemsCampgrounds() {
-  await Promise.all(campgrounds.map(async (item) => createCampground(item)));
+  await Promise.all(campgrounds.map(createCampground));
 }
-
-// createCampgrounds(campgrounds);

--- a/backend/strapi-sync/create-single-item-campgrounds.js
+++ b/backend/strapi-sync/create-single-item-campgrounds.js
@@ -1779,8 +1779,8 @@ async function createCampground(item) {
   await feature.save();
 }
 
-export async function createSingleItemsCampgrounds(items) {
-  await Promise.all(items.map(async (item) => createCampground(item)));
+export async function createSingleItemsCampgrounds() {
+  await Promise.all(campgrounds.map(async (item) => createCampground(item)));
 }
 
 // createSingleItemsCampgrounds(campgrounds);

--- a/backend/strapi-sync/create-single-item-campgrounds.js
+++ b/backend/strapi-sync/create-single-item-campgrounds.js
@@ -1780,7 +1780,5 @@ async function createCampground(item) {
 }
 
 export async function createSingleItemsCampgrounds() {
-  await Promise.all(campgrounds.map(async (item) => createCampground(item)));
+  await Promise.all(campgrounds.map(createCampground));
 }
-
-// createSingleItemsCampgrounds(campgrounds);

--- a/backend/strapi-sync/create-single-item-campgrounds.js
+++ b/backend/strapi-sync/create-single-item-campgrounds.js
@@ -1765,22 +1765,22 @@ async function createCampground(item) {
 
   const campground = await createModel(Campground, data);
 
-  // const feature = await getItemByAttributes(Feature, {
-  //   strapiFeatureId: item.items[0].featureId,
-  // });
-  const strapiId = parseInt(item.items[0].featureId.split("_")[1], 10);
-
   const feature = await getItemByAttributes(Feature, {
-    strapiId,
+    strapiFeatureId: item.items[0].featureId,
   });
+  // const strapiId = parseInt(item.items[0].featureId.split("_")[1], 10);
+
+  // const feature = await getItemByAttributes(Feature, {
+  //   strapiId,
+  // });
 
   feature.campgroundId = campground.id;
   feature.name = "All sites";
   await feature.save();
 }
 
-async function createSingleItemsCampgrounds(items) {
+export async function createSingleItemsCampgrounds(items) {
   await Promise.all(items.map(async (item) => createCampground(item)));
 }
 
-createSingleItemsCampgrounds(campgrounds);
+// createSingleItemsCampgrounds(campgrounds);

--- a/backend/strapi-sync/import-data.js
+++ b/backend/strapi-sync/import-data.js
@@ -1,0 +1,3 @@
+import { importData } from "./reset-and-import-data.js";
+
+importData();

--- a/backend/strapi-sync/oneTimeDataImport.js
+++ b/backend/strapi-sync/oneTimeDataImport.js
@@ -1,3 +1,3 @@
 import { oneTimeDataImport } from "./sync.js";
 
-oneTimeDataImport();
+// oneTimeDataImport();

--- a/backend/strapi-sync/oneTimeDataImport.js
+++ b/backend/strapi-sync/oneTimeDataImport.js
@@ -1,3 +1,0 @@
-import { oneTimeDataImport } from "./sync.js";
-
-// oneTimeDataImport();

--- a/backend/strapi-sync/reset-and-import-data.js
+++ b/backend/strapi-sync/reset-and-import-data.js
@@ -1,0 +1,36 @@
+import { exec } from "node:child_process";
+// import { syncData, oneTimeDataImport } from "./sync.js";
+// import { createSingleItemsCampgrounds } from "./create-single-item-campgrounds.js";
+// import { createCampgrounds } from "./create-multiple-item-campgrounds.js";
+// import { createMissingDatesAndSeasons } from "./create-missing-dates-and-seasons.js";
+
+function resetDatabase() {
+  return new Promise((resolve, reject) => {
+    exec(
+      `npx sequelize-cli db:drop && npx sequelize-cli db:create && npx sequelize-cli db:migrate`,
+      (error, stdout, stderr) => {
+        if (error) {
+          console.error(`Error: ${error.message}`);
+          return reject(error);
+        }
+        if (stderr) {
+          console.error(`Stderr: ${stderr}`);
+          return reject(stderr);
+        }
+        console.log(`Stdout: ${stdout}`);
+        return resolve(stdout);
+      },
+    );
+  });
+}
+
+export async function resetScript() {
+  // await resetDatabase();
+  // await syncData();
+  // await oneTimeDataImport();
+  // await createSingleItemsCampgrounds();
+  // await createCampgrounds();
+  // await createMissingDatesAndSeasons();
+
+  console.log("calling resetDatabase");
+}

--- a/backend/strapi-sync/reset-and-import-data.js
+++ b/backend/strapi-sync/reset-and-import-data.js
@@ -1,8 +1,8 @@
 import { exec } from "node:child_process";
-// import { syncData, oneTimeDataImport } from "./sync.js";
-// import { createSingleItemsCampgrounds } from "./create-single-item-campgrounds.js";
-// import { createCampgrounds } from "./create-multiple-item-campgrounds.js";
-// import { createMissingDatesAndSeasons } from "./create-missing-dates-and-seasons.js";
+import { syncData, oneTimeDataImport } from "./sync.js";
+import { createSingleItemsCampgrounds } from "./create-single-item-campgrounds.js";
+import { createMultipleItemsCampgrounds } from "./create-multiple-item-campgrounds.js";
+import { createMissingDatesAndSeasons } from "./create-missing-dates-and-seasons.js";
 
 function resetDatabase() {
   return new Promise((resolve, reject) => {
@@ -24,13 +24,17 @@ function resetDatabase() {
   });
 }
 
-export async function resetScript() {
-  // await resetDatabase();
-  // await syncData();
-  // await oneTimeDataImport();
-  // await createSingleItemsCampgrounds();
-  // await createCampgrounds();
-  // await createMissingDatesAndSeasons();
+export async function importData() {
+  await syncData();
+  await oneTimeDataImport();
+  await createSingleItemsCampgrounds();
+  await createMultipleItemsCampgrounds();
+  await createMissingDatesAndSeasons();
+}
 
+export async function resetScript() {
+  await resetDatabase();
+
+  await importData();
   console.log("calling resetDatabase");
 }

--- a/backend/strapi-sync/reset-and-import-data.js
+++ b/backend/strapi-sync/reset-and-import-data.js
@@ -1,27 +1,33 @@
-import { exec } from "node:child_process";
 import { syncData, oneTimeDataImport } from "./sync.js";
 import { createSingleItemsCampgrounds } from "./create-single-item-campgrounds.js";
 import { createMultipleItemsCampgrounds } from "./create-multiple-item-campgrounds.js";
 import { createMissingDatesAndSeasons } from "./create-missing-dates-and-seasons.js";
+import {
+  Dateable,
+  Park,
+  User,
+  Campground,
+  FeatureType,
+  Feature,
+  DateType,
+  Season,
+  DateRange,
+  SeasonChangeLog,
+  DateChangeLog,
+} from "../models/index.js";
 
-function resetDatabase() {
-  return new Promise((resolve, reject) => {
-    exec(
-      `npx sequelize-cli db:drop && npx sequelize-cli db:create && npx sequelize-cli db:migrate`,
-      (error, stdout, stderr) => {
-        if (error) {
-          console.error(`Error: ${error.message}`);
-          return reject(error);
-        }
-        if (stderr) {
-          console.error(`Stderr: ${stderr}`);
-          return reject(stderr);
-        }
-        console.log(`Stdout: ${stdout}`);
-        return resolve(stdout);
-      },
-    );
-  });
+export async function deleteAllData() {
+  await DateChangeLog.destroy({ where: {} });
+  await SeasonChangeLog.destroy({ where: {} });
+  await DateRange.destroy({ where: {} });
+  await Season.destroy({ where: {} });
+  await Feature.destroy({ where: {} });
+  await Campground.destroy({ where: {} });
+  await FeatureType.destroy({ where: {} });
+  await DateType.destroy({ where: {} });
+  await Park.destroy({ where: {} });
+  await Dateable.destroy({ where: {} });
+  await User.destroy({ where: {} });
 }
 
 export async function importData() {
@@ -33,7 +39,7 @@ export async function importData() {
 }
 
 export async function resetScript() {
-  await resetDatabase();
+  await deleteAllData();
 
   await importData();
   console.log("calling resetDatabase");

--- a/backend/strapi-sync/sync.js
+++ b/backend/strapi-sync/sync.js
@@ -705,6 +705,3 @@ export async function oneTimeDataImport() {
 
   await createDatesAndSeasons(datesData);
 }
-
-// syncData();
-// oneTimeDataImport();

--- a/backend/strapi-sync/sync.js
+++ b/backend/strapi-sync/sync.js
@@ -79,8 +79,7 @@ export async function getData(url, queryParams) {
  * @returns {Array} list of all models with thier name, endpoint, and items
  */
 export async function fetchAllModels() {
-  // const url = `${process.env.STRAPI_URL}/api`;
-  const url = "https://cms.bcparks.ca/api";
+  const url = `${process.env.STRAPI_URL}/api`;
 
   const strapiData = [
     {
@@ -225,6 +224,14 @@ export async function createOrUpdateFeatureType(strapiData, item) {
   }
 
   return dbItem;
+}
+
+function getSeasonStatus(operatingYear) {
+  // if operating year is in the past, set status to on API, else set to requested
+  const currentYear = new Date().getFullYear();
+  const status = operatingYear < currentYear ? "on API" : "requested";
+
+  return status;
 }
 
 /**
@@ -461,7 +468,7 @@ export async function createDatesAndSeasons(datesData) {
     if (!season) {
       // create season if a season matching those 3 attributes doesn't exist
       const data = {
-        status: "requested",
+        status: getSeasonStatus(operatingYear),
         readyToPublish: true,
         ...attrs,
       };
@@ -542,7 +549,7 @@ export async function createDatesAndSeasons(datesData) {
       // create season if a season matching those 3 attributes doesn't exist
       // needs to be created before creating date ranges, because date ranges need a seasonId
       const data = {
-        status: "requested",
+        status: getSeasonStatus(operatingYear),
         readyToPublish: true,
         ...attrs,
       };
@@ -669,8 +676,7 @@ async function createTestUser() {
  */
 export async function oneTimeDataImport() {
   // only meant to run once - not needed for regular sync
-  // const url = `${process.env.STRAPI_URL}/api`;
-  const url = "https://cms.bcparks.ca/api";
+  const url = `${process.env.STRAPI_URL}/api`;
 
   const datesData = {
     endpoint: "/park-operation-sub-area-dates",

--- a/backend/strapi-sync/syncData.js
+++ b/backend/strapi-sync/syncData.js
@@ -1,3 +1,0 @@
-import { syncData } from "./sync.js";
-
-// syncData();

--- a/backend/strapi-sync/syncData.js
+++ b/backend/strapi-sync/syncData.js
@@ -1,3 +1,3 @@
 import { syncData } from "./sync.js";
 
-syncData();
+// syncData();


### PR DESCRIPTION
### Jira Ticket

CMS-657

### Description
- added ability to run the sync script from the admin dashboard. However, instead of recreating the DB, it will just delete all the contents and re-run the sync script to import the data
- past seasons will default to "on API" instead of requested
- sync script will use the STRAPI_URL environment variable. This is needed so that we can test the publish workflow.
   - every time we import something and publish it to Strapi we'll publish to the equivalent environment. 
   - For this to work, we need the featureId (PKs and FKs) to match what's on the environment. 
   - this means the STRAPI_URL environment variable will be needed in each env and it will need to match the CMS API URL for that environment. `https://alpha-dev-cms.bcparks.ca, https://alpha-test-cms.bcparks.ca, https://dev-cms.bcparks.ca, https://test-cms.bcparks.ca`.
- removed individual files and commands from `package.json` and put it all into a single JS function to avoid duplicate code. 