### PR TITLE
CMS-799: Fix saving from preview page

### DIFF
--- a/backend/routes/api/seasons.js
+++ b/backend/routes/api/seasons.js
@@ -240,7 +240,7 @@ router.post(
   "/:seasonId/save/",
   asyncHandler(async (req, res) => {
     const seasonId = Number(req.params.seasonId);
-    const { notes, dates, readyToPublish, deletedDateRangeIds } = req.body;
+    const { notes, dates, readyToPublish, deletedDateRangeIds = [] } = req.body;
 
     // when we add roles: we need to check that this user has permission to edit this season
     // staff or operator that has access to this park

--- a/frontend/src/router/pages/PreviewChanges.jsx
+++ b/frontend/src/router/pages/PreviewChanges.jsx
@@ -111,6 +111,7 @@ function PreviewChanges() {
         notes,
         dates: [],
         readyToPublish,
+        deletedDateRangeIds: [],
       });
 
       navigate(`${paths.park(parkId)}?saved=${data.id}`);

--- a/frontend/src/router/pages/PreviewWinterFeesChanges.jsx
+++ b/frontend/src/router/pages/PreviewWinterFeesChanges.jsx
@@ -94,6 +94,7 @@ function PreviewChanges() {
         notes,
         dates: [],
         readyToPublish,
+        deletedDateRangeIds: [],
       });
 
       navigate(`${paths.park(parkId)}?saved=${data.id}`);


### PR DESCRIPTION
### Jira Ticket

CMS-799

### Description
<!-- What did you change, and why? -->

I just noticed this recently: the preview pages weren't including the `deletedDateRangeIds` in the payload, so the query broke trying to get IDs from `undefined`. This ticket updates the frontend to always send arrays, and also makes the parameter optional in the backend.