### PR TITLE
CMS-631: Update Edit/Preview pages

### DIFF
--- a/backend/migrations/20250304210219-add-cascade-delete-to-datechangelogs.js
+++ b/backend/migrations/20250304210219-add-cascade-delete-to-datechangelogs.js
@@ -1,0 +1,41 @@
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    // Remove the existing constraint without CASCADE
+    await queryInterface.removeConstraint(
+      "DateChangeLogs",
+      "DateChangeLogs_dateRangeId_fkey",
+    );
+
+    // Add a new constraint with CASCADE
+    await queryInterface.addConstraint("DateChangeLogs", {
+      fields: ["dateRangeId"],
+      type: "foreign key",
+      name: "DateChangeLogs_dateRangeId_fkey",
+      references: {
+        table: "DateRanges",
+        field: "id",
+      },
+      onDelete: "CASCADE",
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    // Remove the created constraint with CASCADE
+    await queryInterface.removeConstraint(
+      "DateChangeLogs",
+      "DateChangeLogs_dateRangeId_fkey",
+    );
+
+    // Recreate the old constraint without CASCADE
+    await queryInterface.addConstraint("DateChangeLogs", {
+      fields: ["dateRangeId"],
+      type: "foreign key",
+      name: "DateChangeLogs_dateRangeId_fkey",
+      references: {
+        table: "DateRanges",
+        field: "id",
+      },
+    });
+  },
+};

--- a/backend/models/daterange.js
+++ b/backend/models/daterange.js
@@ -23,6 +23,7 @@ export default (sequelize) => {
       DateRange.hasMany(models.DateChangeLog, {
         foreignKey: "dateRangeId",
         as: "dateChangeLogs",
+        onDelete: "CASCADE",
       });
     }
   }

