### PR TITLE
CMS-779: Update logic of how winter dates are created

### DIFF
--- a/backend/strapi-sync/create-missing-dates-and-seasons.js
+++ b/backend/strapi-sync/create-missing-dates-and-seasons.js
@@ -7,54 +7,69 @@ import {
   DateRange,
 } from "../models/index.js";
 import { createModel } from "./utils.js";
+import { Op } from "sequelize";
 
 export async function createMissingDatesAndSeasons() {
-  const [seasons2025, dateTypes, winterFeatureType, features] =
-    await Promise.all([
-      Season.findAll({
-        where: { operatingYear: 2025 },
-        attributes: ["id", "operatingYear", "parkId", "featureTypeId"],
-      }),
-      DateType.findAll(),
-      FeatureType.findOne({
-        attributes: ["id", "name"],
-        where: { name: "Winter fee" },
-      }),
-      Feature.findAll({
-        attributes: [
-          "id",
-          "name",
-          "strapiId",
-          "parkId",
-          "featureTypeId",
-          "hasReservations",
-          "hasWinterFeeDates",
-        ],
-        include: [
-          {
-            model: Dateable,
-            as: "dateable",
-            attributes: ["id"],
-            include: [
-              {
-                model: DateRange,
-                as: "dateRanges",
-                attributes: [
-                  "id",
-                  "startDate",
-                  "endDate",
-                  "seasonId",
-                  "dateTypeId",
-                ],
-              },
-            ],
-          },
-        ],
-        where: {
-          active: true,
+  const [seasons, dateTypes, winterFeatureType, features] = await Promise.all([
+    // get all seasons for 2025 and 2024
+    Season.findAll({
+      attributes: ["id", "operatingYear", "parkId", "featureTypeId"],
+      where: {
+        operatingYear: {
+          [Op.in]: [2024, 2025],
         },
-      }),
-    ]);
+      },
+    }),
+    DateType.findAll(),
+    FeatureType.findOne({
+      attributes: ["id", "name"],
+      where: { name: "Winter fee" },
+    }),
+    Feature.findAll({
+      attributes: [
+        "id",
+        "name",
+        "strapiId",
+        "parkId",
+        "featureTypeId",
+        "hasReservations",
+        "hasWinterFeeDates",
+      ],
+      include: [
+        {
+          model: Dateable,
+          as: "dateable",
+          attributes: ["id"],
+          include: [
+            {
+              model: DateRange,
+              as: "dateRanges",
+              attributes: [
+                "id",
+                "startDate",
+                "endDate",
+                "seasonId",
+                "dateTypeId",
+              ],
+            },
+          ],
+        },
+      ],
+      where: {
+        active: true,
+      },
+    }),
+  ]);
+
+  const seasons2024 = seasons.filter((season) => season.operatingYear === 2024);
+  const seasons2025 = seasons.filter((season) => season.operatingYear === 2025);
+
+  const seasonMap2024 = new Map(
+    seasons2024.map((season) => [
+      `${season.parkId}-${season.featureTypeId}`,
+      season,
+    ]),
+  );
 
   const seasonMap = new Map(
     seasons2025.map((season) => [
@@ -89,62 +104,76 @@ export async function createMissingDatesAndSeasons() {
   }
 
   for (const feature of features) {
-    const season = await getOrCreateSeason(
-      feature.parkId,
-      feature.featureTypeId,
-    );
+    const key = `${feature.parkId}-${feature.featureTypeId}`;
 
-    // existing dates for this feature-season
-    const existingDateTypes = new Set(
-      feature.dateable.dateRanges
-        .filter((dateRange) => dateRange.seasonId === season.id)
-        .map((dateRange) => dateRange.dateTypeId),
-    );
+    // get 2024 season
+    const season2024 = seasonMap2024.get(key);
 
-    // add missing operation dates
-    if (!existingDateTypes.has(dateTypeMap.get("Operation")?.id)) {
-      datesToCreate.push({
-        startDate: null,
-        endDate: null,
-        dateTypeId: dateTypeMap.get("Operation").id,
-        dateableId: feature.dateable.id,
-        seasonId: season.id,
-      });
-    }
+    if (season2024) {
+      const season = await getOrCreateSeason(
+        feature.parkId,
+        feature.featureTypeId,
+      );
 
-    // add missing reservation dates
-    if (
-      feature.hasReservations &&
-      !existingDateTypes.has(dateTypeMap.get("Reservation")?.id)
-    ) {
-      datesToCreate.push({
-        startDate: null,
-        endDate: null,
-        dateTypeId: dateTypeMap.get("Reservation").id,
-        dateableId: feature.dateable.id,
-        seasonId: season.id,
-      });
+      // existing dates for this feature-season
+      const existingDateTypes = new Set(
+        feature.dateable.dateRanges
+          .filter((dateRange) => dateRange.seasonId === season.id)
+          .map((dateRange) => dateRange.dateTypeId),
+      );
+
+      // add missing operation dates
+      if (!existingDateTypes.has(dateTypeMap.get("Operation")?.id)) {
+        datesToCreate.push({
+          startDate: null,
+          endDate: null,
+          dateTypeId: dateTypeMap.get("Operation").id,
+          dateableId: feature.dateable.id,
+          seasonId: season.id,
+        });
+      }
+
+      // add missing reservation dates
+      if (
+        feature.hasReservations &&
+        !existingDateTypes.has(dateTypeMap.get("Reservation")?.id)
+      ) {
+        datesToCreate.push({
+          startDate: null,
+          endDate: null,
+          dateTypeId: dateTypeMap.get("Reservation").id,
+          dateableId: feature.dateable.id,
+          seasonId: season.id,
+        });
+      }
     }
 
     // add winter fee seasons
     if (feature.hasWinterFeeDates) {
-      const winterSeason = await getOrCreateSeason(
-        feature.parkId,
-        winterFeatureType.id,
-      );
+      const winterKey = `${feature.parkId}-${winterFeatureType.id}`;
 
-      const existingWinterDates = feature.dateable.dateRanges.filter(
-        (dateRange) => dateRange.seasonId === winterSeason.id,
-      );
+      // get 2024 winter season
+      const winterSeason2024 = seasonMap2024.get(winterKey);
 
-      if (existingWinterDates.length === 0) {
-        datesToCreate.push({
-          startDate: null,
-          endDate: null,
-          dateTypeId: dateTypeMap.get("Winter fee").id,
-          dateableId: feature.dateable.id,
-          seasonId: winterSeason.id,
-        });
+      if (winterSeason2024) {
+        const winterSeason = await getOrCreateSeason(
+          feature.parkId,
+          winterFeatureType.id,
+        );
+
+        const existingWinterDates = feature.dateable.dateRanges.filter(
+          (dateRange) => dateRange.seasonId === winterSeason.id,
+        );
+
+        if (existingWinterDates.length === 0) {
+          datesToCreate.push({
+            startDate: null,
+            endDate: null,
+            dateTypeId: dateTypeMap.get("Winter fee").id,
+            dateableId: feature.dateable.id,
+            seasonId: winterSeason.id,
+          });
+        }
       }
     }
   }

--- a/backend/strapi-sync/park-winter-dates.js
+++ b/backend/strapi-sync/park-winter-dates.js
@@ -1,0 +1,206 @@
+export default {
+  117: {
+    name: "Bamberton Park",
+    features: [],
+    2024: {
+      janApril: { start: "2024-01-01", end: "2024-03-31" },
+      octDec: { start: "2024-11-01", end: "2024-12-31" },
+    },
+    2023: {
+      janApril: { start: "2023-01-01", end: "2023-03-31" },
+      octDec: { start: "2023-11-01", end: "20243-12-31" },
+    },
+  },
+  6161: {
+    name: "Cowichan River Park",
+    features: [],
+    2024: {
+      janApril: { start: "2024-01-01", end: "2024-03-31" },
+      octDec: { start: "2024-11-01", end: "2024-12-31" },
+    },
+    2023: {
+      janApril: { start: "2023-01-01", end: "2023-03-31" },
+      octDec: { start: "2023-11-01", end: "2023-12-31" },
+    },
+  },
+  41: {
+    name: "Cultus Lake Park",
+    features: [],
+    2024: {
+      janApril: { start: "2024-01-01", end: "2024-03-27" },
+      octDec: { start: "2024-11-16", end: "2024-12-31" },
+    },
+    2023: {
+      janApril: { start: "2023-01-01", end: "2023-03-30" },
+      octDec: { start: "2023-10-15", end: "2023-12-31" },
+    },
+  },
+  28: {
+    name: "Elk Falls Park",
+    features: [],
+    2024: {
+      janApril: { start: "2024-01-01", end: "2024-03-14" },
+      octDec: { start: "2024-11-01", end: "2024-12-31" },
+    },
+    2023: {
+      janApril: { start: "2023-01-01", end: "2023-03-23" },
+      octDec: { start: "2023-10-29", end: "2023-12-31" },
+    },
+  },
+  48: {
+    name: "Fillongley Park",
+    features: [],
+    2024: {
+      janApril: { start: "2024-01-01", end: "2024-03-14" },
+      octDec: { start: "2024-11-01", end: "2024-12-31" },
+    },
+    2023: {
+      janApril: { start: "2023-01-01", end: "2023-03-23" },
+      octDec: { start: "2023-10-29", end: "2023-12-31" },
+    },
+  },
+  262: {
+    name: "French Beach Park",
+    features: [],
+    2024: {
+      janApril: { start: "2024-01-01", end: "2024-03-14" },
+      octDec: { start: "2024-10-29", end: "2024-12-31" },
+    },
+    2023: {
+      janApril: { start: "2023-01-01", end: "2023-03-10" },
+      octDec: { start: "2023-10-30", end: "2023-12-31" },
+    },
+  },
+  96: {
+    name: "Goldstream Park",
+    features: [],
+    2024: {
+      janApril: { start: "2024-01-01", end: "2024-03-14" },
+      octDec: { start: "2024-10-29", end: "2024-12-31" },
+    },
+    2023: {
+      janApril: { start: "2023-01-01", end: "2023-03-10" },
+      octDec: { start: "2023-10-30", end: "2023-12-31" },
+    },
+  },
+  8: {
+    name: "Golden Ears Park",
+    features: [],
+    2024: {
+      janApril: { start: "2024-01-01", end: "2024-03-27" },
+      octDec: { start: "2024-10-15", end: "2024-12-31" },
+    },
+    2023: {
+      janApril: { start: "2023-01-01", end: "2023-03-29" },
+      octDec: { start: "2023-10-16", end: "2023-12-31" },
+    },
+  },
+  210: {
+    name: "Gordon Bay Park",
+    features: [],
+    2024: {
+      janApril: { start: "2024-01-01", end: "2024-03-31" },
+      octDec: { start: "2024-11-01", end: "2024-12-31" },
+    },
+    2023: {
+      janApril: { start: "2023-01-01", end: "2023-03-31" },
+      octDec: { start: "2023-11-01", end: "2023-12-31" },
+    },
+  },
+  45: {
+    name: "Miracle Beach Park",
+    features: [],
+    2024: {
+      janApril: { start: "2024-03-01", end: "2024-03-14" },
+      octDec: { start: "2024-11-01", end: "2024-11-30" },
+    },
+    2023: {
+      janApril: { start: "2023-03-01", end: "2023-03-23" },
+      octDec: { start: "2023-10-29", end: "2023-11-30" },
+    },
+  },
+  104: {
+    name: "Montague Harbour Marine Park",
+    features: [],
+    2024: {
+      janApril: { start: "2024-01-01", end: "2024-03-14" },
+      octDec: { start: "2024-11-01", end: "2024-12-31" },
+    },
+    2023: {
+      janApril: { start: "2023-01-01", end: "2023-03-14" },
+      octDec: { start: "2023-11-01", end: "2023-12-31" },
+    },
+  },
+  190: {
+    name: "Morton Lake Park",
+    features: [],
+    2024: {
+      janApril: { start: "2024-03-01", end: "2024-04-24" },
+      octDec: { start: "2024-10-15", end: "2024-12-31" },
+    },
+    2023: {
+      janApril: { start: "2023-03-01", end: "2023-04-24" },
+      octDec: { start: "2023-10-15", end: "2023-12-31" },
+    },
+  },
+  314: {
+    name: "Porteau Cove Park",
+    features: [],
+    2024: {
+      janApril: { start: "2024-01-01", end: "2024-03-01" },
+      octDec: { start: "2024-11-11", end: "2024-12-31" },
+    },
+    2023: {
+      janApril: { start: "2023-01-01", end: "2023-02-28" },
+      octDec: { start: "2023-11-12", end: "2023-12-31" },
+    },
+  },
+  193: {
+    name: "Rathtrevor Beach Park",
+    features: [],
+    2024: {
+      janApril: { start: "2024-01-01", end: "2024-03-14" },
+      octDec: { start: "2024-10-29", end: "2024-12-31" },
+    },
+    2023: {
+      janApril: { start: "2023-01-01", end: "2023-03-10" },
+      octDec: { start: "2023-10-30", end: "2023-12-31" },
+    },
+  },
+  122: {
+    name: "Rolley Lake Park",
+    features: [],
+    2024: {
+      janApril: { start: "2024-01-01", end: "2024-03-27" },
+      octDec: { start: "2024-10-15", end: "2024-12-31" },
+    },
+    2023: {
+      janApril: { start: "2023-01-01", end: "2023-03-29" },
+      octDec: { start: "2023-10-16", end: "2023-12-31" },
+    },
+  },
+  267: {
+    name: "Ruckle Park",
+    features: [],
+    2024: {
+      janApril: { start: "2024-01-01", end: "2024-03-14" },
+      octDec: { start: "2024-11-01", end: "2024-12-31" },
+    },
+    2023: {
+      janApril: { start: "2023-01-01", end: "2023-03-14" },
+      octDec: { start: "2023-11-01", end: "2023-12-31" },
+    },
+  },
+  92: {
+    name: "Liard River Hot Springs Park",
+    features: [],
+    2024: {
+      janApril: { start: "2024-01-01", end: "2024-03-31" },
+      octDec: { start: "2024-10-15", end: "2024-12-31" },
+    },
+    2023: {
+      janApril: { start: "2023-01-01", end: "2023-03-31" },
+      octDec: { start: "2023-10-10", end: "2023-12-31" },
+    },
+  },
+};

--- a/backend/strapi-sync/sync.js
+++ b/backend/strapi-sync/sync.js
@@ -606,7 +606,7 @@ export async function createDatesAndSeasons(datesData) {
     // for each featureId in the season we create one date range using its dateableId
     const featureIDList = Array.from(featureIds);
 
-    Promise.all(
+    await Promise.all(
       featureIDList.map(async (featureId) => {
         const feature = await getItemByAttributes(Feature, {
           strapiId: featureId,


### PR DESCRIPTION
### Jira Ticket

CMS-779

### Description
The logic for creating winter seasons is different than regular seasons. This ticket will update how winter seasons are created.

Past winter seasons

Winter fee dates apply only to certain parks, so winter seasons are created only when all the following conditions are met:

The feature (subarea) belongs to one of the parks in this list (refer to the [spreadsheet](https://docs.google.com/spreadsheets/d/13k7wJjgaJBSiOreyyQQTIZxc_DCNZ1bD/edit?gid=646395629#gid=646395629)).
The feature type is Frontcountry campground.
The feature's operation dates overlap with the park-wide winter fee dates for that year.
When these conditions are met, a winter fee season is created for all applicable features in each qualifying year. For each season, we try to include any existing offSeasonDates from Strapi.

Upcoming winter fee seasons (2025-2026)

We use the same criteria to determine whether to request winter fee dates for 2025-2026. If a feature had winter fee dates in the previous season, a new season for 2025-2026 will be created with empty dates, allowing users the option to add winter fee dates for the current season.
