### PR TITLE
CMS-723: Fix session cookie/store

### DIFF
--- a/backend/middleware/adminJs.js
+++ b/backend/middleware/adminJs.js
@@ -208,13 +208,16 @@ const ConnectSession = Connect(session);
 const sessionStore = new ConnectSession({
   conObject: {
     ...connectionConfig,
+    // this package uses "user" instead of "username"
+    user: connectionConfig.username,
     ssl: process.env.NODE_ENV === "production",
   },
-  tableName: "session",
+  tableName: "AdminSessions",
   createTableIfMissing: true,
 });
 
 export const sessionMiddleware = session({
+  store: sessionStore,
   secret: process.env.ADMIN_SESSION_SECRET,
   resave: false,
   saveUninitialized: true,
@@ -230,10 +233,11 @@ export const adminRouter = AdminJSExpress.buildAuthenticatedRouter(
   null,
   {
     store: sessionStore,
-    resave: true,
+    resave: false,
     saveUninitialized: true,
-    secret: "sessionsecret",
+    secret: process.env.ADMIN_SESSION_SECRET,
     cookie: {
+      maxAge: 10 * 60 * 60 * 1000, // 10 hours
       httpOnly: process.env.NODE_ENV === "production",
       secure: process.env.NODE_ENV === "production",
     },


### PR DESCRIPTION
### Jira Ticket

CMS-723

### Description
<!-- What did you change, and why? -->

Some fixes to the configuration for the db session manager used by AdminJS. I copied from their quickstart tutorial at the time, but it wasn't actually working.

1. Change "username" to "user" in the session db connection config. Previously it was defaulting to "node" and failing silently 😬 And just storing the session in memory
2. Rename the table so it's less ambiguous, and capitalized for consistency with the other tables. You might need to manually drop the existing `session` table or reset your DB so it can create constraints with the same name.
3. Other small config tweaks: reduced the cookie length from default 1 day to only 10 hours. That's the same as the Keycloak session length. You can stay logged in all day, but it will log you out overnight.

Now that your session persists in the DB and you don't get logged out when the sever restarts in dev mode, it's not such a big inconvenience anymore. I didn't bother changing the AdminJS bundle process, since there's no easy way to do that in this version. 

If you want, you can add this to your .env.local file:
```
# Don't bundle admin.js when the server starts
ADMIN_JS_SKIP_BUNDLE="true"
```

It will still build the bundle when you request /admin if it doesn't exist, but it might skip it  when the server reloads.