### PR TITLE
CMS-757: Allow users to save incomplete dates as draft

### DIFF
--- a/frontend/src/hooks/useValidation.js
+++ b/frontend/src/hooks/useValidation.js
@@ -235,20 +235,22 @@ export default function useValidation(dates, notes, season) {
     const operationExtent = dateExtents[dateableId].Operation;
     const reservationExtent = dateExtents[dateableId].Reservation;
 
-    // End date is one or more days after reservation end date
-    const daysBetween = differenceInCalendarDays(
-      operationExtent.maxDate,
-      reservationExtent.maxDate,
-    );
-
-    // The "within range" checks earlier will ensure that the operation end date
-    // is after the reservation end date, so we only need to check the number of days between the them
-
-    if (daysBetween < 1) {
-      return addError(
-        dateableId,
-        "Reservation end date must be one or more days before the operating end date.",
+    if (operationExtent.maxDate && reservationExtent.maxDate) {
+      // End date is one or more days after reservation end date
+      const daysBetween = differenceInCalendarDays(
+        operationExtent.maxDate,
+        reservationExtent.maxDate,
       );
+
+      // The "within range" checks earlier will ensure that the operation end date
+      // is after the reservation end date, so we only need to check the number of days between the them
+
+      if (daysBetween < 1) {
+        return addError(
+          dateableId,
+          "Reservation end date must be one or more days before the operating end date.",
+        );
+      }
     }
 
     return true;

--- a/frontend/src/router/pages/SubmitDates.jsx
+++ b/frontend/src/router/pages/SubmitDates.jsx
@@ -105,7 +105,7 @@ function SubmitDates() {
     setFormSubmitted(true);
 
     // Validate form state before saving
-    if (!validateForm()) {
+    if (!savingDraft && !validateForm()) {
       throw new ValidationError("Form validation failed");
     }
 
@@ -117,8 +117,11 @@ function SubmitDates() {
       )
       // Filter out any blank ranges or unchanged dates
       .filter((dateRange) => {
-        // if either date is null, skip this range
-        if (dateRange.startDate === null || dateRange.endDate === null) {
+        if (
+          dateRange.startDate === null &&
+          dateRange.endDate === null &&
+          !dateRange.id
+        ) {
           return false;
         }
 

--- a/frontend/src/router/pages/SubmitWinterFeesDates.jsx
+++ b/frontend/src/router/pages/SubmitWinterFeesDates.jsx
@@ -502,8 +502,12 @@ export default function SubmitWinterFeesDates() {
 
     // Filter out unchanged or empty date ranges
     const changedDates = flattenedDates.filter((dateRange) => {
-      // if either date is null, skip this range
-      if (dateRange.startDate === null || dateRange.endDate === null) {
+      // if both dates are null and it has no ID, skip this range
+      if (
+        dateRange.startDate === null &&
+        dateRange.endDate === null &&
+        !dateRange.id
+      ) {
         return false;
       }
 


### PR DESCRIPTION
### Jira Ticket

CMS-757

### Description
Validation will not be run when user clicks "save as draft". So users will be able to save dates with only field populated or clear both fields and those changes will be reflected in the DB. 

This applies only when saving as draft. When clicking "continue to preview" the validation wouldn't prevent that.

Apparently we need to start validating as soon as dates are entered. But that is captured in another ticket, so this ticket doesn't deal with it. 
https://bcparksdigital.atlassian.net/browse/CMS-756

Since requirements have been changing and they were never explicitly captured for saving data -- refer to https://apps.nrs.gov.bc.ca/int/confluence/display/BCPRS/Saving+and+submitting+dates
