### PR TITLE
CMS-763: Move submit buttons outside of row container

### DIFF
--- a/frontend/src/router/pages/PreviewChanges.jsx
+++ b/frontend/src/router/pages/PreviewChanges.jsx
@@ -430,40 +430,36 @@ function PreviewChanges() {
               readyToPublish={readyToPublish}
               setReadyToPublish={setReadyToPublish}
             />
-
-            <div className="controls d-flex flex-column flex-sm-row gap-2">
-              <Link
-                to={paths.seasonEdit(parkId, seasonId)}
-                type="button"
-                className="btn btn-outline-primary"
-              >
-                Back
-              </Link>
-
-              <button
-                type="button"
-                className="btn btn-outline-primary"
-                onClick={savePreview}
-              >
-                Save draft
-              </button>
-
-              <button
-                type="button"
-                className="btn btn-primary"
-                onClick={approve}
-              >
-                Mark approved
-              </button>
-
-              {(saving || savingApproval) && (
-                <span
-                  className="spinner-border text-primary align-self-center me-2"
-                  aria-hidden="true"
-                ></span>
-              )}
-            </div>
           </div>
+        </div>
+
+        <div className="controls d-flex flex-column flex-sm-row gap-2">
+          <Link
+            to={paths.seasonEdit(parkId, seasonId)}
+            type="button"
+            className="btn btn-outline-primary"
+          >
+            Back
+          </Link>
+
+          <button
+            type="button"
+            className="btn btn-outline-primary"
+            onClick={savePreview}
+          >
+            Save draft
+          </button>
+
+          <button type="button" className="btn btn-primary" onClick={approve}>
+            Mark approved
+          </button>
+
+          {(saving || savingApproval) && (
+            <span
+              className="spinner-border text-primary align-self-center me-2"
+              aria-hidden="true"
+            ></span>
+          )}
         </div>
       </div>
     </div>

--- a/frontend/src/router/pages/PreviewWinterFeesChanges.jsx
+++ b/frontend/src/router/pages/PreviewWinterFeesChanges.jsx
@@ -319,40 +319,36 @@ function PreviewChanges() {
               readyToPublish={readyToPublish}
               setReadyToPublish={setReadyToPublish}
             />
-
-            <div className="controls d-flex flex-column flex-sm-row gap-2">
-              <Link
-                to={paths.winterFeesEdit(parkId, seasonId)}
-                type="button"
-                className="btn btn-outline-primary"
-              >
-                Back
-              </Link>
-
-              <button
-                type="button"
-                className="btn btn-outline-primary"
-                onClick={savePreview}
-              >
-                Save draft
-              </button>
-
-              <button
-                type="button"
-                className="btn btn-primary"
-                onClick={approve}
-              >
-                Mark approved
-              </button>
-
-              {(saving || savingApproval) && (
-                <span
-                  className="spinner-border text-primary align-self-center me-2"
-                  aria-hidden="true"
-                ></span>
-              )}
-            </div>
           </div>
+        </div>
+
+        <div className="controls d-flex flex-column flex-sm-row gap-2">
+          <Link
+            to={paths.winterFeesEdit(parkId, seasonId)}
+            type="button"
+            className="btn btn-outline-primary"
+          >
+            Back
+          </Link>
+
+          <button
+            type="button"
+            className="btn btn-outline-primary"
+            onClick={savePreview}
+          >
+            Save draft
+          </button>
+
+          <button type="button" className="btn btn-primary" onClick={approve}>
+            Mark approved
+          </button>
+
+          {(saving || savingApproval) && (
+            <span
+              className="spinner-border text-primary align-self-center me-2"
+              aria-hidden="true"
+            ></span>
+          )}
         </div>
       </div>
     </div>

--- a/frontend/src/router/pages/SubmitDates.jsx
+++ b/frontend/src/router/pages/SubmitDates.jsx
@@ -894,42 +894,42 @@ function SubmitDates() {
                 <div className="content">Please fix errors to continue</div>
               </div>
             )}
-
-            <div className="controls d-flex flex-column flex-sm-row gap-2">
-              <Link
-                to={paths.park(parkId)}
-                type="button"
-                className="btn btn-outline-primary"
-              >
-                Back
-              </Link>
-
-              <button
-                type="button"
-                className="btn btn-outline-primary"
-                onClick={saveAsDraft}
-                disabled={!hasChanges()}
-              >
-                Save draft
-              </button>
-
-              <button
-                type="button"
-                className="btn btn-primary"
-                onClick={continueToPreview}
-                disabled={!hasChanges() && !continueToPreviewEnabled}
-              >
-                Save and continue to preview
-              </button>
-
-              {saving && (
-                <span
-                  className="spinner-border text-primary align-self-center me-2"
-                  aria-hidden="true"
-                ></span>
-              )}
-            </div>
           </div>
+        </div>
+
+        <div className="controls d-flex flex-column flex-sm-row gap-2">
+          <Link
+            to={paths.park(parkId)}
+            type="button"
+            className="btn btn-outline-primary"
+          >
+            Back
+          </Link>
+
+          <button
+            type="button"
+            className="btn btn-outline-primary"
+            onClick={saveAsDraft}
+            disabled={!hasChanges()}
+          >
+            Save draft
+          </button>
+
+          <button
+            type="button"
+            className="btn btn-primary"
+            onClick={continueToPreview}
+            disabled={!hasChanges() && !continueToPreviewEnabled}
+          >
+            Save and continue to preview
+          </button>
+
+          {saving && (
+            <span
+              className="spinner-border text-primary align-self-center me-2"
+              aria-hidden="true"
+            ></span>
+          )}
         </div>
       </div>
     </div>

--- a/frontend/src/router/pages/SubmitWinterFeesDates.jsx
+++ b/frontend/src/router/pages/SubmitWinterFeesDates.jsx
@@ -737,42 +737,42 @@ export default function SubmitWinterFeesDates() {
               readyToPublish={readyToPublish}
               setReadyToPublish={setReadyToPublish}
             />
-
-            <div className="controls d-flex flex-column flex-sm-row gap-2">
-              <Link
-                to={paths.park(parkId)}
-                type="button"
-                className="btn btn-outline-primary"
-              >
-                Back
-              </Link>
-
-              <button
-                type="button"
-                className="btn btn-outline-primary"
-                onClick={saveAsDraft}
-                disabled={!hasChanges()}
-              >
-                Save draft
-              </button>
-
-              <button
-                type="button"
-                className="btn btn-primary"
-                onClick={continueToPreview}
-                disabled={!hasChanges() && !continueToPreviewEnabled}
-              >
-                Save and continue to preview
-              </button>
-
-              {saving && (
-                <span
-                  className="spinner-border text-primary align-self-center me-2"
-                  aria-hidden="true"
-                ></span>
-              )}
-            </div>
           </div>
+        </div>
+
+        <div className="controls d-flex flex-column flex-sm-row gap-2">
+          <Link
+            to={paths.park(parkId)}
+            type="button"
+            className="btn btn-outline-primary"
+          >
+            Back
+          </Link>
+
+          <button
+            type="button"
+            className="btn btn-outline-primary"
+            onClick={saveAsDraft}
+            disabled={!hasChanges()}
+          >
+            Save draft
+          </button>
+
+          <button
+            type="button"
+            className="btn btn-primary"
+            onClick={continueToPreview}
+            disabled={!hasChanges() && !continueToPreviewEnabled}
+          >
+            Save and continue to preview
+          </button>
+
+          {saving && (
+            <span
+              className="spinner-border text-primary align-self-center me-2"
+              aria-hidden="true"
+            ></span>
+          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
### Jira Ticket

CMS-763

### Description
<!-- What did you change, and why? -->

Another quick fix for a more visible bug: this fixes some unwanted text wrapping at certain screen sizes (~1060px wide) when the loading spinner shows next to the submit buttons.

I moved the buttons outside of the 6-column container, since they don't need to have their width constrained.