### PR TITLE
CMS-756: Update validation: always check the whole form

### DIFF
--- a/frontend/src/hooks/useValidation.js
+++ b/frontend/src/hooks/useValidation.js
@@ -1,21 +1,67 @@
-import { useState } from "react";
+import { useEffect, useState, useCallback, useMemo, useRef } from "react";
 import { omit, mapValues, minBy, maxBy, orderBy } from "lodash";
 import { differenceInCalendarDays, parseISO, isBefore, max } from "date-fns";
+
+// Returns a chronological list of date ranges with overlapping ranges combined
+function consolidateRanges(ranges) {
+  // Parse ISO date strings (and filter out any missing values)
+  const parsedRanges = ranges
+    .filter((range) => range.startDate && range.endDate)
+    .map((range) => ({
+      startDate: parseISO(range.startDate),
+      endDate: parseISO(range.endDate),
+    }));
+
+  // Sort ranges by start date
+  const sorted = orderBy(parsedRanges, ["startDate"]);
+
+  // Combine overlapping ranges
+  const consolidated = sorted.reduce((merged, current) => {
+    const lastRange = merged.at(-1);
+
+    // If the start date of the current range is before the end date of the last range,
+    // combine the ranges
+    if (lastRange && isBefore(current.startDate, lastRange.endDate)) {
+      lastRange.endDate = max([lastRange.endDate, current.endDate]);
+    } else {
+      merged.push(current);
+    }
+
+    return merged;
+  }, []);
+
+  return consolidated;
+}
+
+// Returns true if innerStart and innerEnd are within outerStart and outerEnd
+function checkWithinRange(outerStart, outerEnd, innerStart, innerEnd) {
+  return outerStart <= innerStart && outerEnd >= innerEnd;
+}
 
 // Validation functions for the SubmitForm component
 export default function useValidation(dates, notes, season) {
   // Validation errors
   const [errors, setErrors] = useState({});
   // Track if the form has been submitted, and validate on change after that
-  const [formSubmitted, setFormSubmitted] = useState(false);
+  const formSubmitted = useRef(false);
 
   // Add field key and error message to `errors`
-  function addError(fieldId, message) {
-    setErrors((prevErrors) => ({
-      ...prevErrors,
-      [fieldId]: message,
-    }));
-    return false;
+  function addError(fieldId, message, overwrite = true) {
+    setErrors((prevErrors) => {
+      // Add and overwrite any existing errors for that field
+      if (overwrite) {
+        return {
+          ...prevErrors,
+          [fieldId]: message,
+        };
+      }
+
+      // Add the error, but don't overwrite any existing errors
+      return {
+        [fieldId]: message,
+        ...prevErrors,
+      };
+    });
   }
 
   // Remove field key from `errors`
@@ -23,87 +69,58 @@ export default function useValidation(dates, notes, season) {
     setErrors((prevErrors) => omit(prevErrors, fieldId));
   }
 
-  // Returns true if innerStart and innerEnd are within outerStart and outerEnd
-  function checkWithinRange(outerStart, outerEnd, innerStart, innerEnd) {
-    return outerStart <= innerStart && outerEnd >= innerEnd;
-  }
-
   // Calculates the extents of each date type for each campsite grouping
-  function getDateExtents(datesObj = dates) {
-    const mapped = mapValues(datesObj, (campsiteDates) =>
-      mapValues(campsiteDates, (dateTypeDates) => {
-        // Get the dateRange with the earliest start date for this campground & date type
-        const minDateRange = minBy(
-          dateTypeDates,
-          (dateRange) => new Date(dateRange.startDate),
-        );
-        const minDate = minDateRange?.startDate
-          ? new Date(minDateRange?.startDate)
-          : null;
+  const getDateExtents = useCallback(
+    (datesObj = dates) => {
+      const mapped = mapValues(datesObj, (campsiteDates) =>
+        mapValues(campsiteDates, (dateTypeDates) => {
+          // Get the dateRange with the earliest start date for this campground & date type
+          const minDateRange = minBy(
+            dateTypeDates,
+            (dateRange) => new Date(dateRange.startDate),
+          );
+          const minDate = minDateRange?.startDate
+            ? new Date(minDateRange?.startDate)
+            : null;
 
-        // Get the dateRange with the latest end date for this campground & date type
-        const maxDateRange = maxBy(
-          dateTypeDates,
-          (dateRange) => new Date(dateRange.endDate),
-        );
-        const maxDate = maxDateRange?.endDate
-          ? new Date(maxDateRange.endDate)
-          : null;
+          // Get the dateRange with the latest end date for this campground & date type
+          const maxDateRange = maxBy(
+            dateTypeDates,
+            (dateRange) => new Date(dateRange.endDate),
+          );
+          const maxDate = maxDateRange?.endDate
+            ? new Date(maxDateRange.endDate)
+            : null;
 
-        return { minDate, maxDate };
-      }),
-    );
+          return { minDate, maxDate };
+        }),
+      );
 
-    return mapped;
-  }
+      return mapped;
+    },
+    [dates],
+  );
 
   // Validates the notes textarea field
-  function validateNotes(value = notes) {
-    clearError("notes");
 
-    if (!value && ["approved", "on API"].includes(season.status)) {
-      return addError(
-        "notes",
-        "The dates you are editing have already been Approved or Published. Please provide a note explaining the reason for this update.",
-      );
-    }
+  const validateNotes = useCallback(
+    (value = notes) => {
+      clearError("notes");
 
-    return true;
-  }
+      if (!season?.status) return;
 
-  // Returns a chronological list of date ranges with overlapping ranges combined
-  function consolidateRanges(ranges) {
-    // Parse ISO date strings (and filter out any missing values)
-    const parsedRanges = ranges
-      .filter((range) => range.startDate && range.endDate)
-      .map((range) => ({
-        startDate: parseISO(range.startDate),
-        endDate: parseISO(range.endDate),
-      }));
-
-    // Sort ranges by start date
-    const sorted = orderBy(parsedRanges, ["startDate"]);
-
-    // Combine overlapping ranges
-    const consolidated = sorted.reduce((merged, current) => {
-      const lastRange = merged.at(-1);
-
-      // If the start date of the current range is before the end date of the last range,
-      // combine the ranges
-      if (lastRange && isBefore(current.startDate, lastRange.endDate)) {
-        lastRange.endDate = max([lastRange.endDate, current.endDate]);
-      } else {
-        merged.push(current);
+      if (!value && ["approved", "on API"].includes(season.status)) {
+        addError(
+          "notes",
+          "The dates you are editing have already been Approved or Published. Please provide a note explaining the reason for this update.",
+        );
       }
-
-      return merged;
-    }, []);
-
-    return consolidated;
-  }
+    },
+    [notes, season],
+  );
 
   // Returns true if all reservation date ranges are within the operating date ranges
-  function validateReservationDates(dateableFeature) {
+  const validateReservationDates = useCallback((dateableFeature) => {
     // Consolidate any overlapping date ranges for comparison
     const operatingRanges = consolidateRanges(dateableFeature.Operation);
     const reservationRanges = consolidateRanges(dateableFeature.Reservation);
@@ -121,175 +138,190 @@ export default function useValidation(dates, notes, season) {
     );
 
     return withinRange;
-  }
+  }, []);
 
   // Validates the start and end datepicker fields in a date range
-  function validateDateRange({
-    start,
-    startDateId,
-    end,
-    endDateId,
-    dateRangeId,
-  }) {
-    // Skip validation for empty ranges
-    if (!start && !end) {
-      return true;
-    }
+  const validateDateRange = useCallback(
+    ({ start, startDateId, end, endDateId, dateRangeId }) => {
+      // Track errors for synchronous validation (on submit)
+      let valid = true;
 
-    // Both dates are required if one is set
-    if (!start) {
-      return addError(startDateId, "Enter a start date");
-    }
+      // Skip validation for empty ranges
+      if (!start && !end) return true;
 
-    if (!end) {
-      return addError(endDateId, "Enter an end date");
-    }
+      // If the form has been submitted, both fields are required
+      if (formSubmitted.current) {
+        if (!start) {
+          valid = false;
+          addError(startDateId, "Enter a start date");
+        }
 
-    // Parse date strings
-    const startDate = new Date(start);
-    const endDate = new Date(end);
+        if (!end) {
+          valid = false;
+          addError(endDateId, "Enter an end date");
+        }
+      } else if (!start || !end) {
+        // If the form has not been submitted, don't validate until both fields are filled
+        return true;
+      }
 
-    // Check if the start date is before the end date
-    if (startDate > endDate) {
-      return addError(
-        dateRangeId,
-        "Enter an end date that comes after the start date",
-      );
-    }
+      // Parse date strings
+      const startDate = new Date(start);
+      const endDate = new Date(end);
 
-    const operatingYear = season.operatingYear;
-
-    // Date must be within the year for that form
-    if (startDate.getUTCFullYear() !== operatingYear) {
-      return addError(startDateId, `Enter dates for ${operatingYear} only`);
-    }
-
-    if (endDate.getUTCFullYear() !== operatingYear) {
-      return addError(endDateId, `Enter dates for ${operatingYear} only`);
-    }
-
-    return true;
-  }
-
-  // Validates all date ranges for a dateable feature from `dates`
-  function validateFeatureDates(dateableId, datesObj = dates) {
-    const dateableFeature = datesObj[dateableId];
-
-    // If the feature has no dates, skip validation
-    if (
-      dateableFeature.Operation.length === 0 &&
-      dateableFeature.Reservation.length === 0
-    ) {
-      return true;
-    }
-
-    const dateTypeGroups = Object.values(dateableFeature);
-
-    // Clear all errors for this dateable feature:
-    // Build a list of all field IDs to clear from `errors`
-    const fieldIds = dateTypeGroups.flatMap((dateRanges) =>
-      dateRanges.flatMap((dateRange, index) => {
-        const dateRangeId = `${dateRange.dateableId}-${dateRange.dateType.id}-${index}`;
-
-        return [
-          dateRange.dateableId,
+      // Check if the start date is before the end date
+      if (startDate > endDate) {
+        valid = false;
+        addError(
           dateRangeId,
-          `start-date-${dateRangeId}`,
-          `end-date-${dateRangeId}`,
-        ];
-      }),
-    );
-
-    // Remove any errors for this dateable feature before revalidating
-    setErrors((prevErrors) => omit(prevErrors, fieldIds));
-
-    // Validate rules for individual dates and ranges
-    const dateTypeGroupsValid = dateTypeGroups.every((dateRanges) =>
-      // Loop over date ranges for the date type
-      dateRanges.every((dateRange, index) =>
-        validateDateRange({
-          start: dateRange.startDate,
-          startDateId: `start-date-${dateRange.dateableId}-${dateRange.dateType.id}-${index}`,
-          end: dateRange.endDate,
-          endDateId: `end-date-${dateRange.dateableId}-${dateRange.dateType.id}-${index}`,
-          dateRangeId: `${dateRange.dateableId}-${dateRange.dateType.id}-${index}`,
-        }),
-      ),
-    );
-
-    // If any date range is invalid, return and don't validate anything further
-    if (!dateTypeGroupsValid) return false;
-
-    // Validate rules rules that involve the entire feature
-
-    // Check if the reservation dates are all within the operating dates
-    if (!validateReservationDates(dateableFeature)) {
-      return addError(
-        dateableId,
-        "Enter reservation dates that fall within the operating dates selected.",
-      );
-    }
-
-    // Get the extent of dates for each type
-    const dateExtents = getDateExtents(datesObj);
-    const operationExtent = dateExtents[dateableId].Operation;
-    const reservationExtent = dateExtents[dateableId].Reservation;
-
-    if (operationExtent.maxDate && reservationExtent.maxDate) {
-      // End date is one or more days after reservation end date
-      const daysBetween = differenceInCalendarDays(
-        operationExtent.maxDate,
-        reservationExtent.maxDate,
-      );
-
-      // The "within range" checks earlier will ensure that the operation end date
-      // is after the reservation end date, so we only need to check the number of days between the them
-
-      if (daysBetween < 1) {
-        return addError(
-          dateableId,
-          "Reservation end date must be one or more days before the operating end date.",
+          "Enter an end date that comes after the start date",
         );
       }
-    }
 
-    return true;
-  }
+      const operatingYear = season?.operatingYear;
 
-  function validateForm() {
+      if (!operatingYear) return valid;
+
+      // Date must be within the year for that form
+      if (startDate.getUTCFullYear() !== operatingYear) {
+        valid = false;
+        addError(startDateId, `Enter dates for ${operatingYear} only`, false);
+      }
+
+      if (endDate.getUTCFullYear() !== operatingYear) {
+        valid = false;
+        addError(endDateId, `Enter dates for ${operatingYear} only`, false);
+      }
+
+      return valid;
+    },
+    [season?.operatingYear, formSubmitted],
+  );
+
+  // Validates all date ranges for a dateable feature from `dates`
+  const validateFeatureDates = useCallback(
+    (dateableId, datesObj = dates) => {
+      const dateableFeature = datesObj[dateableId];
+
+      // Track errors for synchronous validation (on submit)
+      let valid = true;
+
+      // If the feature has no dates, skip validation
+      if (
+        dateableFeature.Operation.length === 0 &&
+        dateableFeature.Reservation.length === 0
+      ) {
+        return true;
+      }
+
+      const dateTypeGroups = Object.values(dateableFeature);
+
+      // Clear all errors for this dateable feature:
+      // Build a list of all field IDs to clear from `errors`
+      const fieldIds = dateTypeGroups.flatMap((dateRanges) =>
+        dateRanges.flatMap((dateRange, index) => {
+          const dateRangeId = `${dateRange.dateableId}-${dateRange.dateType.id}-${index}`;
+
+          return [
+            dateRange.dateableId,
+            dateRangeId,
+            `start-date-${dateRangeId}`,
+            `end-date-${dateRangeId}`,
+          ];
+        }),
+      );
+
+      // Remove any errors for this dateable feature before revalidating
+      setErrors((prevErrors) => omit(prevErrors, fieldIds));
+
+      // Validate rules for individual dates and ranges
+      const groupsValid = dateTypeGroups.flatMap((dateRanges) =>
+        // Loop over date ranges for the date type
+        dateRanges.map((dateRange, index) =>
+          validateDateRange({
+            start: dateRange.startDate,
+            startDateId: `start-date-${dateRange.dateableId}-${dateRange.dateType.id}-${index}`,
+            end: dateRange.endDate,
+            endDateId: `end-date-${dateRange.dateableId}-${dateRange.dateType.id}-${index}`,
+            dateRangeId: `${dateRange.dateableId}-${dateRange.dateType.id}-${index}`,
+          }),
+        ),
+      );
+
+      // If any date range is invalid, the entire feature is invalid
+      if (groupsValid.some((test) => !test)) {
+        valid = false;
+      }
+
+      // Validate rules rules that involve the entire feature
+
+      // Check if the reservation dates are all within the operating dates
+      if (!validateReservationDates(dateableFeature)) {
+        valid = false;
+        addError(
+          dateableId,
+          "Enter reservation dates that fall within the operating dates selected.",
+        );
+      }
+
+      // Get the extent of dates for each type
+      const dateExtents = getDateExtents(datesObj);
+      const operationExtent = dateExtents[dateableId].Operation;
+      const reservationExtent = dateExtents[dateableId].Reservation;
+
+      if (operationExtent.maxDate && reservationExtent.maxDate) {
+        // End date is one or more days after reservation end date
+        const daysBetween = differenceInCalendarDays(
+          operationExtent.maxDate,
+          reservationExtent.maxDate,
+        );
+
+        // The "within range" checks earlier will ensure that the operation end date
+        // is after the reservation end date, so we only need to check the number of days between the them
+
+        if (daysBetween < 1) {
+          valid = false;
+          addError(
+            dateableId,
+            "Reservation end date must be one or more days before the operating end date.",
+          );
+        }
+      }
+
+      return valid;
+    },
+    [dates, getDateExtents, validateDateRange, validateReservationDates],
+  );
+
+  // Validates the entire form
+  const validateForm = useCallback(() => {
     // Clear errors from previous validation
     setErrors({});
 
     // Validate notes
-    if (!validateNotes()) return false;
+    validateNotes();
 
     // Validate all dates:
     // Loop over dateable features from `dates` (campsite groupings)
     const dateableIds = Object.keys(dates);
-    const validDates = dateableIds.every((dateableId) =>
+
+    const validationResults = dateableIds.map((dateableId) =>
       validateFeatureDates(dateableId),
     );
 
-    // @TODO: Scroll the first error into view
+    // Return true if all features passed validation
+    return validationResults.every((result) => result);
+  }, [validateNotes, dates, validateFeatureDates]);
 
-    return validDates;
-  }
+  // Validate the form when the dates change
+  useEffect(() => {
+    // Skip validation until the dates have loaded
+    if (dates.pending) return;
 
-  // Validates a dateable feature after a date range has been updated
-  function onUpdateDateRange({
-    dateRange,
-    // Allow overriding dates during state updates
-    datesObj = dates,
-  }) {
-    // Don't validate until the form has been submitted
-    if (!formSubmitted) return true;
+    validateForm();
+  }, [notes, dates, validateForm, formSubmitted]);
 
-    const { dateableId } = dateRange;
-
-    // Validate the whole campsite grouping feature
-    // to resolve any inter-dependent date range validations.
-    return validateFeatureDates(dateableId, datesObj);
-  }
+  const isValid = useMemo(() => Object.keys(errors).length === 0, [errors]);
 
   // Export a special non-fatal error for handling validation errors
   class ValidationError extends Error {}
@@ -298,7 +330,6 @@ export default function useValidation(dates, notes, season) {
     errors,
     setErrors,
     formSubmitted,
-    setFormSubmitted,
     addError,
     clearError,
     checkWithinRange,
@@ -307,7 +338,7 @@ export default function useValidation(dates, notes, season) {
     validateDateRange,
     validateFeatureDates,
     validateForm,
-    onUpdateDateRange,
     ValidationError,
+    isValid,
   };
 }

--- a/frontend/src/hooks/useValidation.js
+++ b/frontend/src/hooks/useValidation.js
@@ -107,14 +107,17 @@ export default function useValidation(dates, notes, season) {
     (value = notes) => {
       clearError("notes");
 
-      if (!season?.status) return;
+      if (!formSubmitted.current || !season?.status) return true;
 
       if (!value && ["approved", "on API"].includes(season.status)) {
         addError(
           "notes",
           "The dates you are editing have already been Approved or Published. Please provide a note explaining the reason for this update.",
         );
+        return false;
       }
+
+      return true;
     },
     [notes, season],
   );
@@ -299,7 +302,7 @@ export default function useValidation(dates, notes, season) {
     setErrors({});
 
     // Validate notes
-    validateNotes();
+    const notesValid = validateNotes();
 
     // Validate all dates:
     // Loop over dateable features from `dates` (campsite groupings)
@@ -310,7 +313,7 @@ export default function useValidation(dates, notes, season) {
     );
 
     // Return true if all features passed validation
-    return validationResults.every((result) => result);
+    return notesValid && validationResults.every((result) => result);
   }, [validateNotes, dates, validateFeatureDates]);
 
   // Validate the form when the dates change

--- a/frontend/src/hooks/useValidation.js
+++ b/frontend/src/hooks/useValidation.js
@@ -316,7 +316,7 @@ export default function useValidation(dates, notes, season) {
   // Validate the form when the dates change
   useEffect(() => {
     // Skip validation until the dates have loaded
-    if (dates.pending) return;
+    if (!dates) return;
 
     validateForm();
   }, [notes, dates, validateForm, formSubmitted]);

--- a/frontend/src/router/pages/SubmitDates.jsx
+++ b/frontend/src/router/pages/SubmitDates.jsx
@@ -111,9 +111,9 @@ function SubmitDates() {
         dateType.Operation?.concat(dateType.Reservation).every(
           (dateRange) => dateRange.startDate && dateRange.endDate,
         ),
-      ) && season?.status === "requested",
-    [dates, season],
-  );
+      ) && season?.status === "requested"
+    );
+  }, [dates, season]);
 
   async function saveChanges(savingDraft) {
     formSubmitted.current = true;

--- a/frontend/src/router/pages/SubmitDates.jsx
+++ b/frontend/src/router/pages/SubmitDates.jsx
@@ -42,7 +42,7 @@ function SubmitDates() {
   const { parkId, seasonId } = useParams();
 
   const [season, setSeason] = useState(null);
-  const [dates, setDates] = useState({ pending: true });
+  const [dates, setDates] = useState(null);
   const [notes, setNotes] = useState("");
   const [readyToPublish, setReadyToPublish] = useState(false);
   // Track deleted date ranges
@@ -80,6 +80,8 @@ function SubmitDates() {
 
   // Returns true if there are any form changes to save
   function hasChanges() {
+    if (!dates) return false;
+
     // Any existing dates changed
     if (
       Object.values(dates).some((dateType) =>
@@ -101,8 +103,10 @@ function SubmitDates() {
     return notes;
   }
 
-  const continueToPreviewEnabled = useMemo(
-    () =>
+  const continueToPreviewEnabled = useMemo(() => {
+    if (!dates) return false;
+
+    return (
       Object.values(dates).every((dateType) =>
         dateType.Operation?.concat(dateType.Reservation).every(
           (dateRange) => dateRange.startDate && dateRange.endDate,

--- a/frontend/src/router/pages/SubmitDates.jsx
+++ b/frontend/src/router/pages/SubmitDates.jsx
@@ -195,6 +195,10 @@ function SubmitDates() {
 
   async function continueToPreview() {
     try {
+      if (!validateForm()) {
+        throw new ValidationError("Form validation failed");
+      }
+
       if (hasChanges()) {
         const submitOk = await submitChanges();
 

--- a/frontend/src/router/pages/SubmitDates.jsx
+++ b/frontend/src/router/pages/SubmitDates.jsx
@@ -119,7 +119,7 @@ function SubmitDates() {
     formSubmitted.current = true;
 
     // Validate form state before saving
-    if (!validateForm()) {
+    if (!savingDraft && !validateForm()) {
       throw new ValidationError("Form validation failed");
     }
 

--- a/frontend/src/router/pages/SubmitDates.jsx
+++ b/frontend/src/router/pages/SubmitDates.jsx
@@ -316,14 +316,7 @@ function SubmitDates() {
     }
   }
 
-  function updateDateRange(
-    dateableId,
-    dateType,
-    index,
-    key,
-    value,
-    callback = null,
-  ) {
+  function updateDateRange(dateableId, dateType, index, key, value) {
     let newValue = null;
 
     if (value) {
@@ -338,10 +331,6 @@ function SubmitDates() {
       // Update the date value and mark the date range as changed
       lodashSet(updatedDates, [dateableId, dateType, index, key], newValue);
       lodashSet(updatedDates, [dateableId, dateType, index, "changed"], true);
-
-      if (callback) {
-        callback(updatedDates);
-      }
 
       return updatedDates;
     });
@@ -453,8 +442,6 @@ function SubmitDates() {
         index,
         dateField,
         date,
-        // Callback to validate the new value
-        validateForm,
       );
     }
 

--- a/frontend/src/router/pages/SubmitWinterFeesDates.jsx
+++ b/frontend/src/router/pages/SubmitWinterFeesDates.jsx
@@ -560,15 +560,17 @@ export default function SubmitWinterFeesDates() {
     }
   }
 
-  const continueToPreviewEnabled = useMemo(
-    () =>
+  const continueToPreviewEnabled = useMemo(() => {
+    if (!dates) return false;
+
+    return (
       Object.values(dates).every((dateRanges) =>
         dateRanges.every(
           (dateRange) => dateRange.startDate && dateRange.endDate,
         ),
-      ) && season?.status === "requested",
-    [dates, season],
-  );
+      ) && season?.status === "requested"
+    );
+  }, [dates, season]);
 
   async function continueToPreview() {
     try {

--- a/frontend/src/router/pages/SubmitWinterFeesDates.jsx
+++ b/frontend/src/router/pages/SubmitWinterFeesDates.jsx
@@ -6,9 +6,9 @@ import cloneDeep from "lodash/cloneDeep";
 import omit from "lodash/omit";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
-  faCircleInfo,
-  faTriangleExclamation,
   faCalendarCheck,
+  faCircleInfo,
+  faHexagonExclamation,
   faPlus,
   faXmark,
 } from "@fa-kit/icons/classic/regular";
@@ -95,12 +95,7 @@ function DateRange({
       dateField,
       date,
       // @TODO: Callback to validate the new value
-      // (updatedDates) => {
-      //   onUpdateDateRange({
-      //     dateRange,
-      //     datesObj: updatedDates,
-      //   });
-      // },
+      // validateForm
     );
   }
 
@@ -172,7 +167,7 @@ function DateRange({
           {/* Show validation errors for the startDate field */}
           {errors[startDateId] && (
             <div className="error-message mt-2">
-              <FontAwesomeIcon icon={faTriangleExclamation} />
+              <FontAwesomeIcon icon={faHexagonExclamation} />
               <div>{errors[startDateId]}</div>
             </div>
           )}
@@ -227,7 +222,7 @@ function DateRange({
           {/* Show validation errors for the endDate field */}
           {errors[endDateId] && (
             <div className="error-message mt-2">
-              <FontAwesomeIcon icon={faTriangleExclamation} />
+              <FontAwesomeIcon icon={faHexagonExclamation} />
               <div>{errors[endDateId]}</div>
             </div>
           )}
@@ -251,7 +246,7 @@ function DateRange({
       {/* Show validation errors for the date range */}
       {errors[dateRangeId] && (
         <div className="error-message mt-2">
-          <FontAwesomeIcon icon={faTriangleExclamation} />
+          <FontAwesomeIcon icon={faHexagonExclamation} />
           <div>{errors[dateRangeId]}</div>
         </div>
       )}
@@ -739,7 +734,7 @@ export default function SubmitWinterFeesDates() {
 
               {errors.notes && (
                 <div className="error-message mt-2">
-                  <FontAwesomeIcon icon={faTriangleExclamation} />
+                  <FontAwesomeIcon icon={faHexagonExclamation} />
                   <div>{errors.notes}</div>
                 </div>
               )}

--- a/frontend/src/router/pages/SubmitWinterFeesDates.jsx
+++ b/frontend/src/router/pages/SubmitWinterFeesDates.jsx
@@ -90,13 +90,7 @@ function DateRange({
    * @returns {void}
    */
   function onSelect(dateField, date) {
-    updateDateRange(
-      index,
-      dateField,
-      date,
-      // @TODO: Callback to validate the new value
-      // validateForm
-    );
+    updateDateRange(index, dateField, date);
   }
 
   // Use an index based on the dateableId and index,
@@ -321,7 +315,7 @@ function CampgroundFeature({ featureData }) {
    * @param {Function} [callback] validation callback to run after updating the date
    * @returns {void}
    */
-  function updateDateRange(index, key, value, callback = null) {
+  function updateDateRange(index, key, value) {
     let newValue = null;
 
     if (value) {
@@ -336,10 +330,6 @@ function CampgroundFeature({ featureData }) {
       // Update the date value and mark the date range as changed
       updatedDates[dateableId][index][key] = newValue;
       updatedDates[dateableId][index].changed = true;
-
-      if (callback) {
-        callback(updatedDates);
-      }
 
       return updatedDates;
     });

--- a/frontend/src/router/pages/SubmitWinterFeesDates.jsx
+++ b/frontend/src/router/pages/SubmitWinterFeesDates.jsx
@@ -312,7 +312,6 @@ function CampgroundFeature({ featureData }) {
    * @param {number} index the index of the date range in `dates[dateableId]`
    * @param {string} key key in the DateRange object to update (startDate or endDate)
    * @param {string} value new date value as a UTC ISO string
-   * @param {Function} [callback] validation callback to run after updating the date
    * @returns {void}
    */
   function updateDateRange(index, key, value) {

--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -134,6 +134,24 @@ a:not(.btn):focus {
   border-color: var(--surface-color-border-active);
 }
 
+// custom style for validation error alert
+.alert-validation-error {
+  display: flex;
+  gap: 0.5em;
+  color: var(--typography-color-primary);
+
+  .icon {
+    color: var(--icons-color-danger);
+  }
+}
+
+// override bootstrap invalid form control styles
+.was-validated .form-control:invalid,
+.form-control.is-invalid {
+  // don't show the circle icon; we'll append a FontAwesomeIcon
+  background-image: none;
+}
+
 // override bootstrap theme styles: don't shrink radio/checkbox labels
 label.form-check-label {
   font-size: var(--typography-font-size-body) !important;


### PR DESCRIPTION
### Jira Ticket

CMS-756

### Description
<!-- What did you change, and why? -->

Previously, we waited until the form was submitted before running validation, and we only showed one error at a time.

Now, we check all validation at all times, and show all the errors at once. Except the "Enter a start/end date" messages, which are bypassed until you try to submit the form.

To accomplish this:
- Run `validateForm` on every input in a `useEffect` (and use `useCallback` with all of the related functions so it works). I moved the other functions outside of the `useValidation` hook to keep them separate.
- Got rid of the specific `onUpdateDateRange` callback because `validateForm` runs on every change now.
- Instead of returning on the first error, check everything and keep track of the overall valid state with a boolean. Pass it up to `validateForm` so it can return true or false to prevent form submission like before.

Basically anything that was returning early is now checking all the fields, and then deciding if the form is valid or not by looking at the combined results.

We also changed the validation error icons in the fields and the red messages that appear. Restored some styles we previously deleted to show a message right above the submit buttons when submission is prevented by validation.