### PR TITLE
CMS-760: Order date ranges by start date

### DIFF
--- a/backend/routes/api/seasons.js
+++ b/backend/routes/api/seasons.js
@@ -178,6 +178,11 @@ router.get(
       feature.dateable.currentSeasonDates = [];
       feature.dateable.previousSeasonDates = [];
 
+      feature.dateable.dateRanges = _.orderBy(
+        feature.dateable.dateRanges,
+        "startDate",
+      );
+
       feature.dateable.dateRanges.forEach((dateRange) => {
         if (dateRange.seasonId === season.id) {
           feature.dateable.currentSeasonDates.push(dateRange);

--- a/backend/routes/api/winter-seasons.js
+++ b/backend/routes/api/winter-seasons.js
@@ -171,7 +171,9 @@ router.get(
       };
 
       // group dateRanges by operatingYear and type
-      feature.dateable.dateRanges.forEach((dateRange) => {
+      const sortedDates = _.orderBy(feature.dateable.dateRanges, "startDate");
+
+      sortedDates.forEach((dateRange) => {
         const dateRangeItem = {
           id: dateRange.id,
           startDate: dateRange.startDate,


### PR DESCRIPTION
### Jira Ticket

CMS-760

### Description
<!-- What did you change, and why? -->

A small tweak to order the dates by the start date in the API. I posted an example in the ticket, but basically If you have these dates: 
<img width="561" alt="image" src="https://github.com/user-attachments/assets/aafee665-636d-4c9b-bfd9-fe25ed907372" />
if you change "Jan 8" to "Jan 1", I'd expect that date to be listed first when you save dates and reload the page. Only when you re-fetch the data, and doesn't sort any of the dates you change on the fly.

A small change in the season endpoints should affect anywhere dates are listed in the frontend. The CSV export is already sorted like this (sorted by feature, then startDate)