### PR TITLE
CMS-711: Attempt sign-in on auth errors

### DIFF
--- a/frontend/src/router/ProtectedRoute.jsx
+++ b/frontend/src/router/ProtectedRoute.jsx
@@ -36,6 +36,8 @@ export default function ProtectedRoute({ children }) {
   }, [auth, hasTriedSignin]);
 
   if (auth.error) {
+    // If there's an error, redirect to the sign-in page
+    auth.signinRedirect();
     return <div>Authentication error: {auth.error?.message}</div>;
   }
 

--- a/frontend/src/router/ProtectedRoute.jsx
+++ b/frontend/src/router/ProtectedRoute.jsx
@@ -37,6 +37,8 @@ export default function ProtectedRoute({ children }) {
 
   if (auth.error) {
     // If there's an error, redirect to the sign-in page
+    console.error("Authentication error:", auth.error);
+    console.error("Redirecting to sign-in page...");
     auth.signinRedirect();
     return <div>Authentication error: {auth.error?.message}</div>;
   }


### PR DESCRIPTION
### Jira Ticket

CMS-711

### Description
<!-- What did you change, and why? -->

By signing in and out of all of the Keycloak consoles, I've experienced all kinds of weird and rare error states that shouldn't affect normal users. This branch adds a sign-in redirect to the auth error state, just in case something weird happens to anyone else.

Best case scenario: It will sign in and fix the token/cookies automatically

Worst case scenario: You'd go to the log-in page and have to enter your credentials again. Either way you wouldn't be stuck on an error page in DOOT.

Really worst case scenario would be if it got stuck in some kind of redirect loop, but I think you're more likely to see the keycloak login screen and stay there. I added some `console.error` lines to help test this out for a while.