--- a/frontend/src/components/ReadyToPublishBox.jsx
+++ b/frontend/src/components/ReadyToPublishBox.jsx
@@ -6,7 +6,7 @@ export default function ReadyToPublishBox({
 }) {
   return (
     <div className="mb-4">
-      <h2 className="mb-4">Ready to publish?</h2>
+      <h3 className="mb-4">Ready to publish?</h3>
 
       <p>
         Are these dates ready to be made available to the public the next time

--- a/frontend/src/components/ReadyToPublishBox.jsx
+++ b/frontend/src/components/ReadyToPublishBox.jsx
@@ -19,7 +19,7 @@ export default function ReadyToPublishBox({
         <input
           checked={readyToPublish}
           onChange={() => setReadyToPublish(!readyToPublish)}
-          className="form-check-input"
+          className="form-check-input label-switch"
           type="checkbox"
           role="switch"
           id="ready-to-publish"

--- a/frontend/src/lib/utils.js
+++ b/frontend/src/lib/utils.js
@@ -88,7 +88,7 @@ export function formatDateRange(dateRange) {
     DATE_FORMAT_SHORT_WITH_YEAR,
   );
 
-  return `${startDate} - ${endDate}`;
+  return `${startDate} – ${endDate}`;
 }
 
 export function formatDatetoISO(date) {

--- a/frontend/src/router/layouts/LandingPageTabs.jsx
+++ b/frontend/src/router/layouts/LandingPageTabs.jsx
@@ -5,25 +5,27 @@ export default function LandingPageTabs() {
   return (
     <div className="layout landing-page-tabs">
       <header className="section-tabs d-flex flex-column">
-        <h1 className="m-3 mb-4">Dates management</h1>
+        <div className="container">
+          <h1 className="m-3 mb-4">Dates management</h1>
 
-        <ul className="nav nav-tabs px-2">
-          <li className="nav-item">
-            <NavLink className="nav-link" to="/">
-              Edit and Review
-            </NavLink>
-          </li>
-          <li className="nav-item">
-            <NavLink className="nav-link" to="/publish">
-              Publish
-            </NavLink>
-          </li>
-          <li className="nav-item">
-            <NavLink className="nav-link" to="/export">
-              Export
-            </NavLink>
-          </li>
-        </ul>
+          <ul className="nav nav-tabs px-2">
+            <li className="nav-item">
+              <NavLink className="nav-link" to="/">
+                Edit and Review
+              </NavLink>
+            </li>
+            <li className="nav-item">
+              <NavLink className="nav-link" to="/publish">
+                Publish
+              </NavLink>
+            </li>
+            <li className="nav-item">
+              <NavLink className="nav-link" to="/export">
+                Export
+              </NavLink>
+            </li>
+          </ul>
+        </div>
       </header>
       <div className="my-3">
         <Outlet />

--- a/frontend/src/router/layouts/LandingPageTabs.scss
+++ b/frontend/src/router/layouts/LandingPageTabs.scss
@@ -1,6 +1,10 @@
 .layout.landing-page-tabs {
   header.section-tabs {
     background-color: var(--surface-color-background-light-blue);
-    border-bottom-width: 12px;
+    border-bottom: 1px solid var(--theme-gray-50);
+
+    .nav-tabs {
+      border-bottom: none;
+    }
   }
 }

--- a/frontend/src/router/layouts/MainLayout.jsx
+++ b/frontend/src/router/layouts/MainLayout.jsx
@@ -58,7 +58,7 @@ export default function MainLayout() {
         </div>
       </header>
 
-      <main className="container mb-5">
+      <main className="p-0">
         <Outlet />
       </main>
 

--- a/frontend/src/router/pages/EditAndReview.jsx
+++ b/frontend/src/router/pages/EditAndReview.jsx
@@ -122,61 +122,63 @@ function EditAndReview() {
   }
 
   return (
-    <div className="page dates-management">
-      <div className="table-filters row mb-4">
-        <div className="col-lg-3 col-md-6 col-12">
-          <label htmlFor="parkName" className="form-label">
-            Park name
-          </label>
+    <div className="container">
+      <div className="page dates-management">
+        <div className="table-filters row mb-4">
+          <div className="col-lg-3 col-md-6 col-12">
+            <label htmlFor="parkName" className="form-label">
+              Park name
+            </label>
 
-          <div className="input-with-append">
-            <input
-              type="text"
-              className="form-control input-search"
-              id="parkName"
-              placeholder="Search by park name"
-              value={nameFilter}
-              onChange={(e) => {
+            <div className="input-with-append">
+              <input
+                type="text"
+                className="form-control input-search"
+                id="parkName"
+                placeholder="Search by park name"
+                value={nameFilter}
+                onChange={(e) => {
+                  setPage(1);
+                  setNameFilter(e.target.value);
+                }}
+              />
+              <FontAwesomeIcon
+                className="append-content"
+                icon={faMagnifyingGlass}
+              />
+            </div>
+          </div>
+
+          <div className="col-lg-3 col-md-6 col-12">
+            <label htmlFor="status" className="form-label">
+              Status
+            </label>
+
+            <MultiSelect
+              options={statusOptions}
+              onInput={(value) => {
                 setPage(1);
-                setNameFilter(e.target.value);
+                setStatusFilter(value);
               }}
-            />
-            <FontAwesomeIcon
-              className="append-content"
-              icon={faMagnifyingGlass}
-            />
+              value={statusFilter}
+            >
+              Filter by status{" "}
+              {statusFilter.length > 0 && `(${statusFilter.length})`}
+            </MultiSelect>
+          </div>
+
+          <div className="col-lg-3 col-md-6 col-12 d-flex">
+            <button
+              onClick={resetFilters}
+              className="btn btn-link align-self-end"
+            >
+              Clear filters
+            </button>
           </div>
         </div>
 
-        <div className="col-lg-3 col-md-6 col-12">
-          <label htmlFor="status" className="form-label">
-            Status
-          </label>
-
-          <MultiSelect
-            options={statusOptions}
-            onInput={(value) => {
-              setPage(1);
-              setStatusFilter(value);
-            }}
-            value={statusFilter}
-          >
-            Filter by status{" "}
-            {statusFilter.length > 0 && `(${statusFilter.length})`}
-          </MultiSelect>
-        </div>
-
-        <div className="col-lg-3 col-md-6 col-12 d-flex">
-          <button
-            onClick={resetFilters}
-            className="btn btn-link align-self-end"
-          >
-            Clear filters
-          </button>
-        </div>
+        {renderTable()}
       </div>
-
-      {renderTable()}
     </div>
   );
 }

--- a/frontend/src/router/pages/Error.jsx
+++ b/frontend/src/router/pages/Error.jsx
@@ -7,11 +7,13 @@ export default function ErrorPage() {
 
   return (
     <div id="error-page">
-      <h1>Oops!</h1>
-      <p>Sorry, an unexpected error has occurred.</p>
-      <p>
-        <i>{error.statusText || error.message}</i>
-      </p>
+      <div className="container my-2">
+        <h1>Oops!</h1>
+        <p>Sorry, an unexpected error has occurred.</p>
+        <p>
+          <i>{error.statusText || error.message}</i>
+        </p>
+      </div>
     </div>
   );
 }

--- a/frontend/src/router/pages/ExportPage.jsx
+++ b/frontend/src/router/pages/ExportPage.jsx
@@ -105,13 +105,19 @@ function ExportPage() {
   }
 
   if (error) {
-    return <p className="px-3">Error loading options data: {error.message}</p>;
+    return (
+      <div className="container">
+        <p className="px-3">Error loading options data: {error.message}</p>
+      </div>
+    );
   }
 
   if (loading)
     return (
-      <div className="p-3 pt-0">
-        <LoadingBar />
+      <div className="container">
+        <div className="p-3 pt-0">
+          <LoadingBar />
+        </div>
       </div>
     );
 
@@ -119,149 +125,153 @@ function ExportPage() {
     exportFeatures.length === 0 || exportDateTypes.length === 0 || generating;
 
   return (
-    <div className="page export">
-      <FlashMessage
-        title={successFlash.flashTitle}
-        message={successFlash.flashMessage}
-        isVisible={successFlash.isFlashOpen}
-        onClose={successFlash.handleFlashClose}
-      />
+    <div className="container">
+      <div className="page export">
+        <FlashMessage
+          title={successFlash.flashTitle}
+          message={successFlash.flashMessage}
+          isVisible={successFlash.isFlashOpen}
+          onClose={successFlash.handleFlashClose}
+        />
 
-      <FlashMessage
-        title={errorFlash.flashTitle}
-        message={errorFlash.flashMessage}
-        isVisible={errorFlash.isFlashOpen}
-        onClose={errorFlash.handleFlashClose}
-        variant="error"
-      />
-      <p>Select the format of your export:</p>
+        <FlashMessage
+          title={errorFlash.flashTitle}
+          message={errorFlash.flashMessage}
+          isVisible={errorFlash.isFlashOpen}
+          onClose={errorFlash.handleFlashClose}
+          variant="error"
+        />
 
-      <div className="row">
-        <div className="col-md-6 col-lg-5">
-          <fieldset className="section-spaced">
-            <legend className="append-required">Export type</legend>
-            {exportTypes.map((option) => (
-              <div className="form-check" key={option.value}>
-                <input
-                  className="form-check-input"
-                  type="radio"
-                  name="exportType"
-                  id={`type-${option.value}`}
-                  value={option.value}
-                  checked={exportType === option.value}
-                  onChange={(e) => setExportType(e.target.value)}
-                />
-                <label
-                  className="form-check-label"
-                  htmlFor={`type-${option.value}`}
+        <p>Select the format of your export:</p>
+
+        <div className="row">
+          <div className="col-md-6 col-lg-5">
+            <fieldset className="section-spaced">
+              <legend className="append-required">Export type</legend>
+              {exportTypes.map((option) => (
+                <div className="form-check" key={option.value}>
+                  <input
+                    className="form-check-input"
+                    type="radio"
+                    name="exportType"
+                    id={`type-${option.value}`}
+                    value={option.value}
+                    checked={exportType === option.value}
+                    onChange={(e) => setExportType(e.target.value)}
+                  />
+                  <label
+                    className="form-check-label"
+                    htmlFor={`type-${option.value}`}
+                  >
+                    {option.label}
+                  </label>
+                </div>
+              ))}
+            </fieldset>
+            <fieldset className="section-spaced">
+              <legend className="append-required">Year</legend>
+              <div className="input-with-append col-8 col-sm-6">
+                <select
+                  id="year"
+                  className="form-select"
+                  value={exportYear}
+                  onChange={(ev) => setExportYear(+ev.target.value)}
                 >
-                  {option.label}
-                </label>
-              </div>
-            ))}
-          </fieldset>
-          <fieldset className="section-spaced">
-            <legend className="append-required">Year</legend>
-            <div className="input-with-append col-8 col-sm-6">
-              <select
-                id="year"
-                className="form-select"
-                value={exportYear}
-                onChange={(ev) => setExportYear(+ev.target.value)}
-              >
-                {options.years.map((year) => (
-                  <option key={year} value={year}>
-                    {year}
-                  </option>
-                ))}
-              </select>
-              <FontAwesomeIcon
-                className="append-content"
-                icon={faCalendarCheck}
-              />
-            </div>
-          </fieldset>
-          <fieldset className="section-spaced">
-            <legend className="append-required">Park features</legend>
+                  {options.years.map((year) => (
+                    <option key={year} value={year}>
+                      {year}
+                    </option>
+                  ))}
+                </select>
 
-            <div className="mb-2">
+                <FontAwesomeIcon
+                  className="append-content"
+                  icon={faCalendarCheck}
+                />
+              </div>
+            </fieldset>
+            <fieldset className="section-spaced">
+              <legend className="append-required">Park features</legend>
+
+              <div className="mb-2">
+                <button
+                  onClick={selectAllFeatures}
+                  type="button"
+                  className="btn btn-text text-primary"
+                >
+                  Select all
+                </button>
+                |
+                <button
+                  onClick={() => setExportFeatures([])}
+                  type="button"
+                  className="btn btn-text text-primary"
+                >
+                  Clear all
+                </button>
+              </div>
+
+              {options.featureTypes.map((feature) => (
+                <div className="form-check" key={feature.id}>
+                  <input
+                    className="form-check-input"
+                    type="checkbox"
+                    name="features"
+                    id={`features-${feature.id}`}
+                    value={feature.id}
+                    checked={exportFeatures.includes(feature.id)}
+                    onChange={onCheckboxGroupChange(setExportFeatures)}
+                  />
+                  <label
+                    className="form-check-label"
+                    htmlFor={`features-${feature.id}`}
+                  >
+                    {feature.name}
+                  </label>
+                </div>
+              ))}
+            </fieldset>
+            <fieldset className="section-spaced">
+              <legend className="append-required">Type of date</legend>
+
+              {options.dateTypes.map((dateType) => (
+                <div className="form-check" key={dateType.id}>
+                  <input
+                    className="form-check-input"
+                    type="checkbox"
+                    name="features"
+                    id={`date-types-${dateType.id}`}
+                    value={dateType.id}
+                    checked={exportDateTypes.includes(dateType.id)}
+                    onChange={onCheckboxGroupChange(setExportDateTypes)}
+                  />
+                  <label
+                    className="form-check-label"
+                    htmlFor={`date-types-${dateType.id}`}
+                  >
+                    {dateType.name}
+                  </label>
+                </div>
+              ))}
+            </fieldset>
+            <fieldset className="d-flex">
               <button
-                onClick={selectAllFeatures}
-                type="button"
-                className="btn btn-text text-primary"
+                role="button"
+                className="btn btn-primary"
+                disabled={disableButton}
+                onClick={getCsv}
               >
-                Select all
+                Export report
               </button>
-              |
-              <button
-                onClick={() => setExportFeatures([])}
-                type="button"
-                className="btn btn-text text-primary"
-              >
-                Clear all
-              </button>
-            </div>
 
-            {options.featureTypes.map((feature) => (
-              <div className="form-check" key={feature.id}>
-                <input
-                  className="form-check-input"
-                  type="checkbox"
-                  name="features"
-                  id={`features-${feature.id}`}
-                  value={feature.id}
-                  checked={exportFeatures.includes(feature.id)}
-                  onChange={onCheckboxGroupChange(setExportFeatures)}
-                />
-                <label
-                  className="form-check-label"
-                  htmlFor={`features-${feature.id}`}
-                >
-                  {feature.name}
-                </label>
-              </div>
-            ))}
-          </fieldset>
-          <fieldset className="section-spaced">
-            <legend className="append-required">Type of date</legend>
-
-            {options.dateTypes.map((dateType) => (
-              <div className="form-check" key={dateType.id}>
-                <input
-                  className="form-check-input"
-                  type="checkbox"
-                  name="features"
-                  id={`date-types-${dateType.id}`}
-                  value={dateType.id}
-                  checked={exportDateTypes.includes(dateType.id)}
-                  onChange={onCheckboxGroupChange(setExportDateTypes)}
-                />
-                <label
-                  className="form-check-label"
-                  htmlFor={`date-types-${dateType.id}`}
-                >
-                  {dateType.name}
-                </label>
-              </div>
-            ))}
-          </fieldset>
-          <fieldset className="d-flex">
-            <button
-              role="button"
-              className="btn btn-primary"
-              disabled={disableButton}
-              onClick={getCsv}
-            >
-              Export report
-            </button>
-
-            {generating && (
-              <span
-                className="spinner-border text-primary align-self-center ms-2"
-                aria-hidden="true"
-              ></span>
-            )}
-          </fieldset>
+              {generating && (
+                <span
+                  className="spinner-border text-primary align-self-center ms-2"
+                  aria-hidden="true"
+                ></span>
+              )}
+            </fieldset>
+          </div>
         </div>
       </div>
     </div>

--- a/frontend/src/router/pages/ParkDetails.jsx
+++ b/frontend/src/router/pages/ParkDetails.jsx
@@ -71,59 +71,69 @@ function ParkDetails() {
   }, [isFlashOpen, park, searchParams, setSearchParams, openFlashMessage]);
 
   if (loading) {
-    return <LoadingBar />;
+    return (
+      <div className="container">
+        <LoadingBar />
+      </div>
+    );
   }
 
   if (error) {
-    return <p>Error loading parks data: {error.message}</p>;
+    return (
+      <div className="container">
+        <p>Error loading parks data: {error.message}</p>
+      </div>
+    );
   }
 
   return (
-    <div className="page park-details">
-      <FlashMessage
-        title={flashTitle}
-        message={flashMessage}
-        isVisible={isFlashOpen}
-        onClose={handleFlashClose}
-      />
+    <div className="container">
+      <div className="page park-details">
+        <FlashMessage
+          title={flashTitle}
+          message={flashMessage}
+          isVisible={isFlashOpen}
+          onClose={handleFlashClose}
+        />
 
-      <NavBack routePath={"/"}>Back to Dates management</NavBack>
+        <NavBack routePath={"/"}>Back to Dates management</NavBack>
 
-      <header className="page-header internal">
-        <h1>{park?.name}</h1>
-      </header>
+        <header className="page-header internal">
+          <h1>{park?.name}</h1>
+        </header>
 
-      {Object.entries(park.featureTypes).map(([title, seasons]) => (
+        {Object.entries(park.featureTypes).map(([title, seasons]) => (
+          <FeatureType
+            key={title}
+            title={title}
+            icon={seasons[0].featureType.icon}
+            seasons={seasons}
+            seasonProps={{
+              getDataEndpoint: (seasonId) => `/seasons/${seasonId}`,
+              getEditRoutePath: paths.seasonEdit,
+              getPreviewRoutePath: paths.seasonPreview,
+              getTitle: (season) => `${season.operatingYear} season`,
+              DetailsComponent: SeasonDates,
+            }}
+          />
+        ))}
+
+        {/* Render Winter fee seasons separately from "regular" seasons
+            and use a specific season component */}
         <FeatureType
-          key={title}
-          title={title}
-          icon={seasons[0].featureType.icon}
-          seasons={seasons}
+          title="Winter fee"
+          icon="winter-recreation"
+          seasons={park.winterFees}
           seasonProps={{
-            getDataEndpoint: (seasonId) => `/seasons/${seasonId}`,
-            getEditRoutePath: paths.seasonEdit,
-            getPreviewRoutePath: paths.seasonPreview,
-            getTitle: (season) => `${season.operatingYear} season`,
-            DetailsComponent: SeasonDates,
+            getDataEndpoint: (seasonId) => `/winter-fees/${seasonId}`,
+            getEditRoutePath: paths.winterFeesEdit,
+            getPreviewRoutePath: paths.winterFeesPreview,
+            getTitle: (season) =>
+              `${season.operatingYear} – ${season.operatingYear + 1}`,
+            DetailsComponent: WinterFeesDates,
           }}
         />
-      ))}
-
-      {/* Render Winter fee seasons separately from "regular" seasons
-          and use a specific season component */}
-      <FeatureType
-        title="Winter fee"
-        icon="winter-recreation"
-        seasons={park.winterFees}
-        seasonProps={{
-          getDataEndpoint: (seasonId) => `/winter-fees/${seasonId}`,
-          getEditRoutePath: paths.winterFeesEdit,
-          getPreviewRoutePath: paths.winterFeesPreview,
-          getTitle: (season) =>
-            `${season.operatingYear} – ${season.operatingYear + 1}`,
-          DetailsComponent: WinterFeesDates,
-        }}
-      />
+      </div>
     </div>
   );
 }

--- a/frontend/src/router/pages/ParkDetails.scss
+++ b/frontend/src/router/pages/ParkDetails.scss
@@ -8,10 +8,6 @@
       margin-bottom: var(--layout-margin-large);
       display: flex;
       gap: var(--layout-margin-medium);
-
-      .feature-icon {
-        height: 1.25em;
-      }
     }
   }
 

--- a/frontend/src/router/pages/PreviewChanges.jsx
+++ b/frontend/src/router/pages/PreviewChanges.jsx
@@ -235,7 +235,9 @@ function PreviewChanges() {
   function Feature({ feature }) {
     return (
       <div>
-        {feature.name !== "" && <h5>{feature.name}</h5>}
+        {feature.name !== "" && (
+          <h4 className="feature-name mb-4">{feature.name}</h4>
+        )}
         <div className="table-responsive">
           <table className="table table-striped">
             <thead>
@@ -304,7 +306,7 @@ function PreviewChanges() {
   function Campground({ campground }) {
     return (
       <div>
-        <h4>{campground.name}</h4>
+        <h3 className="campground-name mb-4">{campground.name}</h3>
 
         {campground.features.map((feature) => (
           <Feature key={feature.id} feature={feature} />
@@ -330,7 +332,7 @@ function PreviewChanges() {
     setReadyToPublish(data.readyToPublish);
   }, [data]);
 
-  if (loading) {
+  if (loading || !data) {
     return <LoadingBar />;
   }
 
@@ -372,17 +374,14 @@ function PreviewChanges() {
       </NavBack>
 
       <header className="page-header internal">
-        <h1>
-          {data?.park.name} {data?.operatingYear} season dates preview
+        <h1 className="header-with-icon">
+          <FeatureIcon iconName={data.featureType.icon} />
+          {data.park.name} {data.featureType.name}
         </h1>
+        <h2>Edit {data.operatingYear} season dates</h2>
       </header>
 
       <section className="feature-type">
-        <h2 className="header-with-icon">
-          <FeatureIcon iconName={data?.featureType.icon} />
-          {data?.featureType.name}
-        </h2>
-
         {data?.campgrounds.map((campground) => (
           <Campground key={campground.id} campground={campground} />
         ))}
@@ -394,7 +393,7 @@ function PreviewChanges() {
 
       <div className="row notes">
         <div className="col-lg-6">
-          <h2 className="mb-4">Notes</h2>
+          <h3 className="mb-4">Notes</h3>
 
           <ChangeLogsList changeLogs={data?.changeLogs} />
 

--- a/frontend/src/router/pages/PreviewChanges.jsx
+++ b/frontend/src/router/pages/PreviewChanges.jsx
@@ -388,7 +388,7 @@ function PreviewChanges() {
             <FeatureIcon iconName={data.featureType.icon} />
             {data.park.name} {data.featureType.name}
           </h1>
-          <h2>Edit {data.operatingYear} season dates</h2>
+          <h2>Preview {data.operatingYear} season dates</h2>
         </header>
 
         <section className="feature-type">

--- a/frontend/src/router/pages/PreviewChanges.jsx
+++ b/frontend/src/router/pages/PreviewChanges.jsx
@@ -333,120 +333,136 @@ function PreviewChanges() {
   }, [data]);
 
   if (loading || !data) {
-    return <LoadingBar />;
+    return (
+      <div className="container">
+        <LoadingBar />
+      </div>
+    );
   }
 
   if (error) {
-    return <p>Error loading season data: {error.message}</p>;
+    return (
+      <div className="container">
+        <p>Error loading season data: {error.message}</p>
+      </div>
+    );
   }
 
   return (
-    <div className="page review-changes">
-      <FlashMessage
-        title={errorFlashMessage.flashTitle}
-        message={errorFlashMessage.flashMessage}
-        isVisible={errorFlashMessage.isFlashOpen}
-        onClose={errorFlashMessage.handleFlashClose}
-        variant="error"
-      />
+    <div className="container">
+      <div className="page review-changes">
+        <FlashMessage
+          title={errorFlashMessage.flashTitle}
+          message={errorFlashMessage.flashMessage}
+          isVisible={errorFlashMessage.isFlashOpen}
+          onClose={errorFlashMessage.handleFlashClose}
+          variant="error"
+        />
 
-      <ConfirmationDialog
-        title={title}
-        message={message}
-        confirmButtonText={confirmButtonText}
-        cancelButtonText={cancelButtonText}
-        notes={confirmationDialogNotes}
-        onCancel={handleCancel}
-        onConfirm={handleConfirm}
-        isOpen={isConfirmationOpen}
-      />
+        <ConfirmationDialog
+          title={title}
+          message={message}
+          confirmButtonText={confirmButtonText}
+          cancelButtonText={cancelButtonText}
+          notes={confirmationDialogNotes}
+          onCancel={handleCancel}
+          onConfirm={handleConfirm}
+          isOpen={isConfirmationOpen}
+        />
 
-      <MissingDatesConfirmationDialog
-        featureNames={missingDatesConfirmation.featureNames}
-        inputMessage={missingDatesConfirmation.inputMessage}
-        setInputMessage={missingDatesConfirmation.setInputMessage}
-        isOpen={missingDatesConfirmation.isOpen}
-        onCancel={missingDatesConfirmation.handleCancel}
-        onConfirm={missingDatesConfirmation.handleConfirm}
-      />
-      <NavBack routePath={paths.park(parkId)}>
-        Back to {data?.park.name} dates
-      </NavBack>
+        <MissingDatesConfirmationDialog
+          featureNames={missingDatesConfirmation.featureNames}
+          inputMessage={missingDatesConfirmation.inputMessage}
+          setInputMessage={missingDatesConfirmation.setInputMessage}
+          isOpen={missingDatesConfirmation.isOpen}
+          onCancel={missingDatesConfirmation.handleCancel}
+          onConfirm={missingDatesConfirmation.handleConfirm}
+        />
 
-      <header className="page-header internal">
-        <h1 className="header-with-icon">
-          <FeatureIcon iconName={data.featureType.icon} />
-          {data.park.name} {data.featureType.name}
-        </h1>
-        <h2>Edit {data.operatingYear} season dates</h2>
-      </header>
+        <NavBack routePath={paths.park(parkId)}>
+          Back to {data?.park.name} dates
+        </NavBack>
 
-      <section className="feature-type">
-        {data?.campgrounds.map((campground) => (
-          <Campground key={campground.id} campground={campground} />
-        ))}
+        <header className="page-header internal">
+          <h1 className="header-with-icon">
+            <FeatureIcon iconName={data.featureType.icon} />
+            {data.park.name} {data.featureType.name}
+          </h1>
+          <h2>Edit {data.operatingYear} season dates</h2>
+        </header>
 
-        {data?.features.map((feature) => (
-          <Feature key={feature.id} feature={feature} />
-        ))}
-      </section>
+        <section className="feature-type">
+          {data?.campgrounds.map((campground) => (
+            <Campground key={campground.id} campground={campground} />
+          ))}
 
-      <div className="row notes">
-        <div className="col-lg-6">
-          <h3 className="mb-4">Notes</h3>
+          {data?.features.map((feature) => (
+            <Feature key={feature.id} feature={feature} />
+          ))}
+        </section>
 
-          <ChangeLogsList changeLogs={data?.changeLogs} />
+        <div className="row notes">
+          <div className="col-lg-6">
+            <h3 className="mb-4">Notes</h3>
 
-          <p>
-            If you are updating the current year’s dates, provide an explanation
-            for why dates have changed. Provide any other notes about these
-            dates if needed.
-          </p>
+            <ChangeLogsList changeLogs={data?.changeLogs} />
 
-          <div className="form-group mb-4">
-            <textarea
-              className="form-control"
-              id="notes"
-              name="notes"
-              rows="5"
-              value={notes}
-              onChange={(ev) => setNotes(ev.target.value)}
-            ></textarea>
-          </div>
-          <ContactBox />
+            <p>
+              If you are updating the current year’s dates, provide an
+              explanation for why dates have changed. Provide any other notes
+              about these dates if needed.
+            </p>
 
-          <ReadyToPublishBox
-            readyToPublish={readyToPublish}
-            setReadyToPublish={setReadyToPublish}
-          />
+            <div className="form-group mb-4">
+              <textarea
+                className="form-control"
+                id="notes"
+                name="notes"
+                rows="5"
+                value={notes}
+                onChange={(ev) => setNotes(ev.target.value)}
+              ></textarea>
+            </div>
 
-          <div className="controls d-flex flex-column flex-sm-row gap-2">
-            <Link
-              to={paths.seasonEdit(parkId, seasonId)}
-              type="button"
-              className="btn btn-outline-primary"
-            >
-              Back
-            </Link>
+            <ContactBox />
 
-            <button
-              type="button"
-              className="btn btn-outline-primary"
-              onClick={savePreview}
-            >
-              Save draft
-            </button>
+            <ReadyToPublishBox
+              readyToPublish={readyToPublish}
+              setReadyToPublish={setReadyToPublish}
+            />
 
-            <button type="button" className="btn btn-primary" onClick={approve}>
-              Mark approved
-            </button>
+            <div className="controls d-flex flex-column flex-sm-row gap-2">
+              <Link
+                to={paths.seasonEdit(parkId, seasonId)}
+                type="button"
+                className="btn btn-outline-primary"
+              >
+                Back
+              </Link>
 
-            {(saving || savingApproval) && (
-              <span
-                className="spinner-border text-primary align-self-center me-2"
-                aria-hidden="true"
-              ></span>
-            )}
+              <button
+                type="button"
+                className="btn btn-outline-primary"
+                onClick={savePreview}
+              >
+                Save draft
+              </button>
+
+              <button
+                type="button"
+                className="btn btn-primary"
+                onClick={approve}
+              >
+                Mark approved
+              </button>
+
+              {(saving || savingApproval) && (
+                <span
+                  className="spinner-border text-primary align-self-center me-2"
+                  aria-hidden="true"
+                ></span>
+              )}
+            </div>
           </div>
         </div>
       </div>

--- a/frontend/src/router/pages/PreviewChanges.scss
+++ b/frontend/src/router/pages/PreviewChanges.scss
@@ -6,10 +6,6 @@
 
     & > h2 {
       margin-bottom: var(--layout-margin-xlarge);
-
-      .feature-icon {
-        height: 1.25em;
-      }
     }
   }
 

--- a/frontend/src/router/pages/PreviewWinterFeesChanges.jsx
+++ b/frontend/src/router/pages/PreviewWinterFeesChanges.jsx
@@ -218,7 +218,7 @@ function PreviewChanges() {
     setReadyToPublish(data.readyToPublish);
   }, [data]);
 
-  if (loading) {
+  if (loading || !data) {
     return <LoadingBar />;
   }
 
@@ -283,7 +283,7 @@ function PreviewChanges() {
 
       <div className="row notes">
         <div className="col-lg-6">
-          <h2 className="mb-4">Notes</h2>
+          <h3 className="mb-4">Notes</h3>
 
           <ChangeLogsList changeLogs={data?.changeLogs} />
 

--- a/frontend/src/router/pages/PreviewWinterFeesChanges.jsx
+++ b/frontend/src/router/pages/PreviewWinterFeesChanges.jsx
@@ -154,7 +154,7 @@ function PreviewChanges() {
   function Feature({ feature }) {
     return (
       <div>
-        <h5>{feature.name}</h5>
+        <h4 className="feature-name mb-4">{feature.name}</h4>
 
         <div className="table-responsive">
           <table className="table table-striped">
@@ -279,7 +279,7 @@ function PreviewChanges() {
 
         {data?.featureTypes.map((featureType) => (
           <section key={featureType.id} className="feature-type">
-            <h3 className="header-with-icon">
+            <h3 className="header-with-icon mb-4">
               <FeatureIcon iconName={featureType.icon} />
               {featureType.name}
             </h3>

--- a/frontend/src/router/pages/PreviewWinterFeesChanges.jsx
+++ b/frontend/src/router/pages/PreviewWinterFeesChanges.jsx
@@ -219,124 +219,139 @@ function PreviewChanges() {
   }, [data]);
 
   if (loading || !data) {
-    return <LoadingBar />;
+    return (
+      <div className="container">
+        <LoadingBar />
+      </div>
+    );
   }
 
   if (error) {
-    return <p>Error loading season data: {error.message}</p>;
+    return (
+      <div className="container">
+        <p>Error loading season data: {error.message}</p>
+      </div>
+    );
   }
 
   return (
-    <div className="page review-winter-fees-changes">
-      <FlashMessage
-        title={errorFlashMessage.flashTitle}
-        message={errorFlashMessage.flashMessage}
-        isVisible={errorFlashMessage.isFlashOpen}
-        onClose={errorFlashMessage.handleFlashClose}
-        variant="error"
-      />
+    <div className="container">
+      <div className="page review-winter-fees-changes">
+        <FlashMessage
+          title={errorFlashMessage.flashTitle}
+          message={errorFlashMessage.flashMessage}
+          isVisible={errorFlashMessage.isFlashOpen}
+          onClose={errorFlashMessage.handleFlashClose}
+          variant="error"
+        />
 
-      <ConfirmationDialog
-        title={title}
-        message={message}
-        notes={confirmationDialogNotes}
-        confirmButtonText={confirmButtonText}
-        cancelButtonText={cancelButtonText}
-        onCancel={handleCancel}
-        onConfirm={handleConfirm}
-        isOpen={isConfirmationOpen}
-      />
+        <ConfirmationDialog
+          title={title}
+          message={message}
+          notes={confirmationDialogNotes}
+          confirmButtonText={confirmButtonText}
+          cancelButtonText={cancelButtonText}
+          onCancel={handleCancel}
+          onConfirm={handleConfirm}
+          isOpen={isConfirmationOpen}
+        />
 
-      <MissingDatesConfirmationDialog
-        featureNames={missingDatesConfirmation.featureNames}
-        inputMessage={missingDatesConfirmation.inputMessage}
-        setInputMessage={missingDatesConfirmation.setInputMessage}
-        isOpen={missingDatesConfirmation.isOpen}
-        onCancel={missingDatesConfirmation.handleCancel}
-        onConfirm={missingDatesConfirmation.handleConfirm}
-      />
+        <MissingDatesConfirmationDialog
+          featureNames={missingDatesConfirmation.featureNames}
+          inputMessage={missingDatesConfirmation.inputMessage}
+          setInputMessage={missingDatesConfirmation.setInputMessage}
+          isOpen={missingDatesConfirmation.isOpen}
+          onCancel={missingDatesConfirmation.handleCancel}
+          onConfirm={missingDatesConfirmation.handleConfirm}
+        />
 
-      <NavBack routePath={paths.park(parkId)}>
-        Back to {data?.park.name} dates
-      </NavBack>
+        <NavBack routePath={paths.park(parkId)}>
+          Back to {data?.park.name} dates
+        </NavBack>
 
-      <header className="page-header internal">
-        <h1 className="header-with-icon">
-          <FeatureIcon iconName="winter-recreation" />
-          {data.park.name} winter fee
-        </h1>
-        <h2>Preview {data.name}</h2>
-      </header>
+        <header className="page-header internal">
+          <h1 className="header-with-icon">
+            <FeatureIcon iconName="winter-recreation" />
+            {data.park.name} winter fee
+          </h1>
+          <h2>Preview {data.name}</h2>
+        </header>
 
-      {data?.featureTypes.map((featureType) => (
-        <section key={featureType.id} className="feature-type">
-          <h3 className="header-with-icon">
-            <FeatureIcon iconName={featureType.icon} />
-            {featureType.name}
-          </h3>
+        {data?.featureTypes.map((featureType) => (
+          <section key={featureType.id} className="feature-type">
+            <h3 className="header-with-icon">
+              <FeatureIcon iconName={featureType.icon} />
+              {featureType.name}
+            </h3>
 
-          {featureType.features.map((feature) => (
-            <Feature key={feature.id} feature={feature} />
-          ))}
-        </section>
-      ))}
+            {featureType.features.map((feature) => (
+              <Feature key={feature.id} feature={feature} />
+            ))}
+          </section>
+        ))}
 
-      <div className="row notes">
-        <div className="col-lg-6">
-          <h3 className="mb-4">Notes</h3>
+        <div className="row notes">
+          <div className="col-lg-6">
+            <h3 className="mb-4">Notes</h3>
 
-          <ChangeLogsList changeLogs={data?.changeLogs} />
+            <ChangeLogsList changeLogs={data?.changeLogs} />
 
-          <p>
-            If you are updating the current year’s dates, provide an explanation
-            for why dates have changed. Provide any other notes about these
-            dates if needed.
-          </p>
+            <p>
+              If you are updating the current year’s dates, provide an
+              explanation for why dates have changed. Provide any other notes
+              about these dates if needed.
+            </p>
 
-          <div className="form-group mb-4">
-            <textarea
-              className="form-control"
-              id="notes"
-              name="notes"
-              rows="5"
-              value={notes}
-              onChange={(ev) => setNotes(ev.target.value)}
-            ></textarea>
-          </div>
-          <ContactBox />
+            <div className="form-group mb-4">
+              <textarea
+                className="form-control"
+                id="notes"
+                name="notes"
+                rows="5"
+                value={notes}
+                onChange={(ev) => setNotes(ev.target.value)}
+              ></textarea>
+            </div>
 
-          <ReadyToPublishBox
-            readyToPublish={readyToPublish}
-            setReadyToPublish={setReadyToPublish}
-          />
+            <ContactBox />
 
-          <div className="controls d-flex flex-column flex-sm-row gap-2">
-            <Link
-              to={paths.winterFeesEdit(parkId, seasonId)}
-              type="button"
-              className="btn btn-outline-primary"
-            >
-              Back
-            </Link>
+            <ReadyToPublishBox
+              readyToPublish={readyToPublish}
+              setReadyToPublish={setReadyToPublish}
+            />
 
-            <button
-              type="button"
-              className="btn btn-outline-primary"
-              onClick={savePreview}
-            >
-              Save draft
-            </button>
+            <div className="controls d-flex flex-column flex-sm-row gap-2">
+              <Link
+                to={paths.winterFeesEdit(parkId, seasonId)}
+                type="button"
+                className="btn btn-outline-primary"
+              >
+                Back
+              </Link>
 
-            <button type="button" className="btn btn-primary" onClick={approve}>
-              Mark approved
-            </button>
+              <button
+                type="button"
+                className="btn btn-outline-primary"
+                onClick={savePreview}
+              >
+                Save draft
+              </button>
 
-            {(saving || savingApproval) && (
-              <span
-                className="spinner-border text-primary align-self-center me-2"
-                aria-hidden="true"
-              ></span>
-            )}
+              <button
+                type="button"
+                className="btn btn-primary"
+                onClick={approve}
+              >
+                Mark approved
+              </button>
+
+              {(saving || savingApproval) && (
+                <span
+                  className="spinner-border text-primary align-self-center me-2"
+                  aria-hidden="true"
+                ></span>
+              )}
+            </div>
           </div>
         </div>
       </div>

--- a/frontend/src/router/pages/PublishPage.jsx
+++ b/frontend/src/router/pages/PublishPage.jsx
@@ -30,11 +30,19 @@ function PublishPage() {
   );
 
   if (loading) {
-    return <LoadingBar />;
+    return (
+      <div className="container">
+        <LoadingBar />
+      </div>
+    );
   }
 
   if (error) {
-    return <div>Error loading data: {error.message}</div>;
+    return (
+      <div className="container">
+        <div>Error loading data: {error.message}</div>
+      </div>
+    );
   }
 
   async function publishToApi() {
@@ -66,66 +74,70 @@ function PublishPage() {
   }
 
   return (
-    <div className="page publish">
-      <FlashMessage
-        title={successFlash.flashTitle}
-        message={successFlash.flashMessage}
-        isVisible={successFlash.isFlashOpen}
-        onClose={successFlash.handleFlashClose}
-      />
+    <div className="container">
+      <div className="page publish">
+        <FlashMessage
+          title={successFlash.flashTitle}
+          message={successFlash.flashMessage}
+          isVisible={successFlash.isFlashOpen}
+          onClose={successFlash.handleFlashClose}
+        />
 
-      <FlashMessage
-        title={errorFlash.flashTitle}
-        message={errorFlash.flashMessage}
-        isVisible={errorFlash.isFlashOpen}
-        onClose={errorFlash.handleFlashClose}
-        variant="error"
-      />
+        <FlashMessage
+          title={errorFlash.flashTitle}
+          message={errorFlash.flashMessage}
+          isVisible={errorFlash.isFlashOpen}
+          onClose={errorFlash.handleFlashClose}
+          variant="error"
+        />
 
-      <ConfirmationDialog
-        isOpen={isConfirmationOpen}
-        onConfirm={handleConfirm}
-        onCancel={handleCancel}
-        title={title}
-        message={message}
-        confirmButtonText={confirmButtonText}
-        cancelButtonText={cancelButtonText}
-        notes={confirmationDialogNotes}
-      />
-      <div className="d-flex justify-content-end mb-2">
-        <button className="btn btn-primary" onClick={publishToApi}>
-          Publish to API
-        </button>
-        {saving && (
-          <span
-            className="spinner-border text-primary align-self-center me-2"
-            aria-hidden="true"
-          ></span>
-        )}
-      </div>
+        <ConfirmationDialog
+          isOpen={isConfirmationOpen}
+          onConfirm={handleConfirm}
+          onCancel={handleCancel}
+          title={title}
+          message={message}
+          confirmButtonText={confirmButtonText}
+          cancelButtonText={cancelButtonText}
+          notes={confirmationDialogNotes}
+        />
 
-      <div className="table-responsive">
-        <table className="table table-striped">
-          <thead>
-            <tr>
-              <th scope="col">Park name</th>
-              <th scope="col">Feature</th>
-              <th scope="col">Season</th>
-            </tr>
-          </thead>
-          <tbody>
-            {data?.features.map((feature) => (
-              <tr key={`${feature.id}-${feature.season}`}>
-                <td>{feature.park.name}</td>
-                <td>{feature.name}</td>
-                <td>
-                  {feature.season}
-                  <NotReadyFlag show={!feature.readyToPublish} />
-                </td>
+        <div className="d-flex justify-content-end mb-2">
+          <button className="btn btn-primary" onClick={publishToApi}>
+            Publish to API
+          </button>
+
+          {saving && (
+            <span
+              className="spinner-border text-primary align-self-center me-2"
+              aria-hidden="true"
+            ></span>
+          )}
+        </div>
+
+        <div className="table-responsive">
+          <table className="table table-striped">
+            <thead>
+              <tr>
+                <th scope="col">Park name</th>
+                <th scope="col">Feature</th>
+                <th scope="col">Season</th>
               </tr>
-            ))}
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              {data?.features.map((feature) => (
+                <tr key={`${feature.id}-${feature.season}`}>
+                  <td>{feature.park.name}</td>
+                  <td>{feature.name}</td>
+                  <td>
+                    {feature.season}
+                    <NotReadyFlag show={!feature.readyToPublish} />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/router/pages/SubmitDates.jsx
+++ b/frontend/src/router/pages/SubmitDates.jsx
@@ -355,9 +355,9 @@ function SubmitDates() {
     const endDateId = `end-date-${dateRangeId}`;
 
     // Track validation errors for the whole range, or the whole dateable feature
-    const groupErrors = errors?.[dateRangeId] || errors?.[dateRange.dateableId];
-    const startErrors = errors?.[startDateId] || groupErrors;
-    const endErrors = errors?.[endDateId] || groupErrors;
+    const groupErrors = errors[dateRangeId] || errors[dateRange.dateableId];
+    const startErrors = errors[startDateId] || groupErrors;
+    const endErrors = errors[endDateId] || groupErrors;
 
     // Limit the date range to the operating year
     const minDate = new Date(season.operatingYear, 0, 1);
@@ -472,8 +472,11 @@ function SubmitDates() {
             </div>
 
             {/* Show validation errors for the startDate field */}
-            {errors?.[startDateId] && (
-              <div className="error-message mt-2">{errors?.[startDateId]}</div>
+            {errors[startDateId] && (
+              <div className="error-message mt-2">
+                <FontAwesomeIcon icon={faTriangleExclamation} />
+                <div>{errors[startDateId]}</div>
+              </div>
             )}
           </div>
         </div>
@@ -527,17 +530,20 @@ function SubmitDates() {
             </div>
 
             {/* Show validation errors for the endDate field */}
-            {errors?.[endDateId] && (
-              <div className="error-message mt-2">{errors?.[endDateId]}</div>
+            {errors[endDateId] && (
+              <div className="error-message mt-2">
+                <FontAwesomeIcon icon={faTriangleExclamation} />
+                <div>{errors[endDateId]}</div>
+              </div>
             )}
           </div>
         </div>
 
         {/* Show validation errors for the date range */}
-        {errors?.[dateRangeId] && (
+        {errors[dateRangeId] && (
           <div className="error-message mt-2">
-            <FontAwesomeIcon icon={faTriangleExclamation} />{" "}
-            {errors?.[dateRangeId]}
+            <FontAwesomeIcon icon={faTriangleExclamation} />
+            <div>{errors[dateRangeId]}</div>
           </div>
         )}
       </div>
@@ -660,16 +666,10 @@ function SubmitDates() {
           )}
         </div>
         {/* Show validation errors for the whole dateable feature */}
-        {errors?.[feature.dateable.id] && (
-          <div
-            className="alert alert-danger alert-validation-error mt-2"
-            role="alert"
-          >
-            <div className="icon">
-              <FontAwesomeIcon icon={faTriangleExclamation} />{" "}
-            </div>
-
-            <div className="content">{errors?.[feature.dateable.id]}</div>
+        {errors[feature.dateable.id] && (
+          <div className="error-message mt-2">
+            <FontAwesomeIcon icon={faTriangleExclamation} />{" "}
+            <div>{errors[feature.dateable.id]}</div>
           </div>
         )}
       </section>
@@ -777,13 +777,11 @@ function SubmitDates() {
             dates if needed.
           </p>
 
-          <div
-            className={`form-group mb-4 ${errors?.notes ? "has-error" : ""}`}
-          >
+          <div className={`form-group mb-4 ${errors.notes ? "has-error" : ""}`}>
             <textarea
               className={classNames({
                 "form-control": true,
-                "is-invalid": errors?.notes,
+                "is-invalid": errors.notes,
               })}
               id="notes"
               name="notes"
@@ -794,8 +792,11 @@ function SubmitDates() {
                 validateNotes(ev.target.value);
               }}
             ></textarea>
-            {errors?.notes && (
-              <div className="error-message mt-2">{errors?.notes}</div>
+            {errors.notes && (
+              <div className="error-message mt-2">
+                <FontAwesomeIcon icon={faTriangleExclamation} />
+                <div>{errors.notes}</div>
+              </div>
             )}
           </div>
 

--- a/frontend/src/router/pages/SubmitDates.jsx
+++ b/frontend/src/router/pages/SubmitDates.jsx
@@ -697,7 +697,7 @@ function SubmitDates() {
     }),
   };
 
-  if (loading) {
+  if (loading || !season) {
     return <LoadingBar />;
   }
 
@@ -727,7 +727,7 @@ function SubmitDates() {
       />
 
       <NavBack routePath={paths.park(parkId)}>
-        Back to {season?.park.name} season dates
+        Back to {season.park.name} dates
       </NavBack>
 
       <header className="page-header internal">

--- a/frontend/src/router/pages/SubmitDates.jsx
+++ b/frontend/src/router/pages/SubmitDates.jsx
@@ -722,7 +722,7 @@ function SubmitDates() {
         {/* Show validation errors for the whole dateable feature */}
         {errors[feature.dateable.id] && (
           <div className="error-message mt-2">
-            <FontAwesomeIcon icon={faTriangleExclamation} />{" "}
+            <FontAwesomeIcon icon={faTriangleExclamation} />
             <div>{errors[feature.dateable.id]}</div>
           </div>
         )}

--- a/frontend/src/router/pages/SubmitDates.jsx
+++ b/frontend/src/router/pages/SubmitDates.jsx
@@ -5,6 +5,8 @@ import {
   faCircleInfo,
   faTriangleExclamation,
   faCalendarCheck,
+  faPlus,
+  faXmark,
 } from "@fa-kit/icons/classic/regular";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import DatePicker from "react-datepicker";
@@ -265,6 +267,18 @@ function SubmitDates() {
     }));
   }
 
+  function removeDateRange(dateType, dateableId, index) {
+    setDates((prevDates) => ({
+      ...prevDates,
+      [dateableId]: {
+        ...prevDates[dateableId],
+        [dateType]: prevDates[dateableId][dateType].filter(
+          (_, i) => i !== index,
+        ),
+      },
+    }));
+  }
+
   function updateDateRange(
     dateableId,
     dateType,
@@ -315,17 +329,6 @@ function SubmitDates() {
     // Default: general operating dates tooltip
     return season.dateTypes.Operation.description;
   }
-
-  // The wireframes don't show the option to remove a date, but if we need it, we can add it here
-  // function removeDateRange(dateType, dateableId, index) {
-  //   setDates((prevDates) => ({
-  //     ...prevDates,
-  //     [dateableId]: {
-  //       ...prevDates[dateableId],
-  //       [dateType]: prevDates[dateableId][dateType].filter((_, i) => i !== index),
-  //     },
-  //   }));
-  // }
 
   function Campground({ campground }) {
     return (
@@ -481,8 +484,8 @@ function SubmitDates() {
           </div>
         </div>
 
-        <div className="d-none d-lg-flex justify-content-center col-lg-1 text-center">
-          <span className="date-range-dash">&ndash;</span>
+        <div className="date-range-dash d-none d-lg-flex justify-content-center col-lg-auto px-lg-2 text-center">
+          <span>&ndash;</span>
         </div>
 
         <div className="col-lg-5">
@@ -537,6 +540,26 @@ function SubmitDates() {
               </div>
             )}
           </div>
+        </div>
+
+        <div className="date-range-remove col-lg-1">
+          {index > 0 && (
+            <button
+              className="btn btn-text text-link"
+              onClick={() =>
+                removeDateRange(
+                  dateRange.dateType.name,
+                  dateRange.dateableId,
+                  index,
+                )
+              }
+            >
+              <FontAwesomeIcon icon={faXmark} />
+              <span className="ms-1 d-inline d-lg-none">
+                Remove this date range
+              </span>
+            </button>
+          )}
         </div>
 
         {/* Show validation errors for the date range */}
@@ -619,7 +642,8 @@ function SubmitDates() {
                 className="btn btn-text text-link"
                 onClick={() => addDateRange("Operation", feature.dateable.id)}
               >
-                + Add more operating dates
+                <FontAwesomeIcon icon={faPlus} />
+                <span className="ms-1">Add more operating dates</span>
               </button>
             </p>
           </div>
@@ -659,7 +683,8 @@ function SubmitDates() {
                     addDateRange("Reservation", feature.dateable.id)
                   }
                 >
-                  + Add more reservation dates
+                  <FontAwesomeIcon icon={faPlus} />
+                  <span className="ms-1">Add more reservation dates</span>
                 </button>
               </p>
             </div>

--- a/frontend/src/router/pages/SubmitDates.jsx
+++ b/frontend/src/router/pages/SubmitDates.jsx
@@ -481,8 +481,8 @@ function SubmitDates() {
           </div>
         </div>
 
-        <div className="d-none d-lg-flex align-items-center justify-content-center col-lg-1 text-center">
-          <span>&ndash;</span>
+        <div className="d-none d-lg-flex justify-content-center col-lg-1 text-center">
+          <span className="date-range-dash">&ndash;</span>
         </div>
 
         <div className="col-lg-5">

--- a/frontend/src/router/pages/SubmitDates.jsx
+++ b/frontend/src/router/pages/SubmitDates.jsx
@@ -330,7 +330,7 @@ function SubmitDates() {
   function Campground({ campground }) {
     return (
       <section className="campground">
-        <h2 className="campground-name">{campground.name}</h2>
+        <h3 className="campground-name mb-4">{campground.name}</h3>
         {campground.features.map((feature) => (
           <Feature key={feature.id} feature={feature} />
         ))}
@@ -573,17 +573,21 @@ function SubmitDates() {
       return "Not available";
     }
 
-    return previousDates.map((dateRange, index) => (
-      <div key={dateRange.id} className={index > 0 ? "my-2" : "mb-2"}>
-        {formatDateRange(dateRange)}
+    return (
+      <div>
+        {previousDates.map((dateRange, index) => (
+          <div key={dateRange.id} className={index > 0 ? "my-2" : "mb-2"}>
+            {formatDateRange(dateRange)}
+          </div>
+        ))}
       </div>
-    ));
+    );
   }
 
   function Feature({ feature }) {
     return (
       <section className="feature">
-        {feature.name && <h3>{feature.name}</h3>}
+        {feature.name && <h4 className="feature-name mb-4">{feature.name}</h4>}
         <div className="row">
           <div className="col-md-6">
             <div>
@@ -601,11 +605,9 @@ function SubmitDates() {
               )}
             </div>
 
-            <div className="row">
-              <div className="col-auto">Previous:</div>
-              <div className="col">
-                {getPreviousDates(feature, "Operation")}
-              </div>
+            <div className="related-dates d-flex">
+              <span className="me-2">Previous:</span>{" "}
+              {getPreviousDates(feature, "Operation")}
             </div>
 
             {dates[feature.dateable.id]?.Operation.map((dateRange, index) => (
@@ -639,11 +641,9 @@ function SubmitDates() {
                 )}
               </div>
 
-              <div className="row">
-                <div className="col-auto">Previous:</div>
-                <div className="col">
-                  {getPreviousDates(feature, "Reservation")}
-                </div>
+              <div className="related-dates d-flex">
+                <span className="me-2">Previous:</span>{" "}
+                {getPreviousDates(feature, "Reservation")}
               </div>
 
               {dates[feature.dateable.id]?.Reservation.map(
@@ -731,17 +731,12 @@ function SubmitDates() {
       </NavBack>
 
       <header className="page-header internal">
-        <h1>
-          {season && `${season.park.name} ${season.operatingYear} season dates`}
-        </h1>
-      </header>
-
-      {season && (
-        <h2 className="feature-type-name header-with-icon">
+        <h1 className="header-with-icon">
           <FeatureIcon iconName={season.featureType.icon} />
-          {season.featureType.name}
-        </h2>
-      )}
+          {season.park.name} {season.featureType.name}
+        </h1>
+        <h2>Edit {season.operatingYear} season dates</h2>
+      </header>
 
       <p className="mb-5">
         <a
@@ -762,12 +757,12 @@ function SubmitDates() {
 
       <div className="row notes">
         <div className="col-lg-6">
-          <h2 className="mb-4">
+          <h3 className="mb-4">
             Notes
             {["approved", "on API"].includes(season?.status) && (
               <span className="text-danger">*</span>
             )}
-          </h2>
+          </h3>
 
           <ChangeLogsList changeLogs={season?.changeLogs} />
 

--- a/frontend/src/router/pages/SubmitDates.jsx
+++ b/frontend/src/router/pages/SubmitDates.jsx
@@ -420,7 +420,7 @@ function SubmitDates() {
     }
 
     return (
-      <div className="row dates-row operating-dates">
+      <div className="row gx-0 dates-row">
         <div className="col-lg-5">
           <div className="form-group">
             <label htmlFor={startDateId} className="form-label d-lg-none">
@@ -481,7 +481,7 @@ function SubmitDates() {
           </div>
         </div>
 
-        <div className="d-none d-lg-block col-lg-1 text-center">
+        <div className="d-none d-lg-flex align-items-center justify-content-center col-lg-1 text-center">
           <span>&ndash;</span>
         </div>
 

--- a/frontend/src/router/pages/SubmitDates.jsx
+++ b/frontend/src/router/pages/SubmitDates.jsx
@@ -78,7 +78,7 @@ function SubmitDates() {
 
   const navigate = useNavigate();
 
-  // are there changes to save?
+  // Returns true if there are any form changes to save
   function hasChanges() {
     // Any existing dates changed
     if (

--- a/frontend/src/router/pages/SubmitDates.jsx
+++ b/frontend/src/router/pages/SubmitDates.jsx
@@ -1,6 +1,6 @@
 import { useParams, useNavigate, Link } from "react-router-dom";
 import { useEffect, useState } from "react";
-import { cloneDeep, set as lodashSet } from "lodash";
+import { cloneDeep, set as lodashSet, omit } from "lodash";
 import {
   faCircleInfo,
   faTriangleExclamation,
@@ -125,9 +125,9 @@ function SubmitDates() {
         // if the range is unchanged, skip this range
         return dateRange.changed;
       })
-      // Add dateTypeId to the date ranges
+      // Add dateTypeId to the date ranges, remove tempId
       .map((dateRange) => ({
-        ...dateRange,
+        ...omit(dateRange, ["tempId"]),
         dateTypeId: dateRange.dateType.id,
       }));
 
@@ -274,6 +274,8 @@ function SubmitDates() {
             dateableId,
             dateType: season.dateTypes[dateType],
             changed: true,
+            // Add a temporary ID for records that haven't been saved yet
+            tempId: crypto.randomUUID(),
           },
         ],
       },
@@ -653,7 +655,11 @@ function SubmitDates() {
             </div>
 
             {dates[feature.dateable.id]?.Operation.map((dateRange, index) => (
-              <DateRange key={index} dateRange={dateRange} index={index} />
+              <DateRange
+                key={dateRange.id || dateRange.tempId}
+                dateRange={dateRange}
+                index={index}
+              />
             ))}
 
             <p>
@@ -691,7 +697,11 @@ function SubmitDates() {
 
               {dates[feature.dateable.id]?.Reservation.map(
                 (dateRange, index) => (
-                  <DateRange key={index} dateRange={dateRange} index={index} />
+                  <DateRange
+                    key={dateRange.id || dateRange.tempId}
+                    dateRange={dateRange}
+                    index={index}
+                  />
                 ),
               )}
 

--- a/frontend/src/router/pages/SubmitDates.jsx
+++ b/frontend/src/router/pages/SubmitDates.jsx
@@ -353,9 +353,13 @@ function SubmitDates() {
   function Campground({ campground }) {
     return (
       <section className="campground">
-        <h3 className="campground-name mb-4">{campground.name}</h3>
+        <div className="container">
+          <h3 className="campground-name mb-4">{campground.name}</h3>
+        </div>
         {campground.features.map((feature) => (
-          <Feature key={feature.id} feature={feature} />
+          <div key={feature.id} className="container">
+            <Feature feature={feature} />
+          </div>
         ))}
       </section>
     );
@@ -630,7 +634,7 @@ function SubmitDates() {
 
   function Feature({ feature }) {
     return (
-      <section className="feature">
+      <div className="feature">
         {feature.name && <h4 className="feature-name mb-4">{feature.name}</h4>}
         <div className="row">
           <div className="col-md-6">
@@ -662,7 +666,7 @@ function SubmitDates() {
               />
             ))}
 
-            <p>
+            <div>
               <button
                 className="btn btn-text text-link"
                 onClick={() => addDateRange("Operation", feature.dateable.id)}
@@ -670,7 +674,7 @@ function SubmitDates() {
                 <FontAwesomeIcon icon={faPlus} />
                 <span className="ms-1">Add more operating dates</span>
               </button>
-            </p>
+            </div>
           </div>
 
           {feature.hasReservations && (
@@ -705,7 +709,7 @@ function SubmitDates() {
                 ),
               )}
 
-              <p>
+              <div>
                 <button
                   className="btn btn-text text-link"
                   onClick={() =>
@@ -715,10 +719,11 @@ function SubmitDates() {
                   <FontAwesomeIcon icon={faPlus} />
                   <span className="ms-1">Add more reservation dates</span>
                 </button>
-              </p>
+              </div>
             </div>
           )}
         </div>
+
         {/* Show validation errors for the whole dateable feature */}
         {errors[feature.dateable.id] && (
           <div className="error-message mt-2">
@@ -726,7 +731,7 @@ function SubmitDates() {
             <div>{errors[feature.dateable.id]}</div>
           </div>
         )}
-      </section>
+      </div>
     );
   }
 
@@ -752,11 +757,19 @@ function SubmitDates() {
   };
 
   if (loading || !season) {
-    return <LoadingBar />;
+    return (
+      <div className="container">
+        <LoadingBar />
+      </div>
+    );
   }
 
   if (error) {
-    return <p>Error loading season data: {error.message}</p>;
+    return (
+      <div className="container">
+        <p>Error loading season data: {error.message}</p>
+      </div>
+    );
   }
 
   return (
@@ -780,115 +793,128 @@ function SubmitDates() {
         variant="error"
       />
 
-      <NavBack routePath={paths.park(parkId)}>
-        Back to {season.park.name} dates
-      </NavBack>
+      <div className="container">
+        <NavBack routePath={paths.park(parkId)}>
+          Back to {season.park.name} dates
+        </NavBack>
 
-      <header className="page-header internal">
-        <h1 className="header-with-icon">
-          <FeatureIcon iconName={season.featureType.icon} />
-          {season.park.name} {season.featureType.name}
-        </h1>
-        <h2>Edit {season.operatingYear} season dates</h2>
-      </header>
+        <header className="page-header internal">
+          <h1 className="header-with-icon">
+            <FeatureIcon iconName={season.featureType.icon} />
+            {season.park.name} {season.featureType.name}
+          </h1>
+          <h2>Edit {season.operatingYear} season dates</h2>
+        </header>
 
-      <p className="mb-5">
-        <a
-          href="https://www2.gov.bc.ca/gov/content/employment-business/employment-standards-advice/employment-standards/statutory-holidays"
-          target="_blank"
-        >
-          View a list of all statutory holidays
-        </a>
-      </p>
+        <p className="mb-5">
+          <a
+            href="https://www2.gov.bc.ca/gov/content/employment-business/employment-standards-advice/employment-standards/statutory-holidays"
+            target="_blank"
+          >
+            View a list of all statutory holidays
+          </a>
+        </p>
+      </div>
 
-      {season?.campgrounds.map((campground) => (
-        <Campground key={campground.id} campground={campground} />
-      ))}
+      <div className="mb-5">
+        {season?.campgrounds.map((campground) => (
+          <Campground key={campground.id} campground={campground} />
+        ))}
 
-      {season?.features.map((feature) => (
-        <Feature key={feature.id} feature={feature} />
-      ))}
+        {season?.features.map((feature) => (
+          <section key={feature.id} className="non-campground-feature">
+            <div className="container">
+              <Feature feature={feature} />
+            </div>
+          </section>
+        ))}
+      </div>
 
-      <div className="row notes">
-        <div className="col-lg-6">
-          <h3 className="mb-4">
-            Notes
-            {["approved", "on API"].includes(season?.status) && (
-              <span className="text-danger">*</span>
-            )}
-          </h3>
+      <div className="container">
+        <div className="row notes">
+          <div className="col-lg-6">
+            <h3 className="mb-4">
+              Notes
+              {["approved", "on API"].includes(season?.status) && (
+                <span className="text-danger">*</span>
+              )}
+            </h3>
 
-          <ChangeLogsList changeLogs={season?.changeLogs} />
+            <ChangeLogsList changeLogs={season?.changeLogs} />
 
-          <p>
-            If you are updating the current year’s dates, provide an explanation
-            for why dates have changed. Provide any other notes about these
-            dates if needed.
-          </p>
+            <p>
+              If you are updating the current year’s dates, provide an
+              explanation for why dates have changed. Provide any other notes
+              about these dates if needed.
+            </p>
 
-          <div className={`form-group mb-4 ${errors.notes ? "has-error" : ""}`}>
-            <textarea
-              className={classNames({
-                "form-control": true,
-                "is-invalid": errors.notes,
-              })}
-              id="notes"
-              name="notes"
-              rows="5"
-              value={notes}
-              onChange={(ev) => {
-                setNotes(ev.target.value);
-                validateNotes(ev.target.value);
-              }}
-            ></textarea>
-            {errors.notes && (
-              <div className="error-message mt-2">
-                <FontAwesomeIcon icon={faTriangleExclamation} />
-                <div>{errors.notes}</div>
-              </div>
-            )}
-          </div>
-
-          <ContactBox />
-
-          <ReadyToPublishBox
-            readyToPublish={readyToPublish}
-            setReadyToPublish={setReadyToPublish}
-          />
-
-          <div className="controls d-flex flex-column flex-sm-row gap-2">
-            <Link
-              to={paths.park(parkId)}
-              type="button"
-              className="btn btn-outline-primary"
+            <div
+              className={`form-group mb-4 ${errors.notes ? "has-error" : ""}`}
             >
-              Back
-            </Link>
+              <textarea
+                className={classNames({
+                  "form-control": true,
+                  "is-invalid": errors.notes,
+                })}
+                id="notes"
+                name="notes"
+                rows="5"
+                value={notes}
+                onChange={(ev) => {
+                  setNotes(ev.target.value);
+                  validateNotes(ev.target.value);
+                }}
+              ></textarea>
 
-            <button
-              type="button"
-              className="btn btn-outline-primary"
-              onClick={saveAsDraft}
-              disabled={!hasChanges()}
-            >
-              Save draft
-            </button>
+              {errors.notes && (
+                <div className="error-message mt-2">
+                  <FontAwesomeIcon icon={faTriangleExclamation} />
+                  <div>{errors.notes}</div>
+                </div>
+              )}
+            </div>
 
-            <button
-              type="button"
-              className="btn btn-primary"
-              onClick={continueToPreview}
-              disabled={!hasChanges()}
-            >
-              Save and continue to preview
-            </button>
+            <ContactBox />
 
-            {saving && (
-              <span
-                className="spinner-border text-primary align-self-center me-2"
-                aria-hidden="true"
-              ></span>
-            )}
+            <ReadyToPublishBox
+              readyToPublish={readyToPublish}
+              setReadyToPublish={setReadyToPublish}
+            />
+
+            <div className="controls d-flex flex-column flex-sm-row gap-2">
+              <Link
+                to={paths.park(parkId)}
+                type="button"
+                className="btn btn-outline-primary"
+              >
+                Back
+              </Link>
+
+              <button
+                type="button"
+                className="btn btn-outline-primary"
+                onClick={saveAsDraft}
+                disabled={!hasChanges()}
+              >
+                Save draft
+              </button>
+
+              <button
+                type="button"
+                className="btn btn-primary"
+                onClick={continueToPreview}
+                disabled={!hasChanges()}
+              >
+                Save and continue to preview
+              </button>
+
+              {saving && (
+                <span
+                  className="spinner-border text-primary align-self-center me-2"
+                  aria-hidden="true"
+                ></span>
+              )}
+            </div>
           </div>
         </div>
       </div>

--- a/frontend/src/router/pages/SubmitDates.scss
+++ b/frontend/src/router/pages/SubmitDates.scss
@@ -47,5 +47,3 @@
       transparent;
   }
 }
-
-// @TODO: spacing helpers for xl, xxl, etc.

--- a/frontend/src/router/pages/SubmitDates.scss
+++ b/frontend/src/router/pages/SubmitDates.scss
@@ -60,9 +60,4 @@
     border-color: var(--surface-color-border-dark) transparent transparent
       transparent;
   }
-
-  .error-message {
-    color: var(--support-border-color-danger);
-    font-size: 0.875em;
-  }
 }

--- a/frontend/src/router/pages/SubmitDates.scss
+++ b/frontend/src/router/pages/SubmitDates.scss
@@ -33,7 +33,7 @@
         }
       }
 
-      .date-range-dash {
+      .date-range-dash span {
         line-height: 2.25em;
       }
     }

--- a/frontend/src/router/pages/SubmitDates.scss
+++ b/frontend/src/router/pages/SubmitDates.scss
@@ -1,19 +1,14 @@
 .page.submit-dates {
-  .campground {
+  section {
+    padding-block: var(--layout-margin-large);
+
     // alternating background color
-    &:nth-child(even) {
+    &:nth-of-type(odd) {
       background-color: var(--surface-color-background-light-gray);
     }
   }
 
   .feature {
-    margin-bottom: var(--layout-margin-large);
-
-    // alternating background color
-    &:nth-child(odd) {
-      background-color: var(--surface-color-background-light-gray);
-    }
-
     .dates-row {
       margin-bottom: var(--layout-margin-large);
 

--- a/frontend/src/router/pages/SubmitDates.scss
+++ b/frontend/src/router/pages/SubmitDates.scss
@@ -24,7 +24,7 @@
     }
 
     h3 {
-      margin-bottom: var(--layout-margin-large);
+      margin-bottom: var(--layout-margin-xlarge);
     }
 
     .dates-row {

--- a/frontend/src/router/pages/SubmitDates.scss
+++ b/frontend/src/router/pages/SubmitDates.scss
@@ -1,12 +1,4 @@
 .page.submit-dates {
-  h2:not(.react-datepicker h2) {
-    margin-bottom: var(--layout-margin-xlarge);
-
-    .feature-icon {
-      height: 1.25em;
-    }
-  }
-
   .campground {
     // alternating background color
     &:nth-child(even) {
@@ -16,15 +8,10 @@
 
   .feature {
     margin-bottom: var(--layout-margin-large);
-    padding-block: var(--layout-padding-medium);
 
     // alternating background color
     &:nth-child(odd) {
       background-color: var(--surface-color-background-light-gray);
-    }
-
-    h3 {
-      margin-bottom: var(--layout-margin-xlarge);
     }
 
     .dates-row {
@@ -61,3 +48,5 @@
       transparent;
   }
 }
+
+// @TODO: spacing helpers for xl, xxl, etc.

--- a/frontend/src/router/pages/SubmitDates.scss
+++ b/frontend/src/router/pages/SubmitDates.scss
@@ -32,6 +32,10 @@
           margin-bottom: 0;
         }
       }
+
+      .date-range-dash {
+        line-height: 2.25em;
+      }
     }
   }
 

--- a/frontend/src/router/pages/SubmitWinterFeesDates.jsx
+++ b/frontend/src/router/pages/SubmitWinterFeesDates.jsx
@@ -351,7 +351,7 @@ function CampgroundFeature({ featureData }) {
   }
 
   return (
-    <section className="feature mb-4">
+    <div className="feature">
       <h4 className="feature-name mb-4">{featureData.name}</h4>
 
       <div className="row">
@@ -390,7 +390,7 @@ function CampgroundFeature({ featureData }) {
             />
           ))}
 
-          <p>
+          <div>
             <button
               className="btn btn-text text-link"
               onClick={() => addDateRange()}
@@ -398,25 +398,27 @@ function CampgroundFeature({ featureData }) {
               <FontAwesomeIcon icon={faPlus} />
               <span className="ms-1">Add more operating dates</span>
             </button>
-          </p>
+          </div>
         </div>
       </div>
-    </section>
+    </div>
   );
 }
 
 function FeatureType({ featureTypeData }) {
   return (
-    <div className="feature-type mb-5">
-      <h3 className="header-with-icon mb-4">
-        <FeatureIcon iconName={featureTypeData.icon} />
-        {featureTypeData.name}
-      </h3>
+    <section className="feature-type">
+      <div className="container">
+        <h3 className="header-with-icon mb-4">
+          <FeatureIcon iconName={featureTypeData.icon} />
+          {featureTypeData.name}
+        </h3>
 
-      {featureTypeData.features.map((feature) => (
-        <CampgroundFeature key={feature.id} featureData={feature} />
-      ))}
-    </div>
+        {featureTypeData.features.map((feature) => (
+          <CampgroundFeature key={feature.id} featureData={feature} />
+        ))}
+      </div>
+    </section>
   );
 }
 
@@ -611,11 +613,19 @@ export default function SubmitWinterFeesDates() {
   }, [data]);
 
   if (loading || !season) {
-    return <LoadingBar />;
+    return (
+      <div className="container">
+        <LoadingBar />
+      </div>
+    );
   }
 
   if (error) {
-    return <p>Error loading season data: {error.message}</p>;
+    return (
+      <div className="container">
+        <p>Error loading season data: {error.message}</p>
+      </div>
+    );
   }
 
   return (
@@ -639,116 +649,125 @@ export default function SubmitWinterFeesDates() {
         isOpen={isConfirmationOpen}
       />
 
-      <NavBack routePath={paths.park(parkId)}>
-        Back to {season.park.name} dates
-      </NavBack>
+      <div className="container">
+        <NavBack routePath={paths.park(parkId)}>
+          Back to {season.park.name} dates
+        </NavBack>
 
-      <header className="page-header internal">
-        <h1 className="header-with-icon">
-          <FeatureIcon iconName="winter-recreation" />
-          {season.park.name} winter fee
-        </h1>
-        <h2>Edit {season.name}</h2>
-      </header>
+        <header className="page-header internal">
+          <h1 className="header-with-icon">
+            <FeatureIcon iconName="winter-recreation" />
+            {season.park.name} winter fee
+          </h1>
+          <h2>Edit {season.name}</h2>
+        </header>
 
-      <p className="mb-5">
-        <a
-          href="https://www2.gov.bc.ca/gov/content/employment-business/employment-standards-advice/employment-standards/statutory-holidays"
-          target="_blank"
-        >
-          View a list of all statutory holidays
-        </a>
-      </p>
+        <p className="mb-5">
+          <a
+            href="https://www2.gov.bc.ca/gov/content/employment-business/employment-standards-advice/employment-standards/statutory-holidays"
+            target="_blank"
+          >
+            View a list of all statutory holidays
+          </a>
+        </p>
+      </div>
 
-      <dataContext.Provider value={data}>
-        <datesContext.Provider
-          value={{ dates, setDates, setDeletedDateRangeIds }}
-        >
-          {season.featureTypes.map((featureType) => (
-            <FeatureType key={featureType.id} featureTypeData={featureType} />
-          ))}
-        </datesContext.Provider>
-      </dataContext.Provider>
+      <div className="mb-5">
+        <dataContext.Provider value={data}>
+          <datesContext.Provider
+            value={{ dates, setDates, setDeletedDateRangeIds }}
+          >
+            {season.featureTypes.map((featureType) => (
+              <FeatureType key={featureType.id} featureTypeData={featureType} />
+            ))}
+          </datesContext.Provider>
+        </dataContext.Provider>
+      </div>
 
-      <div className="row notes">
-        <div className="col-lg-6">
-          <h3 className="mb-4">
-            Notes
-            {["approved", "on API"].includes(season.status) && (
-              <span className="text-danger">*</span>
-            )}
-          </h3>
+      <div className="container">
+        <div className="row notes">
+          <div className="col-lg-6">
+            <h3 className="mb-4">
+              Notes
+              {["approved", "on API"].includes(season.status) && (
+                <span className="text-danger">*</span>
+              )}
+            </h3>
 
-          <ChangeLogsList changeLogs={season.changeLogs} />
+            <ChangeLogsList changeLogs={season.changeLogs} />
 
-          <p>
-            If you are updating the current year’s dates, provide an explanation
-            for why dates have changed. Provide any other notes about these
-            dates if needed.
-          </p>
+            <p>
+              If you are updating the current year’s dates, provide an
+              explanation for why dates have changed. Provide any other notes
+              about these dates if needed.
+            </p>
 
-          <div className={`form-group mb-4 ${errors.notes ? "has-error" : ""}`}>
-            <textarea
-              className={classNames("form-control", {
-                "is-invalid": errors.notes,
-              })}
-              id="notes"
-              name="notes"
-              rows="5"
-              value={notes}
-              onChange={(ev) => {
-                setNotes(ev.target.value);
-                validateNotes(ev.target.value);
-              }}
-            ></textarea>
-            {errors.notes && (
-              <div className="error-message mt-2">
-                <FontAwesomeIcon icon={faTriangleExclamation} />
-                <div>{errors.notes}</div>
-              </div>
-            )}
-          </div>
-
-          <ContactBox />
-
-          <ReadyToPublishBox
-            readyToPublish={readyToPublish}
-            setReadyToPublish={setReadyToPublish}
-          />
-
-          <div className="controls d-flex flex-column flex-sm-row gap-2">
-            <Link
-              to={paths.park(parkId)}
-              type="button"
-              className="btn btn-outline-primary"
+            <div
+              className={`form-group mb-4 ${errors.notes ? "has-error" : ""}`}
             >
-              Back
-            </Link>
+              <textarea
+                className={classNames("form-control", {
+                  "is-invalid": errors.notes,
+                })}
+                id="notes"
+                name="notes"
+                rows="5"
+                value={notes}
+                onChange={(ev) => {
+                  setNotes(ev.target.value);
+                  validateNotes(ev.target.value);
+                }}
+              ></textarea>
 
-            <button
-              type="button"
-              className="btn btn-outline-primary"
-              onClick={saveAsDraft}
-              disabled={!hasChanges()}
-            >
-              Save draft
-            </button>
+              {errors.notes && (
+                <div className="error-message mt-2">
+                  <FontAwesomeIcon icon={faTriangleExclamation} />
+                  <div>{errors.notes}</div>
+                </div>
+              )}
+            </div>
 
-            <button
-              type="button"
-              className="btn btn-primary"
-              onClick={continueToPreview}
-              disabled={!hasChanges()}
-            >
-              Save and continue to preview
-            </button>
+            <ContactBox />
 
-            {saving && (
-              <span
-                className="spinner-border text-primary align-self-center me-2"
-                aria-hidden="true"
-              ></span>
-            )}
+            <ReadyToPublishBox
+              readyToPublish={readyToPublish}
+              setReadyToPublish={setReadyToPublish}
+            />
+
+            <div className="controls d-flex flex-column flex-sm-row gap-2">
+              <Link
+                to={paths.park(parkId)}
+                type="button"
+                className="btn btn-outline-primary"
+              >
+                Back
+              </Link>
+
+              <button
+                type="button"
+                className="btn btn-outline-primary"
+                onClick={saveAsDraft}
+                disabled={!hasChanges()}
+              >
+                Save draft
+              </button>
+
+              <button
+                type="button"
+                className="btn btn-primary"
+                onClick={continueToPreview}
+                disabled={!hasChanges()}
+              >
+                Save and continue to preview
+              </button>
+
+              {saving && (
+                <span
+                  className="spinner-border text-primary align-self-center me-2"
+                  aria-hidden="true"
+                ></span>
+              )}
+            </div>
           </div>
         </div>
       </div>

--- a/frontend/src/router/pages/SubmitWinterFeesDates.jsx
+++ b/frontend/src/router/pages/SubmitWinterFeesDates.jsx
@@ -577,7 +577,7 @@ export default function SubmitWinterFeesDates() {
       />
 
       <NavBack routePath={paths.park(parkId)}>
-        Back to {season.park.name} season dates
+        Back to {season.park.name} dates
       </NavBack>
 
       <header className="page-header internal">

--- a/frontend/src/router/pages/SubmitWinterFeesDates.jsx
+++ b/frontend/src/router/pages/SubmitWinterFeesDates.jsx
@@ -460,15 +460,25 @@ export default function SubmitWinterFeesDates() {
 
   function validateNotes() {}
 
-  // Are there changes to save?
+  // Returns true if there are any form changes to save
   function hasChanges() {
-    const datesChanged = Object.values(dates).some((dateRanges) =>
-      dateRanges.some((dateRange) => dateRange.changed),
-    );
+    // Any existing dates changed
+    if (
+      Object.values(dates).some((dateRanges) =>
+        dateRanges.some((dateRange) => dateRange.changed),
+      )
+    ) {
+      return true;
+    }
 
-    const readyChanged = readyToPublish !== data.readyToPublish;
+    // If any date ranges have been deleted
+    if (deletedDateRangeIds.length > 0) return true;
 
-    return datesChanged || notes || readyChanged;
+    // Ready to publish state has changed
+    if (readyToPublish !== data.readyToPublish) return true;
+
+    // Notes have been entered
+    return notes;
   }
 
   useNavigationGuard(hasChanges, openConfirmation);

--- a/frontend/src/router/pages/SubmitWinterFeesDates.jsx
+++ b/frontend/src/router/pages/SubmitWinterFeesDates.jsx
@@ -115,7 +115,7 @@ function DateRange({ dateableId, dateRange, index, updateDateRange }) {
   const openDateEnd = parseInputDate(localDateRange.endDate) || minDate;
 
   return (
-    <div className="row dates-row operating-dates">
+    <div className="row gx-0 dates-row operating-dates">
       <div className="col-lg-5">
         <div className="form-group">
           <label htmlFor={startDateId} className="form-label d-lg-none">
@@ -170,7 +170,7 @@ function DateRange({ dateableId, dateRange, index, updateDateRange }) {
         </div>
       </div>
 
-      <div className="d-none d-lg-block col-lg-1 text-center">
+      <div className="d-none d-lg-flex align-items-center justify-content-center col-lg-1 text-center">
         <span>&ndash;</span>
       </div>
 

--- a/frontend/src/router/pages/SubmitWinterFeesDates.jsx
+++ b/frontend/src/router/pages/SubmitWinterFeesDates.jsx
@@ -161,8 +161,11 @@ function DateRange({ dateableId, dateRange, index, updateDateRange }) {
           </div>
 
           {/* Show validation errors for the startDate field */}
-          {errors?.[startDateId] && (
-            <div className="error-message mt-2">{errors?.[startDateId]}</div>
+          {errors[startDateId] && (
+            <div className="error-message mt-2">
+              <FontAwesomeIcon icon={faTriangleExclamation} />
+              {errors[startDateId]}
+            </div>
           )}
         </div>
       </div>
@@ -213,17 +216,20 @@ function DateRange({ dateableId, dateRange, index, updateDateRange }) {
           </div>
 
           {/* Show validation errors for the endDate field */}
-          {errors?.[endDateId] && (
-            <div className="error-message mt-2">{errors?.[endDateId]}</div>
+          {errors[endDateId] && (
+            <div className="error-message mt-2">
+              <FontAwesomeIcon icon={faTriangleExclamation} />
+              <div>{errors[endDateId]}</div>
+            </div>
           )}
         </div>
       </div>
 
       {/* Show validation errors for the date range */}
-      {errors?.[dateRangeId] && (
+      {errors[dateRangeId] && (
         <div className="error-message mt-2">
-          <FontAwesomeIcon icon={faTriangleExclamation} />{" "}
-          {errors?.[dateRangeId]}
+          <FontAwesomeIcon icon={faTriangleExclamation} />
+          <div>{errors[dateRangeId]}</div>
         </div>
       )}
     </div>
@@ -637,7 +643,10 @@ export default function SubmitWinterFeesDates() {
               }}
             ></textarea>
             {errors.notes && (
-              <div className="error-message mt-2">{errors.notes}</div>
+              <div className="error-message mt-2">
+                <FontAwesomeIcon icon={faTriangleExclamation} />
+                <div>{errors.notes}</div>
+              </div>
             )}
           </div>
 

--- a/frontend/src/router/pages/SubmitWinterFeesDates.jsx
+++ b/frontend/src/router/pages/SubmitWinterFeesDates.jsx
@@ -310,7 +310,7 @@ function CampgroundFeature({ featureData }) {
 
   return (
     <section className="feature mb-4">
-      <h4>{featureData.name}</h4>
+      <h4 className="feature-name mb-4">{featureData.name}</h4>
 
       <div className="row">
         <div className="col-md-6">
@@ -613,12 +613,12 @@ export default function SubmitWinterFeesDates() {
 
       <div className="row notes">
         <div className="col-lg-6">
-          <h2 className="mb-4">
+          <h3 className="mb-4">
             Notes
             {["approved", "on API"].includes(season.status) && (
               <span className="text-danger">*</span>
             )}
-          </h2>
+          </h3>
 
           <ChangeLogsList changeLogs={season.changeLogs} />
 

--- a/frontend/src/router/pages/SubmitWinterFeesDates.jsx
+++ b/frontend/src/router/pages/SubmitWinterFeesDates.jsx
@@ -173,7 +173,7 @@ function DateRange({
           {errors[startDateId] && (
             <div className="error-message mt-2">
               <FontAwesomeIcon icon={faTriangleExclamation} />
-              {errors[startDateId]}
+              <div>{errors[startDateId]}</div>
             </div>
           )}
         </div>

--- a/frontend/src/router/pages/SubmitWinterFeesDates.jsx
+++ b/frontend/src/router/pages/SubmitWinterFeesDates.jsx
@@ -179,7 +179,7 @@ function DateRange({
         </div>
       </div>
 
-      <div className="d-none d-lg-flex align-items-center justify-content-center col-lg-1 text-center">
+      <div className="date-range-dash d-none d-lg-flex justify-content-center col-lg-auto px-lg-2 text-center">
         <span>&ndash;</span>
       </div>
 

--- a/frontend/src/router/pages/SubmitWinterFeesDates.scss
+++ b/frontend/src/router/pages/SubmitWinterFeesDates.scss
@@ -1,6 +1,6 @@
 .page.submit-winter-fees-dates {
   h4 {
-    margin-bottom: var(--layout-margin-large);
+    margin-bottom: var(--layout-margin-xlarge);
   }
 
   .date-type-header {

--- a/frontend/src/router/pages/SubmitWinterFeesDates.scss
+++ b/frontend/src/router/pages/SubmitWinterFeesDates.scss
@@ -1,8 +1,4 @@
 .page.submit-winter-fees-dates {
-  h4 {
-    margin-bottom: var(--layout-margin-xlarge);
-  }
-
   .date-type-header {
     font: var(--typography-regular-large-body); // "BC Sans"
     font-family: var(--bs-font-sans-serif); // "BCSans"

--- a/frontend/src/router/pages/SubmitWinterFeesDates.scss
+++ b/frontend/src/router/pages/SubmitWinterFeesDates.scss
@@ -4,6 +4,15 @@
     font-family: var(--bs-font-sans-serif); // "BCSans"
   }
 
+  section {
+    padding-block: var(--layout-margin-large);
+
+    // alternating background color
+    &:nth-of-type(odd) {
+      background-color: var(--surface-color-background-light-gray);
+    }
+  }
+
   .dates-row {
     margin-bottom: var(--layout-margin-large);
 

--- a/frontend/src/router/pages/SubmitWinterFeesDates.scss
+++ b/frontend/src/router/pages/SubmitWinterFeesDates.scss
@@ -31,5 +31,9 @@
         margin-bottom: 0;
       }
     }
+
+    .date-range-dash span {
+      line-height: 2.25em;
+    }
   }
 }

--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -158,8 +158,7 @@ label.form-check-label {
   }
 }
 
-// error messages with optional icons
-// for validation, etc.
+// error messages for validation, etc.
 .error-message {
   color: var(--support-border-color-danger);
   font-size: 0.875em;

--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -162,3 +162,33 @@ label.form-check-label {
   align-items: center;
   gap: 0.5em;
 }
+
+// custom switch component with text labels for on/off
+.form-switch:has(.label-switch) {
+  display: flex;
+  align-items: center;
+
+  input.label-switch[role="switch"] {
+    height: 1.5em;
+    width: 3.5em;
+    margin-right: 0.5em;
+    position: relative;
+
+    &::after {
+      font-size: 0.85em;
+      position: absolute;
+      top: 1px;
+      right: 5px;
+      content: "Off";
+      display: block;
+      color: var(--typography-color-primary);
+    }
+
+    &:checked::after {
+      left: 5px;
+      right: auto;
+      content: "On";
+      color: var(--typography-color-primary-invert);
+    }
+  }
+}

--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -147,6 +147,10 @@ label.form-check-label {
   display: flex;
   align-items: center;
   gap: 0.5em;
+
+  .feature-icon {
+    height: 1.25em;
+  }
 }
 
 // error messages with optional icons

--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -21,6 +21,11 @@ header.page-header {
   border-bottom: 1px solid var(--surface-color-border-default);
 }
 
+.page {
+  margin-top: var(--layout-margin-medium);
+  margin-bottom: var(--layout-margin-huge);
+}
+
 // Increase bootstrap x-padding for containers to 16px
 .container {
   --bs-gutter-x: 2rem;

--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -134,18 +134,6 @@ label.form-check-label {
   font-size: var(--typography-font-size-body) !important;
 }
 
-// custom style for validation error alert
-.alert-validation-error {
-  display: flex;
-  gap: 0.5em;
-  color: var(--typography-color-primary);
-  width: fit-content;
-
-  .icon {
-    color: var(--icons-color-danger);
-  }
-}
-
 // custom style for bootstrap dropdowns
 .dropdown-toggle {
   // flip the arrow icon when the dropdown is open
@@ -156,6 +144,16 @@ label.form-check-label {
 
 // styles for header elements with icons
 .header-with-icon {
+  display: flex;
+  align-items: center;
+  gap: 0.5em;
+}
+
+// error messages with optional icons
+// for validation, etc.
+.error-message {
+  color: var(--support-border-color-danger);
+  font-size: 0.875em;
   display: flex;
   align-items: center;
   gap: 0.5em;


### PR DESCRIPTION
### Jira Ticket

CMS-631

### Description
<!-- What did you change, and why? -->

Big ticket with lots of changes on the Submit and Preview pages for winter and regular seasons. I should have split it into several branches 🙈 And I could still do that if it's too ridiculous to review. Here's a summary:

# Small stuff
There are screenshots in the ticket to clarify this stuff:
- Update the `NavBack` component text and link target to match what's currently in Figma
- Update validation styles: always show the icon, and always show red text on a white bg.
- Update spacing and header level for h1, h2, h3, h4's
- Update the header for regular seasons to match the new style already used on the Winter pages
- Remove fancy spacing for previous dates and just show plain text ("Previous: Fri, Mar 15...")
- Improve positioning of the dash between the date range inputs

# Ready to publish toggle
Use a CSS pseudo-element to add "On" and "Off" labels to the bootstrap toggle switch. Quick and dirty change, but seems fine.

# Add "X" button to remove extra rows of dates
- Hiding the button on the first date range in the list to prevent people from deleting all the dates for a feature, unless that's a requirement...
- Using an array of "deleted date range IDs" to track the ones to delete from the DB. Only changed ranges are sent in the payload, so it would be tricky to tell which ones are to delete or ignore otherwise. 
- No changes are made until you hit "Save" so you can just refresh or leave the page if you make a mistake, same as the other edit actions.
- I had to add an ON DELETE CASCADE constraint in a migration to delete the changelogs, but the backend changes are minimal.
- To get it to render right, I had to add a temporary ID for unsaved records because relying on key="index" won't work when you remove from the middle of the list.

# Full-width alternating row colors on Submit pages
The whole page was wrapped in a `container` class before. I had to move it into the content to wrap individual sections, but it wasn't too bad. Hopefully you can still make sense of the diff if you ignore whitespace.