### PR TITLE
CMS-577: Refactor Edit/Preview, add Review page

### DIFF
--- a/frontend/src/components/ParkDetailsFeatureType.jsx
+++ b/frontend/src/components/ParkDetailsFeatureType.jsx
@@ -30,7 +30,7 @@ FeatureType.propTypes = {
   seasonProps: PropTypes.shape({
     getDataEndpoint: PropTypes.func.isRequired,
     getEditRoutePath: PropTypes.func.isRequired,
-    getPreviewRoutePath: PropTypes.func.isRequired,
+    getReviewRoutePath: PropTypes.func.isRequired,
     getTitle: PropTypes.func.isRequired,
     DetailsComponent: PropTypes.elementType.isRequired,
   }),

--- a/frontend/src/components/ParkDetailsSeason.jsx
+++ b/frontend/src/components/ParkDetailsSeason.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import classNames from "classnames";
 import PropTypes from "prop-types";
@@ -20,7 +20,7 @@ export default function ParkSeason({
   season,
   getDataEndpoint,
   getEditRoutePath,
-  getPreviewRoutePath,
+  getReviewRoutePath,
   getTitle,
   DetailsComponent,
 }) {
@@ -74,10 +74,13 @@ export default function ParkSeason({
   }
 
   // @TODO: implement logic to show/hide preview button
-  const showPreviewButton = true;
+  const showReviewButton = true;
 
   // @TODO: implement logic to disable preview button
-  const disablePreviewButton = true;
+  const disableReviewButton = useMemo(
+    () => season.status !== "pending review",
+    [season.status],
+  );
 
   const updateDate = season.updatedAt
     ? formatDate(season.updatedAt, "America/Vancouver")
@@ -119,8 +122,8 @@ export default function ParkSeason({
     }
   }
 
-  function navigateToPreview() {
-    navigate(getPreviewRoutePath(parkId, season.id));
+  function navigateToReview() {
+    navigate(getReviewRoutePath(parkId, season.id));
   }
 
   return (
@@ -179,14 +182,14 @@ export default function ParkSeason({
           <span>Edit</span>
         </button>
 
-        {showPreviewButton && (
+        {showReviewButton && (
           <>
             <div className="divider"></div>
 
             <button
-              onClick={navigateToPreview}
+              onClick={navigateToReview}
               className="btn btn-text text-primary"
-              disabled={disablePreviewButton}
+              disabled={disableReviewButton}
             >
               <FontAwesomeIcon
                 className="append-content me-2"
@@ -214,7 +217,7 @@ ParkSeason.propTypes = {
 
   getDataEndpoint: PropTypes.func.isRequired,
   getEditRoutePath: PropTypes.func.isRequired,
-  getPreviewRoutePath: PropTypes.func.isRequired,
+  getReviewRoutePath: PropTypes.func.isRequired,
   getTitle: PropTypes.func.isRequired,
   DetailsComponent: PropTypes.elementType.isRequired,
 };

--- a/frontend/src/hooks/useConfirmation.js
+++ b/frontend/src/hooks/useConfirmation.js
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useCallback, useState } from "react";
 
 export function useConfirmation() {
   const [isOpen, setIsOpen] = useState(false);
@@ -9,23 +9,33 @@ export function useConfirmation() {
   const [cancelButtonText, setCancelButtonText] = useState("");
   const [resolvePromise, setResolvePromise] = useState(null);
 
-  function openConfirmation(
-    confirmationTitle,
-    confirmationMessage,
-    confirmText = "Confirm",
-    cancelText = "Cancel",
-    notesParam = "",
-  ) {
-    return new Promise((resolve) => {
-      setTitle(confirmationTitle);
-      setMessage(confirmationMessage);
-      setNotes(notesParam);
-      setConfirmButtonText(confirmText);
-      setCancelButtonText(cancelText);
-      setResolvePromise(() => resolve); // Store the resolve function
-      setIsOpen(true);
-    });
-  }
+  const openConfirmation = useCallback(
+    (
+      confirmationTitle,
+      confirmationMessage,
+      confirmText = "Confirm",
+      cancelText = "Cancel",
+      notesParam = "",
+    ) =>
+      new Promise((resolve) => {
+        setTitle(confirmationTitle);
+        setMessage(confirmationMessage);
+        setNotes(notesParam);
+        setConfirmButtonText(confirmText);
+        setCancelButtonText(cancelText);
+        setResolvePromise(() => resolve); // Store the resolve function
+        setIsOpen(true);
+      }),
+    [
+      setTitle,
+      setMessage,
+      setNotes,
+      setConfirmButtonText,
+      setCancelButtonText,
+      setResolvePromise,
+      setIsOpen,
+    ],
+  );
 
   function handleConfirm() {
     if (resolvePromise) {

--- a/frontend/src/hooks/useNavigationGuard.js
+++ b/frontend/src/hooks/useNavigationGuard.js
@@ -3,8 +3,7 @@ import { useBlocker } from "react-router-dom";
 import { removeTrailingSlash } from "@/lib/utils";
 
 export function useNavigationGuard(hasChanges, openConfirmation) {
-  const blocker = useBlocker(({ currentLocation, nextLocation }) => {
-    const currentPath = currentLocation.pathname;
+  const blocker = useBlocker(({ nextLocation }) => {
     const nextPath = removeTrailingSlash(nextLocation.pathname);
 
     // Get query string from nextPath
@@ -12,8 +11,8 @@ export function useNavigationGuard(hasChanges, openConfirmation) {
 
     // Bypass the blocker when saving or approving
     if (
-      nextPath === `${currentPath}/preview` ||
-      nextPath === `${currentPath.replace("edit", "preview")}` ||
+      nextPath.includes("/preview") ||
+      nextPath.includes("/edit") ||
       queryString.has("approved") ||
       queryString.has("saved")
     ) {

--- a/frontend/src/router/index.jsx
+++ b/frontend/src/router/index.jsx
@@ -68,6 +68,12 @@ const RouterConfig = createBrowserRouter(
               path: "preview",
               element: <PreviewChanges />,
             },
+
+            // review submissions for approval
+            {
+              path: "review",
+              element: <PreviewChanges review={true} />,
+            },
           ],
         },
 
@@ -87,6 +93,12 @@ const RouterConfig = createBrowserRouter(
             {
               path: "preview",
               element: <PreviewWinterFeesChanges />,
+            },
+
+            // review winter fees submissions for approval
+            {
+              path: "review",
+              element: <PreviewWinterFeesChanges review={true} />,
             },
           ],
         },

--- a/frontend/src/router/index.jsx
+++ b/frontend/src/router/index.jsx
@@ -3,6 +3,7 @@ import EditAndReview from "./pages/EditAndReview";
 import PublishPage from "./pages/PublishPage";
 import ExportPage from "./pages/ExportPage";
 import ParkDetails from "./pages/ParkDetails";
+import SeasonPage from "./pages/SeasonPage";
 import SubmitDates from "./pages/SubmitDates";
 import SubmitWinterFeesDates from "./pages/SubmitWinterFeesDates";
 import PreviewChanges from "./pages/PreviewChanges";
@@ -49,17 +50,27 @@ const RouterConfig = createBrowserRouter(
           element: <ParkDetails />,
         },
 
-        // edit/submit dates for a season
+        // Season page with sub-routes
         {
-          path: paths.seasonEdit(":parkId", ":seasonId"),
-          element: <SubmitDates />,
+          path: paths.season(":parkId", ":seasonId"),
+          // element: <div>test foo</div>,
+          element: <SeasonPage />,
+          children: [
+            // edit/submit dates for a season
+            {
+              path: "edit",
+              element: <SubmitDates />,
+            },
+
+            // preview changes before saving
+            {
+              path: "preview",
+              element: <PreviewChanges />,
+            },
+          ],
         },
 
-        // review changes
-        {
-          path: paths.seasonPreview(":parkId", ":seasonId"),
-          element: <PreviewChanges />,
-        },
+        // @TODO: whatever we do above, do the same for winter fees
 
         // edit/submit winter fees dates
         {

--- a/frontend/src/router/index.jsx
+++ b/frontend/src/router/index.jsx
@@ -1,4 +1,4 @@
-import { createBrowserRouter } from "react-router-dom";
+import { createBrowserRouter, Navigate } from "react-router-dom";
 import EditAndReview from "./pages/EditAndReview";
 import PublishPage from "./pages/PublishPage";
 import ExportPage from "./pages/ExportPage";
@@ -21,6 +21,7 @@ const RouterConfig = createBrowserRouter(
       // Protect the entire app with the AuthProvider
       element: <MainLayout />,
       errorElement: <ErrorPage />,
+
       children: [
         {
           path: "/",
@@ -45,7 +46,7 @@ const RouterConfig = createBrowserRouter(
           ],
         },
 
-        // view park details
+        // View park details
         {
           path: paths.park(":parkId"),
           element: <ParkDetails />,
@@ -54,22 +55,28 @@ const RouterConfig = createBrowserRouter(
         // Season page with sub-routes
         {
           path: paths.season(":parkId", ":seasonId"),
-          // element: <div>test foo</div>,
           element: <SeasonPage />,
+
           children: [
-            // edit/submit dates for a season
+            // Redirect the season root to the edit page
+            {
+              index: true,
+              element: <Navigate to="edit" replace />,
+            },
+
+            // Edit/submit dates for a season
             {
               path: "edit",
               element: <SubmitDates />,
             },
 
-            // preview changes before saving
+            // Preview changes before saving
             {
               path: "preview",
               element: <PreviewChanges />,
             },
 
-            // review submissions for approval
+            // Review submissions for approval
             {
               path: "review",
               element: <PreviewChanges review={true} />,
@@ -83,19 +90,25 @@ const RouterConfig = createBrowserRouter(
           element: <WinterFeesSeasonPage />,
 
           children: [
-            // edit/submit winter fees dates
+            // Redirect the season root to the edit page
+            {
+              index: true,
+              element: <Navigate to="edit" replace />,
+            },
+
+            // Edit/submit winter fees dates
             {
               path: "edit",
               element: <SubmitWinterFeesDates />,
             },
 
-            // preview winter fees changes before saving
+            // Preview winter fees changes before saving
             {
               path: "preview",
               element: <PreviewWinterFeesChanges />,
             },
 
-            // review winter fees submissions for approval
+            // Review winter fees submissions for approval
             {
               path: "review",
               element: <PreviewWinterFeesChanges review={true} />,

--- a/frontend/src/router/index.jsx
+++ b/frontend/src/router/index.jsx
@@ -5,6 +5,7 @@ import ExportPage from "./pages/ExportPage";
 import ParkDetails from "./pages/ParkDetails";
 import SeasonPage from "./pages/SeasonPage";
 import SubmitDates from "./pages/SubmitDates";
+import WinterFeesSeasonPage from "./pages/WinterFeesSeasonPage";
 import SubmitWinterFeesDates from "./pages/SubmitWinterFeesDates";
 import PreviewChanges from "./pages/PreviewChanges";
 import PreviewWinterFeesChanges from "./pages/PreviewWinterFeesChanges";
@@ -70,18 +71,24 @@ const RouterConfig = createBrowserRouter(
           ],
         },
 
-        // @TODO: whatever we do above, do the same for winter fees
-
-        // edit/submit winter fees dates
+        // Winter Fee Season page with sub-routes
         {
-          path: paths.winterFeesEdit(":parkId", ":seasonId"),
-          element: <SubmitWinterFeesDates />,
-        },
+          path: paths.winterFeesSeason(":parkId", ":seasonId"),
+          element: <WinterFeesSeasonPage />,
 
-        // review winter fees dates
-        {
-          path: paths.winterFeesPreview(":parkId", ":seasonId"),
-          element: <PreviewWinterFeesChanges />,
+          children: [
+            // edit/submit winter fees dates
+            {
+              path: "edit",
+              element: <SubmitWinterFeesDates />,
+            },
+
+            // preview winter fees changes before saving
+            {
+              path: "preview",
+              element: <PreviewWinterFeesChanges />,
+            },
+          ],
         },
       ],
     },

--- a/frontend/src/router/pages/ParkDetails.jsx
+++ b/frontend/src/router/pages/ParkDetails.jsx
@@ -113,7 +113,7 @@ function ParkDetails() {
             seasonProps={{
               getDataEndpoint: (seasonId) => `/seasons/${seasonId}`,
               getEditRoutePath: paths.seasonEdit,
-              getPreviewRoutePath: paths.seasonPreview,
+              getReviewRoutePath: paths.seasonReview,
               getTitle: (season) => `${season.operatingYear} dates`,
               DetailsComponent: SeasonDates,
             }}
@@ -129,7 +129,7 @@ function ParkDetails() {
           seasonProps={{
             getDataEndpoint: (seasonId) => `/winter-fees/${seasonId}`,
             getEditRoutePath: paths.winterFeesEdit,
-            getPreviewRoutePath: paths.winterFeesPreview,
+            getReviewRoutePath: paths.winterFeesReview,
             getTitle: (season) =>
               `${season.operatingYear} – ${season.operatingYear + 1}`,
             DetailsComponent: WinterFeesDates,

--- a/frontend/src/router/pages/PreviewChanges.jsx
+++ b/frontend/src/router/pages/PreviewChanges.jsx
@@ -150,6 +150,18 @@ function PreviewChanges({ review = false }) {
     return featureNameList;
   }
 
+  // Navigate back to the previous page
+  function onBackButtonClick() {
+    // On the Review page, go back to the Park Details page
+    if (review) {
+      navigate(paths.park(parkId));
+      return;
+    }
+
+    // On the Preview page, go back to the Edit page
+    navigateAndScroll(paths.seasonEdit(parkId, seasonId));
+  }
+
   // Saves and approves the changes
   async function approve() {
     validation.formSubmitted.current = true;
@@ -382,7 +394,7 @@ function PreviewChanges({ review = false }) {
           <button
             type="button"
             className="btn btn-outline-primary"
-            onClick={navigateToEdit}
+            onClick={onBackButtonClick}
           >
             Back
           </button>

--- a/frontend/src/router/pages/PreviewChanges.jsx
+++ b/frontend/src/router/pages/PreviewChanges.jsx
@@ -72,7 +72,7 @@ function PreviewChanges() {
 
     return editedDates.map((dateRange) => (
       <DateRange
-        key={dateRange.id}
+        key={dateRange.id || dateRange.tempId}
         start={dateRange.startDate}
         end={dateRange.endDate}
       />

--- a/frontend/src/router/pages/PreviewChanges.jsx
+++ b/frontend/src/router/pages/PreviewChanges.jsx
@@ -230,7 +230,13 @@ function PreviewChanges() {
             <tbody>
               <tr>
                 <td>Operating</td>
+                {
+                  // @TODO: use live data from `dates`
+                }
                 <td>{getPrevSeasonDates(feature, "Operation")}</td>
+                {
+                  // @TODO: use live data from `dates`
+                }
                 <td>{getCurrentSeasonDates(feature, "Operation")}</td>
                 <td>
                   <button
@@ -249,7 +255,13 @@ function PreviewChanges() {
               {feature.hasReservations && (
                 <tr>
                   <td>Reservation</td>
+                  {
+                    // @TODO: use live data from `dates`
+                  }
                   <td>{getPrevSeasonDates(feature, "Reservation")}</td>
+                  {
+                    // @TODO: use live data from `dates`
+                  }
                   <td>{getCurrentSeasonDates(feature, "Reservation")}</td>
                   <td>
                     <button

--- a/frontend/src/router/pages/PreviewChanges.jsx
+++ b/frontend/src/router/pages/PreviewChanges.jsx
@@ -32,6 +32,7 @@ function PreviewChanges() {
     navigate,
     navigateAndScroll,
     saveAsDraft,
+    saveChanges,
     showErrorFlash,
     hasChanges,
     saving,
@@ -139,8 +140,6 @@ function PreviewChanges() {
   async function approve() {
     validation.formSubmitted.current = true;
 
-    // @TODO: save changes first, if necessary
-
     if (!validation.validateForm()) {
       throw new validation.ValidationError("Form validation failed");
     }
@@ -148,6 +147,11 @@ function PreviewChanges() {
     const featuresWithMissingDates = getFeaturesWithMissingDates();
 
     try {
+      // Save changes first, if necessary
+      if (hasChanges()) {
+        await saveChanges();
+      }
+
       if (featuresWithMissingDates.length > 0) {
         const { confirm, confirmationMessage } =
           await missingDatesConfirmation.openConfirmation(
@@ -156,7 +160,7 @@ function PreviewChanges() {
 
         if (confirm) {
           await approveData({
-            notes: [notes, confirmationMessage],
+            notes: [confirmationMessage],
             readyToPublish,
           });
 
@@ -167,7 +171,7 @@ function PreviewChanges() {
         }
       } else {
         await approveData({
-          notes: [notes],
+          notes: [], // Notes were saved with saveChanges,
           readyToPublish,
         });
         // Redirect back to the Park Details page on success.

--- a/frontend/src/router/pages/PreviewChanges.jsx
+++ b/frontend/src/router/pages/PreviewChanges.jsx
@@ -35,6 +35,7 @@ function PreviewChanges() {
     validation,
     navigate,
     navigateAndScroll,
+    saveAsDraft,
   } = useOutletContext();
 
   const { sendData: saveData, loading: saving } = useApiPost(
@@ -110,20 +111,12 @@ function PreviewChanges() {
   }
 
   async function savePreview() {
-    try {
-      await saveData({
-        notes,
-        dates: [],
-        readyToPublish,
-        deletedDateRangeIds: [],
-      });
-
-      navigate(`${paths.park(parkId)}?saved=${seasonId}`);
-    } catch (err) {
-      console.error("Error saving preview", err);
-
-      showErrorFlash();
-    }
+    return saveData({
+      notes,
+      dates: [],
+      readyToPublish,
+      deletedDateRangeIds: [],
+    });
   }
 
   function getFeaturesWithMissingDates() {
@@ -451,7 +444,10 @@ function PreviewChanges() {
           <button
             type="button"
             className="btn btn-outline-primary"
-            onClick={savePreview}
+            onClick={() =>
+              saveAsDraft(savePreview, openConfirmation, showErrorFlash)
+            }
+            disabled={!hasChanges()}
           >
             Save draft
           </button>

--- a/frontend/src/router/pages/PreviewChanges.jsx
+++ b/frontend/src/router/pages/PreviewChanges.jsx
@@ -201,6 +201,12 @@ function PreviewChanges() {
   }
 
   async function approve() {
+    validation.formSubmitted.current = true;
+
+    if (!validation.validateForm()) {
+      throw new validation.ValidationError("Form validation failed");
+    }
+
     const featuresWithMissingDates = getFeaturesWithMissingDates();
 
     try {
@@ -233,7 +239,13 @@ function PreviewChanges() {
     } catch (err) {
       console.error("Error approving preview", err);
 
-      showErrorFlash();
+      if (err instanceof validation.ValidationError) {
+        // @TODO: Handle validation errors
+        console.error(err);
+      } else {
+        // Show a flash message for fatal server errors
+        showErrorFlash();
+      }
     }
   }
 

--- a/frontend/src/router/pages/PreviewChanges.jsx
+++ b/frontend/src/router/pages/PreviewChanges.jsx
@@ -23,6 +23,7 @@ function PreviewChanges() {
     parkId,
     seasonId,
     season,
+    dates,
     notes,
     setNotes,
     readyToPublish,
@@ -47,28 +48,28 @@ function PreviewChanges() {
   }
 
   function getPrevSeasonDates(feature, dateType) {
-    const dates = feature.dateable.previousSeasonDates.filter(
+    const seasonDates = feature.dateable.previousSeasonDates.filter(
       (dateRange) => dateRange.dateType.name === dateType,
     );
 
-    if (dates.length === 0) {
+    if (seasonDates.length === 0) {
       return "Not available";
     }
-    return dates.map((date) => (
+    return seasonDates.map((date) => (
       <DateRange key={date.id} start={date.startDate} end={date.endDate} />
     ));
   }
 
+  // Returns the current (potentially edited) season dates for the feature
   function getCurrentSeasonDates(feature, dateType) {
     if (!feature.active) {
       return "Not requested";
     }
 
-    const dates = feature.dateable.currentSeasonDates.filter(
-      (dateRange) => dateRange.dateType.name === dateType,
-    );
+    // Get edited dates from `dates` (instead of the original dates in `season`)
+    const editedDates = dates[feature.dateable.id]?.[dateType] ?? [];
 
-    return dates.map((dateRange) => (
+    return editedDates.map((dateRange) => (
       <DateRange
         key={dateRange.id}
         start={dateRange.startDate}
@@ -77,6 +78,7 @@ function PreviewChanges() {
     ));
   }
 
+  // @TODO: use `dates`
   function getFeaturesWithMissingDates() {
     const featureNameList = [];
 

--- a/frontend/src/router/pages/PreviewChanges.jsx
+++ b/frontend/src/router/pages/PreviewChanges.jsx
@@ -1,3 +1,4 @@
+import { useCallback, useEffect } from "react";
 import PropTypes from "prop-types";
 import { useOutletContext } from "react-router-dom";
 import { useApiPost } from "@/hooks/useApi";
@@ -38,15 +39,28 @@ function PreviewChanges({ review = false }) {
     saving,
   } = useOutletContext();
 
+  const navigateToEdit = useCallback(() => {
+    navigateAndScroll(paths.seasonEdit(parkId, seasonId));
+  }, [parkId, seasonId, navigateAndScroll]);
+
+  // Set formSubmitted to trigger full validation
+  validation.formSubmitted.current = true;
+
+  // The data should be valid before getting to this Preview/Review page.
+  // If somebody types in the URL manually to get here with invalid data,
+  // just redirect them to the edit page.
+  useEffect(() => {
+    if (!validation.isValid) {
+      // @TODO: show a flash message about the redirect?
+      navigateToEdit();
+    }
+  }, [navigateToEdit, validation.isValid]);
+
   const { sendData: approveData, loading: savingApproval } = useApiPost(
     `/seasons/${seasonId}/approve/`,
   );
 
   const missingDatesConfirmation = useMissingDatesConfirmation();
-
-  function navigateToEdit() {
-    navigateAndScroll(paths.seasonEdit(parkId, seasonId));
-  }
 
   function getPrevSeasonDates(feature, dateType) {
     const seasonDates = feature.dateable.previousSeasonDates.filter(

--- a/frontend/src/router/pages/PreviewChanges.jsx
+++ b/frontend/src/router/pages/PreviewChanges.jsx
@@ -78,7 +78,7 @@ function PreviewChanges() {
     ));
   }
 
-  // @TODO: use `dates`
+  // @TODO: use `dates` - see winter fees version
   function getFeaturesWithMissingDates() {
     const featureNameList = [];
 
@@ -153,8 +153,11 @@ function PreviewChanges() {
     return featureNameList;
   }
 
+  // Saves and approves the changes
   async function approve() {
     validation.formSubmitted.current = true;
+
+    // @TODO: save changes first, if necessary
 
     if (!validation.validateForm()) {
       throw new validation.ValidationError("Form validation failed");

--- a/frontend/src/router/pages/PreviewChanges.jsx
+++ b/frontend/src/router/pages/PreviewChanges.jsx
@@ -18,7 +18,7 @@ import MissingDatesConfirmationDialog from "@/components/MissingDatesConfirmatio
 
 import "./PreviewChanges.scss";
 
-function PreviewChanges() {
+function PreviewChanges({ review = false }) {
   const {
     parkId,
     seasonId,
@@ -304,7 +304,9 @@ function PreviewChanges() {
             <FeatureIcon iconName={season.featureType.icon} />
             {season.park.name} {season.featureType.name}
           </h1>
-          <h2>Preview {season.operatingYear} dates</h2>
+          <h2>
+            {review ? "Review" : "Preview"} {season.operatingYear} dates
+          </h2>
         </header>
 
         <section className="feature-type">
@@ -395,5 +397,11 @@ function PreviewChanges() {
     </div>
   );
 }
+
+PreviewChanges.propTypes = {
+  // Boolean flag for Review mode (display different titles and buttons)
+  // Otherwise, default to Preview mode (for editing/submitters)
+  review: PropTypes.bool,
+};
 
 export default PreviewChanges;

--- a/frontend/src/router/pages/PreviewChanges.jsx
+++ b/frontend/src/router/pages/PreviewChanges.jsx
@@ -216,13 +216,7 @@ function PreviewChanges() {
             <tbody>
               <tr>
                 <td>Operating</td>
-                {
-                  // @TODO: use live data from `dates`
-                }
                 <td>{getPrevSeasonDates(feature, "Operation")}</td>
-                {
-                  // @TODO: use live data from `dates`
-                }
                 <td>{getCurrentSeasonDates(feature, "Operation")}</td>
                 <td>
                   <button
@@ -241,13 +235,7 @@ function PreviewChanges() {
               {feature.hasReservations && (
                 <tr>
                   <td>Reservation</td>
-                  {
-                    // @TODO: use live data from `dates`
-                  }
                   <td>{getPrevSeasonDates(feature, "Reservation")}</td>
-                  {
-                    // @TODO: use live data from `dates`
-                  }
                   <td>{getCurrentSeasonDates(feature, "Reservation")}</td>
                   <td>
                     <button

--- a/frontend/src/router/pages/PreviewChanges.jsx
+++ b/frontend/src/router/pages/PreviewChanges.jsx
@@ -1,10 +1,7 @@
 import PropTypes from "prop-types";
 import { useOutletContext } from "react-router-dom";
 import { useApiPost } from "@/hooks/useApi";
-import { useNavigationGuard } from "@/hooks/useNavigationGuard";
-import { useConfirmation } from "@/hooks/useConfirmation";
 import { useMissingDatesConfirmation } from "@/hooks/useMissingDatesConfirmation";
-import { useFlashMessage } from "@/hooks/useFlashMessage";
 import paths from "@/router/paths";
 
 import { faPen } from "@fa-kit/icons/classic/solid";
@@ -17,9 +14,7 @@ import ContactBox from "@/components/ContactBox";
 import ReadyToPublishBox from "@/components/ReadyToPublishBox";
 import DateRange from "@/components/DateRange";
 import ChangeLogsList from "@/components/ChangeLogsList";
-import ConfirmationDialog from "@/components/ConfirmationDialog";
 import MissingDatesConfirmationDialog from "@/components/MissingDatesConfirmationDialog";
-import FlashMessage from "@/components/FlashMessage";
 
 import "./PreviewChanges.scss";
 
@@ -36,37 +31,16 @@ function PreviewChanges() {
     navigate,
     navigateAndScroll,
     saveAsDraft,
+    showErrorFlash,
+    hasChanges,
+    saving,
   } = useOutletContext();
-
-  const { sendData: saveData, loading: saving } = useApiPost(
-    `/seasons/${seasonId}/save/`,
-  );
 
   const { sendData: approveData, loading: savingApproval } = useApiPost(
     `/seasons/${seasonId}/approve/`,
   );
 
-  const errorFlashMessage = useFlashMessage();
-
-  const {
-    title,
-    message,
-    confirmButtonText,
-    cancelButtonText,
-    confirmationDialogNotes,
-    openConfirmation,
-    handleConfirm,
-    handleCancel,
-    isConfirmationOpen,
-  } = useConfirmation();
-
   const missingDatesConfirmation = useMissingDatesConfirmation();
-
-  function hasChanges() {
-    return notes !== "" || season.readyToPublish !== readyToPublish;
-  }
-
-  useNavigationGuard(hasChanges, openConfirmation);
 
   function navigateToEdit() {
     navigateAndScroll(paths.seasonEdit(parkId, seasonId));
@@ -101,22 +75,6 @@ function PreviewChanges() {
         end={dateRange.endDate}
       />
     ));
-  }
-
-  function showErrorFlash() {
-    errorFlashMessage.openFlashMessage(
-      "Unable to save changes",
-      "There was a problem saving these changes. Please try again.",
-    );
-  }
-
-  async function savePreview() {
-    return saveData({
-      notes,
-      dates: [],
-      readyToPublish,
-      deletedDateRangeIds: [],
-    });
   }
 
   function getFeaturesWithMissingDates() {
@@ -337,25 +295,6 @@ function PreviewChanges() {
   return (
     <div className="container">
       <div className="page review-changes">
-        <FlashMessage
-          title={errorFlashMessage.flashTitle}
-          message={errorFlashMessage.flashMessage}
-          isVisible={errorFlashMessage.isFlashOpen}
-          onClose={errorFlashMessage.handleFlashClose}
-          variant="error"
-        />
-
-        <ConfirmationDialog
-          title={title}
-          message={message}
-          confirmButtonText={confirmButtonText}
-          cancelButtonText={cancelButtonText}
-          notes={confirmationDialogNotes}
-          onCancel={handleCancel}
-          onConfirm={handleConfirm}
-          isOpen={isConfirmationOpen}
-        />
-
         <MissingDatesConfirmationDialog
           featureNames={missingDatesConfirmation.featureNames}
           inputMessage={missingDatesConfirmation.inputMessage}
@@ -444,9 +383,7 @@ function PreviewChanges() {
           <button
             type="button"
             className="btn btn-outline-primary"
-            onClick={() =>
-              saveAsDraft(savePreview, openConfirmation, showErrorFlash)
-            }
+            onClick={saveAsDraft}
             disabled={!hasChanges()}
           >
             Save draft

--- a/frontend/src/router/pages/PreviewWinterFeesChanges.jsx
+++ b/frontend/src/router/pages/PreviewWinterFeesChanges.jsx
@@ -1,6 +1,6 @@
 import { useCallback } from "react";
 import PropTypes from "prop-types";
-import { Link, useOutletContext } from "react-router-dom";
+import { useOutletContext } from "react-router-dom";
 import { useApiPost } from "@/hooks/useApi";
 import { useMissingDatesConfirmation } from "@/hooks/useMissingDatesConfirmation";
 import paths from "@/router/paths";
@@ -84,6 +84,18 @@ function PreviewChanges({ review = false }) {
     });
 
     return featureNames;
+  }
+
+  // Navigate back to the previous page
+  function onBackButtonClick() {
+    // On the Review page, go back to the Park Details page
+    if (review) {
+      navigate(paths.park(parkId));
+      return;
+    }
+
+    // On the Preview page, go back to the Edit page
+    navigateAndScroll(paths.winterFeesEdit(parkId, seasonId));
   }
 
   // Saves and approves the changes
@@ -263,13 +275,13 @@ function PreviewChanges({ review = false }) {
         </div>
 
         <div className="controls d-flex flex-column flex-sm-row gap-2">
-          <Link
-            to={paths.winterFeesEdit(parkId, seasonId)}
+          <button
             type="button"
             className="btn btn-outline-primary"
+            onClick={onBackButtonClick}
           >
             Back
-          </Link>
+          </button>
 
           <button
             type="button"

--- a/frontend/src/router/pages/PreviewWinterFeesChanges.jsx
+++ b/frontend/src/router/pages/PreviewWinterFeesChanges.jsx
@@ -30,6 +30,7 @@ function PreviewChanges() {
     navigate,
     navigateAndScroll,
     saveAsDraft,
+    saveChanges,
     showErrorFlash,
     hasChanges,
     saving,
@@ -88,9 +89,12 @@ function PreviewChanges() {
   async function approve() {
     const featuresWithMissingDates = getFeaturesWithMissingDates();
 
-    // @TODO: save changes first, if necessary
-
     try {
+      // Save changes first, if necessary
+      if (hasChanges()) {
+        await saveChanges();
+      }
+
       if (featuresWithMissingDates.length > 0) {
         const { confirm, confirmationMessage } =
           await missingDatesConfirmation.openConfirmation(
@@ -99,7 +103,7 @@ function PreviewChanges() {
 
         if (confirm) {
           await approveData({
-            notes: [notes, confirmationMessage],
+            notes: [confirmationMessage],
             readyToPublish,
           });
 
@@ -110,7 +114,7 @@ function PreviewChanges() {
         }
       } else {
         await approveData({
-          notes: [notes],
+          notes: [], // Notes were saved with saveChanges,
           readyToPublish,
         });
         // Redirect back to the Park Details page on success.

--- a/frontend/src/router/pages/PreviewWinterFeesChanges.jsx
+++ b/frontend/src/router/pages/PreviewWinterFeesChanges.jsx
@@ -22,6 +22,7 @@ function PreviewChanges() {
     parkId,
     seasonId,
     season,
+    dates,
     notes,
     setNotes,
     readyToPublish,
@@ -44,11 +45,11 @@ function PreviewChanges() {
     navigateAndScroll(paths.winterFeesEdit(parkId, seasonId));
   }
 
-  function getDates(dates) {
-    if (dates.length === 0) {
+  function getDates(seasonDates) {
+    if (seasonDates.length === 0) {
       return "Not available";
     }
-    return dates.map((date) => (
+    return seasonDates.map((date) => (
       <DateRange
         key={date.id}
         formatWithYear={true}
@@ -58,6 +59,7 @@ function PreviewChanges() {
     ));
   }
 
+  // @TODO: use `dates`
   function getFeaturesWithMissingDates() {
     const features = season.featureTypes.flatMap((featureType) =>
       featureType.features.filter(
@@ -106,6 +108,9 @@ function PreviewChanges() {
   }
 
   function Feature({ feature }) {
+    // Get edited dates from `dates` (instead of the original dates in `season`)
+    const currentWinterDates = dates[feature.dateableId] ?? [];
+
     return (
       <div>
         <h4 className="feature-name mb-4">{feature.name}</h4>
@@ -130,7 +135,7 @@ function PreviewChanges() {
               <tr>
                 <td>Winter fee</td>
                 <td>{getDates(feature.previousWinterDates)}</td>
-                <td>{getDates(feature.currentWinterDates)}</td>
+                <td>{getDates(currentWinterDates)}</td>
                 <td>
                   <button
                     onClick={navigateToEdit}

--- a/frontend/src/router/pages/PreviewWinterFeesChanges.jsx
+++ b/frontend/src/router/pages/PreviewWinterFeesChanges.jsx
@@ -17,7 +17,7 @@ import MissingDatesConfirmationDialog from "@/components/MissingDatesConfirmatio
 
 import "./PreviewChanges.scss";
 
-function PreviewChanges() {
+function PreviewChanges({ review = false }) {
   const {
     parkId,
     seasonId,
@@ -211,7 +211,9 @@ function PreviewChanges() {
             <FeatureIcon iconName="winter-recreation" />
             {season.park.name} winter fee
           </h1>
-          <h2>Preview {season.name}</h2>
+          <h2>
+            {review ? "Review" : "Preview"} {season.name}
+          </h2>
         </header>
 
         {season?.featureTypes.map((featureType) => (
@@ -292,5 +294,11 @@ function PreviewChanges() {
     </div>
   );
 }
+
+PreviewChanges.propTypes = {
+  // Boolean flag for Review mode (display different titles and buttons)
+  // Otherwise, default to Preview mode (for editing/submitters)
+  review: PropTypes.bool,
+};
 
 export default PreviewChanges;

--- a/frontend/src/router/pages/PreviewWinterFeesChanges.jsx
+++ b/frontend/src/router/pages/PreviewWinterFeesChanges.jsx
@@ -52,7 +52,7 @@ function PreviewChanges() {
     }
     return featureDates.map((date) => (
       <DateRange
-        key={date.id}
+        key={date.id || date.tempId}
         formatWithYear={true}
         start={date.startDate}
         end={date.endDate}

--- a/frontend/src/router/pages/PreviewWinterFeesChanges.jsx
+++ b/frontend/src/router/pages/PreviewWinterFeesChanges.jsx
@@ -45,11 +45,11 @@ function PreviewChanges() {
     navigateAndScroll(paths.winterFeesEdit(parkId, seasonId));
   }
 
-  function getDates(seasonDates) {
-    if (seasonDates.length === 0) {
+  function getDates(featureDates) {
+    if (featureDates.length === 0) {
       return "Not available";
     }
-    return seasonDates.map((date) => (
+    return featureDates.map((date) => (
       <DateRange
         key={date.id}
         formatWithYear={true}
@@ -59,17 +59,32 @@ function PreviewChanges() {
     ));
   }
 
-  // @TODO: use `dates`
+  // Returns the names of features with no (or null) date ranges
   function getFeaturesWithMissingDates() {
-    const features = season.featureTypes.flatMap((featureType) =>
-      featureType.features.filter(
-        (feature) => feature.currentWinterDates.length === 0,
+    const allFeatures = season.featureTypes.flatMap(
+      (featureType) => featureType.features,
+    );
+
+    // Get dateable IDs with no associated dates (or null date ranges)
+    const dateableIds = Object.entries(dates).filter(([, featureDates]) =>
+      featureDates.every(
+        (featureDate) =>
+          featureDate.startDate === null && featureDate.endDate === null,
       ),
     );
 
-    return features.map((feature) => feature.name);
+    const featureNames = dateableIds.map(([dateableId]) => {
+      const feature = allFeatures.find(
+        (f) => f.dateableId === Number(dateableId),
+      );
+
+      return feature.name;
+    });
+
+    return featureNames;
   }
 
+  // Saves and approves the changes
   async function approve() {
     const featuresWithMissingDates = getFeaturesWithMissingDates();
 

--- a/frontend/src/router/pages/PreviewWinterFeesChanges.jsx
+++ b/frontend/src/router/pages/PreviewWinterFeesChanges.jsx
@@ -1,3 +1,4 @@
+import { useCallback } from "react";
 import PropTypes from "prop-types";
 import { Link, useOutletContext } from "react-router-dom";
 import { useApiPost } from "@/hooks/useApi";
@@ -36,15 +37,15 @@ function PreviewChanges({ review = false }) {
     saving,
   } = useOutletContext();
 
+  const navigateToEdit = useCallback(() => {
+    navigateAndScroll(paths.winterFeesEdit(parkId, seasonId));
+  }, [parkId, seasonId, navigateAndScroll]);
+
   const { sendData: approveData, loading: savingApproval } = useApiPost(
     `/seasons/${seasonId}/approve/`,
   );
 
   const missingDatesConfirmation = useMissingDatesConfirmation();
-
-  function navigateToEdit() {
-    navigateAndScroll(paths.winterFeesEdit(parkId, seasonId));
-  }
 
   function getDates(featureDates) {
     if (featureDates.length === 0) {

--- a/frontend/src/router/pages/PreviewWinterFeesChanges.jsx
+++ b/frontend/src/router/pages/PreviewWinterFeesChanges.jsx
@@ -1,10 +1,7 @@
 import PropTypes from "prop-types";
 import { Link, useOutletContext } from "react-router-dom";
 import { useApiPost } from "@/hooks/useApi";
-import { useNavigationGuard } from "@/hooks/useNavigationGuard";
-import { useConfirmation } from "@/hooks/useConfirmation";
 import { useMissingDatesConfirmation } from "@/hooks/useMissingDatesConfirmation";
-import { useFlashMessage } from "@/hooks/useFlashMessage";
 import paths from "@/router/paths";
 
 import { faPen } from "@fa-kit/icons/classic/solid";
@@ -16,9 +13,7 @@ import ContactBox from "@/components/ContactBox";
 import ReadyToPublishBox from "@/components/ReadyToPublishBox";
 import DateRange from "@/components/DateRange";
 import ChangeLogsList from "@/components/ChangeLogsList";
-import ConfirmationDialog from "@/components/ConfirmationDialog";
 import MissingDatesConfirmationDialog from "@/components/MissingDatesConfirmationDialog";
-import FlashMessage from "@/components/FlashMessage";
 
 import "./PreviewChanges.scss";
 
@@ -34,31 +29,16 @@ function PreviewChanges() {
     navigate,
     navigateAndScroll,
     saveAsDraft,
-    hasChanges,
     saving,
+    hasChanges,
+    showErrorFlash,
   } = useOutletContext();
 
   const { sendData: approveData, loading: savingApproval } = useApiPost(
     `/seasons/${seasonId}/approve/`,
   );
 
-  const errorFlashMessage = useFlashMessage();
-
-  const {
-    title,
-    message,
-    confirmationDialogNotes,
-    confirmButtonText,
-    cancelButtonText,
-    openConfirmation,
-    handleConfirm,
-    handleCancel,
-    isConfirmationOpen,
-  } = useConfirmation();
-
   const missingDatesConfirmation = useMissingDatesConfirmation();
-
-  useNavigationGuard(hasChanges, openConfirmation);
 
   function navigateToEdit() {
     navigateAndScroll(paths.winterFeesEdit(parkId, seasonId));
@@ -76,13 +56,6 @@ function PreviewChanges() {
         end={date.endDate}
       />
     ));
-  }
-
-  function showErrorFlash() {
-    errorFlashMessage.openFlashMessage(
-      "Unable to save changes",
-      "There was a problem saving these changes. Please try again.",
-    );
   }
 
   function getFeaturesWithMissingDates() {
@@ -194,25 +167,6 @@ function PreviewChanges() {
   return (
     <div className="container">
       <div className="page review-winter-fees-changes">
-        <FlashMessage
-          title={errorFlashMessage.flashTitle}
-          message={errorFlashMessage.flashMessage}
-          isVisible={errorFlashMessage.isFlashOpen}
-          onClose={errorFlashMessage.handleFlashClose}
-          variant="error"
-        />
-
-        <ConfirmationDialog
-          title={title}
-          message={message}
-          notes={confirmationDialogNotes}
-          confirmButtonText={confirmButtonText}
-          cancelButtonText={cancelButtonText}
-          onCancel={handleCancel}
-          onConfirm={handleConfirm}
-          isOpen={isConfirmationOpen}
-        />
-
         <MissingDatesConfirmationDialog
           featureNames={missingDatesConfirmation.featureNames}
           inputMessage={missingDatesConfirmation.inputMessage}
@@ -291,7 +245,7 @@ function PreviewChanges() {
           <button
             type="button"
             className="btn btn-outline-primary"
-            onClick={() => saveAsDraft(openConfirmation, showErrorFlash)}
+            onClick={saveAsDraft}
             disabled={!hasChanges()}
           >
             Save draft

--- a/frontend/src/router/pages/PreviewWinterFeesChanges.jsx
+++ b/frontend/src/router/pages/PreviewWinterFeesChanges.jsx
@@ -29,9 +29,9 @@ function PreviewChanges() {
     navigate,
     navigateAndScroll,
     saveAsDraft,
-    saving,
-    hasChanges,
     showErrorFlash,
+    hasChanges,
+    saving,
   } = useOutletContext();
 
   const { sendData: approveData, loading: savingApproval } = useApiPost(

--- a/frontend/src/router/pages/PreviewWinterFeesChanges.jsx
+++ b/frontend/src/router/pages/PreviewWinterFeesChanges.jsx
@@ -88,6 +88,8 @@ function PreviewChanges() {
   async function approve() {
     const featuresWithMissingDates = getFeaturesWithMissingDates();
 
+    // @TODO: save changes first, if necessary
+
     try {
       if (featuresWithMissingDates.length > 0) {
         const { confirm, confirmationMessage } =

--- a/frontend/src/router/pages/SeasonPage.jsx
+++ b/frontend/src/router/pages/SeasonPage.jsx
@@ -1,11 +1,17 @@
 import { useEffect, useState } from "react";
 import { Outlet, useNavigate, useParams } from "react-router-dom";
+import omit from "lodash/omit";
 
 import paths from "@/router/paths";
-import { useApiGet } from "@/hooks/useApi";
+import { useApiGet, useApiPost } from "@/hooks/useApi";
 import useValidation from "@/hooks/useValidation";
+import { useFlashMessage } from "@/hooks/useFlashMessage";
+import { useConfirmation } from "@/hooks/useConfirmation";
+import { useNavigationGuard } from "@/hooks/useNavigationGuard";
 
 import LoadingBar from "@/components/LoadingBar";
+import FlashMessage from "@/components/FlashMessage";
+import ConfirmationDialog from "@/components/ConfirmationDialog";
 
 export default function SeasonPage() {
   // Render the SubmitDates (edit form) or PreviewDates (read-only) component
@@ -14,15 +20,25 @@ export default function SeasonPage() {
 
   const { parkId, seasonId } = useParams();
   const navigate = useNavigate();
+  const errorFlashMessage = useFlashMessage();
+  const confirmationDialog = useConfirmation();
 
   const [season, setSeason] = useState(null);
   const [dates, setDates] = useState(null);
   const [readyToPublish, setReadyToPublish] = useState(false);
   const [notes, setNotes] = useState("");
 
+  // Track deleted date ranges
+  const [deletedDateRangeIds, setDeletedDateRangeIds] = useState([]);
+
   const validation = useValidation(dates, notes, season);
 
   const { data, loading, error } = useApiGet(`/seasons/${seasonId}`);
+
+  const { sendData, loading: saving } = useApiPost(
+    // @TODO: refactor too
+    `/seasons/${seasonId}/save/`,
+  );
 
   useEffect(() => {
     if (data) {
@@ -76,10 +92,55 @@ export default function SeasonPage() {
     window.scrollTo(0, 0);
   }
 
-  async function saveAsDraft(saveFunction, openConfirmation, showErrorFlash) {
+  async function saveChanges() {
+    // Build a list of date ranges of all date types
+    const allDates = Object.values(dates)
+      .reduce(
+        (acc, dateType) => acc.concat(dateType.Operation, dateType.Reservation),
+        [],
+      )
+      // Filter out any blank ranges or unchanged dates
+      .filter((dateRange) => {
+        if (
+          dateRange.startDate === null &&
+          dateRange.endDate === null &&
+          !dateRange.id
+        ) {
+          return false;
+        }
+
+        // if the range is unchanged, skip this range
+        return dateRange.changed;
+      })
+      // Add dateTypeId to the date ranges, remove tempId
+      .map((dateRange) => ({
+        ...omit(dateRange, ["tempId"]),
+        dateTypeId: dateRange.dateType.id,
+      }));
+
+    const payload = {
+      notes,
+      readyToPublish,
+      dates: allDates,
+      deletedDateRangeIds,
+    };
+
+    const response = await sendData(payload);
+
+    return response;
+  }
+
+  function showErrorFlash() {
+    errorFlashMessage.openFlashMessage(
+      "Unable to save changes",
+      "There was a problem saving these changes. Please try again.",
+    );
+  }
+
+  async function saveAsDraft() {
     try {
       if (["pending review", "approved", "on API"].includes(season.status)) {
-        const confirm = await openConfirmation(
+        const confirm = await confirmationDialog.openConfirmation(
           "Move back to draft?",
           "The dates will be moved back to draft and need to be submitted again to be reviewed.",
           "Move to draft",
@@ -90,7 +151,7 @@ export default function SeasonPage() {
         if (!confirm) return;
       }
 
-      await saveFunction();
+      await saveChanges();
 
       navigate(`${paths.park(parkId)}?saved=${seasonId}`);
     } catch (err) {
@@ -105,6 +166,33 @@ export default function SeasonPage() {
       }
     }
   }
+
+  // Returns true if there are any form changes to save
+  function hasChanges() {
+    if (!dates) return false;
+
+    // Any existing dates changed
+    if (
+      Object.values(dates).some((dateType) =>
+        dateType.Operation.concat(dateType.Reservation).some(
+          (dateRange) => dateRange.changed,
+        ),
+      )
+    ) {
+      return true;
+    }
+
+    // If any date ranges have been deleted
+    if (deletedDateRangeIds.length > 0) return true;
+
+    // Ready to publish state has changed
+    if (readyToPublish !== season.readyToPublish) return true;
+
+    // Notes have been entered
+    return notes;
+  }
+
+  useNavigationGuard(hasChanges, confirmationDialog.openConfirmation);
 
   if (loading || !season) {
     return (
@@ -123,22 +211,47 @@ export default function SeasonPage() {
   }
 
   return (
-    <Outlet
-      context={{
-        parkId,
-        seasonId,
-        season,
-        dates,
-        setDates,
-        notes,
-        setNotes,
-        readyToPublish,
-        setReadyToPublish,
-        validation,
-        navigate,
-        navigateAndScroll,
-        saveAsDraft,
-      }}
-    />
+    <>
+      <FlashMessage
+        title={errorFlashMessage.flashTitle}
+        message={errorFlashMessage.flashMessage}
+        isVisible={errorFlashMessage.isFlashOpen}
+        onClose={errorFlashMessage.handleFlashClose}
+        variant="error"
+      />
+
+      <ConfirmationDialog
+        title={confirmationDialog.title}
+        message={confirmationDialog.message}
+        confirmButtonText={confirmationDialog.confirmButtonText}
+        cancelButtonText={confirmationDialog.cancelButtonText}
+        notes={confirmationDialog.confirmationDialogNotes}
+        onCancel={confirmationDialog.handleCancel}
+        onConfirm={confirmationDialog.handleConfirm}
+        isOpen={confirmationDialog.isConfirmationOpen}
+      />
+
+      <Outlet
+        context={{
+          parkId,
+          seasonId,
+          season,
+          dates,
+          setDates,
+          notes,
+          setNotes,
+          readyToPublish,
+          setReadyToPublish,
+          validation,
+          navigate,
+          navigateAndScroll,
+          setDeletedDateRangeIds,
+          saveAsDraft,
+          showErrorFlash,
+          hasChanges,
+          saving,
+        }}
+      />
+    </>
   );
 }

--- a/frontend/src/router/pages/SeasonPage.jsx
+++ b/frontend/src/router/pages/SeasonPage.jsx
@@ -1,0 +1,121 @@
+import { useEffect, useState } from "react";
+import { Outlet, useNavigate, useParams } from "react-router-dom";
+
+import { useApiGet } from "@/hooks/useApi";
+import useValidation from "@/hooks/useValidation";
+
+import LoadingBar from "@/components/LoadingBar";
+
+export default function SeasonPage() {
+  // Render the SubmitDates (edit form) or PreviewDates (read-only) component
+  // based on the current route. Provide the same date to either route
+  // and allow switching back and forth.
+
+  const { parkId, seasonId } = useParams();
+  const navigate = useNavigate();
+
+  const [season, setSeason] = useState(null);
+  const [dates, setDates] = useState(null);
+  const [readyToPublish, setReadyToPublish] = useState(false);
+  const [notes, setNotes] = useState("");
+
+  const validation = useValidation(dates, notes, season);
+
+  const { data, loading, error } = useApiGet(`/seasons/${seasonId}`);
+
+  useEffect(() => {
+    if (data) {
+      const currentSeasonDates = {};
+
+      data.campgrounds.forEach((campground) => {
+        campground.features.forEach((feature) => {
+          currentSeasonDates[feature.dateable.id] = {
+            Operation: [],
+            Reservation: [],
+          };
+          feature.dateable.currentSeasonDates.forEach((dateRange) => {
+            currentSeasonDates[feature.dateable.id][
+              dateRange.dateType.name
+            ].push({
+              ...dateRange,
+              dateableId: feature.dateable.id,
+              inputType: "text",
+              changed: false,
+            });
+          });
+        });
+      });
+
+      data.features.forEach((feature) => {
+        currentSeasonDates[feature.dateable.id] = {
+          Operation: [],
+          Reservation: [],
+        };
+        feature.dateable.currentSeasonDates.forEach((dateRange) => {
+          currentSeasonDates[feature.dateable.id][dateRange.dateType.name].push(
+            {
+              ...dateRange,
+              dateableId: feature.dateable.id,
+              inputType: "text",
+              changed: false,
+            },
+          );
+        });
+      });
+
+      setSeason(data);
+      setDates(currentSeasonDates);
+      setReadyToPublish(data.readyToPublish);
+    }
+  }, [data]);
+
+  // Navigates to a new route and scrolls to the top of the page
+  function navigateAndScroll(to) {
+    navigate(to);
+    window.scrollTo(0, 0);
+  }
+
+  if (loading || !season) {
+    return (
+      <div className="container">
+        <LoadingBar />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="container">
+        <p>Error loading season data: {error.message}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <p>debug</p>
+      <p>validation.isValid: {validation.isValid ? "Y" : "N"}</p>
+      <p>validation errors:</p>
+      <pre>{JSON.stringify(validation.errors)}</pre>
+
+      <hr></hr>
+
+      <Outlet
+        context={{
+          parkId,
+          seasonId,
+          season,
+          dates,
+          setDates,
+          notes,
+          setNotes,
+          readyToPublish,
+          setReadyToPublish,
+          validation,
+          navigate,
+          navigateAndScroll,
+        }}
+      />
+    </div>
+  );
+}

--- a/frontend/src/router/pages/SeasonPage.jsx
+++ b/frontend/src/router/pages/SeasonPage.jsx
@@ -92,30 +92,21 @@ export default function SeasonPage() {
   }
 
   return (
-    <div>
-      <p>debug</p>
-      <p>validation.isValid: {validation.isValid ? "Y" : "N"}</p>
-      <p>validation errors:</p>
-      <pre>{JSON.stringify(validation.errors)}</pre>
-
-      <hr></hr>
-
-      <Outlet
-        context={{
-          parkId,
-          seasonId,
-          season,
-          dates,
-          setDates,
-          notes,
-          setNotes,
-          readyToPublish,
-          setReadyToPublish,
-          validation,
-          navigate,
-          navigateAndScroll,
-        }}
-      />
-    </div>
+    <Outlet
+      context={{
+        parkId,
+        seasonId,
+        season,
+        dates,
+        setDates,
+        notes,
+        setNotes,
+        readyToPublish,
+        setReadyToPublish,
+        validation,
+        navigate,
+        navigateAndScroll,
+      }}
+    />
   );
 }

--- a/frontend/src/router/pages/SeasonPage.jsx
+++ b/frontend/src/router/pages/SeasonPage.jsx
@@ -246,6 +246,7 @@ export default function SeasonPage() {
           navigateAndScroll,
           setDeletedDateRangeIds,
           saveAsDraft,
+          saveChanges,
           showErrorFlash,
           hasChanges,
           saving,

--- a/frontend/src/router/pages/SeasonPage.jsx
+++ b/frontend/src/router/pages/SeasonPage.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { Outlet, useNavigate, useParams } from "react-router-dom";
 
+import paths from "@/router/paths";
 import { useApiGet } from "@/hooks/useApi";
 import useValidation from "@/hooks/useValidation";
 
@@ -75,6 +76,36 @@ export default function SeasonPage() {
     window.scrollTo(0, 0);
   }
 
+  async function saveAsDraft(saveFunction, openConfirmation, showErrorFlash) {
+    try {
+      if (["pending review", "approved", "on API"].includes(season.status)) {
+        const confirm = await openConfirmation(
+          "Move back to draft?",
+          "The dates will be moved back to draft and need to be submitted again to be reviewed.",
+          "Move to draft",
+          "Cancel",
+          "If dates have already been published, they will not be updated until new dates are submitted, approved, and published.",
+        );
+
+        if (!confirm) return;
+      }
+
+      await saveFunction();
+
+      navigate(`${paths.park(parkId)}?saved=${seasonId}`);
+    } catch (err) {
+      console.error(err);
+
+      if (err instanceof validation.ValidationError) {
+        // @TODO: Handle validation errors
+        console.error(validation.errors);
+      } else {
+        // Show a flash message for fatal server errors
+        showErrorFlash();
+      }
+    }
+  }
+
   if (loading || !season) {
     return (
       <div className="container">
@@ -106,6 +137,7 @@ export default function SeasonPage() {
         validation,
         navigate,
         navigateAndScroll,
+        saveAsDraft,
       }}
     />
   );

--- a/frontend/src/router/pages/SeasonPage.jsx
+++ b/frontend/src/router/pages/SeasonPage.jsx
@@ -36,7 +36,6 @@ export default function SeasonPage() {
   const { data, loading, error } = useApiGet(`/seasons/${seasonId}`);
 
   const { sendData, loading: saving } = useApiPost(
-    // @TODO: refactor too
     `/seasons/${seasonId}/save/`,
   );
 

--- a/frontend/src/router/pages/SubmitDates.jsx
+++ b/frontend/src/router/pages/SubmitDates.jsx
@@ -800,7 +800,7 @@ function SubmitDates() {
             type="button"
             className="btn btn-primary"
             onClick={continueToPreview}
-            disabled={!hasChanges() && !continueToPreviewEnabled}
+            disabled={!continueToPreviewEnabled}
           >
             Continue to preview
           </button>

--- a/frontend/src/router/pages/SubmitDates.jsx
+++ b/frontend/src/router/pages/SubmitDates.jsx
@@ -53,8 +53,13 @@ function SubmitDates() {
   const { errors, formSubmitted, validateForm, ValidationError } = validation;
 
   const continueToPreviewEnabled = useMemo(() => {
+    // Form must be loaded
     if (!dates) return false;
 
+    // Form must be valid
+    if (!validation.isValid) return false;
+
+    // All date ranges must have start and end dates
     return (
       Object.values(dates).every((dateType) =>
         dateType.Operation?.concat(dateType.Reservation).every(
@@ -62,7 +67,7 @@ function SubmitDates() {
         ),
       ) && season?.status === "requested"
     );
-  }, [dates, season]);
+  }, [dates, season, validation.isValid]);
 
   async function continueToPreview() {
     try {

--- a/frontend/src/router/pages/SubmitDates.jsx
+++ b/frontend/src/router/pages/SubmitDates.jsx
@@ -57,13 +57,7 @@ function SubmitDates() {
 
   const errorFlashMessage = useFlashMessage();
 
-  const {
-    errors,
-    formSubmitted,
-    validateNotes,
-    validateForm,
-    ValidationError,
-  } = validation;
+  const { errors, formSubmitted, validateForm, ValidationError } = validation;
 
   const {
     title,
@@ -749,7 +743,6 @@ function SubmitDates() {
                 value={notes}
                 onChange={(ev) => {
                   setNotes(ev.target.value);
-                  validateNotes(ev.target.value);
                 }}
               ></textarea>
 

--- a/frontend/src/router/pages/SubmitWinterFeesDates.jsx
+++ b/frontend/src/router/pages/SubmitWinterFeesDates.jsx
@@ -20,12 +20,6 @@ import FeatureIcon from "@/components/FeatureIcon";
 import ChangeLogsList from "@/components/ChangeLogsList";
 import ContactBox from "@/components/ContactBox";
 import ReadyToPublishBox from "@/components/ReadyToPublishBox";
-import ConfirmationDialog from "@/components/ConfirmationDialog";
-import FlashMessage from "@/components/FlashMessage";
-
-import { useConfirmation } from "@/hooks/useConfirmation";
-import { useNavigationGuard } from "@/hooks/useNavigationGuard";
-import { useFlashMessage } from "@/hooks/useFlashMessage";
 
 import {
   formatDateRange,
@@ -413,31 +407,8 @@ export default function SubmitWinterFeesDates() {
     hasChanges,
   } = useOutletContext();
 
-  const errorFlashMessage = useFlashMessage();
-
-  const {
-    title,
-    message,
-    confirmButtonText,
-    cancelButtonText,
-    confirmationDialogNotes,
-    openConfirmation,
-    handleConfirm,
-    handleCancel,
-    isConfirmationOpen,
-  } = useConfirmation();
-
   // @TODO: Implement validation
   const errors = {};
-
-  useNavigationGuard(hasChanges, openConfirmation); // @TODO: refactor
-
-  function showErrorFlash() {
-    errorFlashMessage.openFlashMessage(
-      "Unable to save changes",
-      "There was a problem saving these changes. Please try again.",
-    );
-  }
 
   const continueToPreviewEnabled = useMemo(() => {
     if (!dates) return false;
@@ -458,25 +429,6 @@ export default function SubmitWinterFeesDates() {
 
   return (
     <div className="page submit-winter-fees-dates">
-      <FlashMessage
-        title={errorFlashMessage.flashTitle}
-        message={errorFlashMessage.flashMessage}
-        isVisible={errorFlashMessage.isFlashOpen}
-        onClose={errorFlashMessage.handleFlashClose}
-        variant="error"
-      />
-
-      <ConfirmationDialog
-        title={title}
-        message={message}
-        confirmButtonText={confirmButtonText}
-        cancelButtonText={cancelButtonText}
-        notes={confirmationDialogNotes}
-        onCancel={handleCancel}
-        onConfirm={handleConfirm}
-        isOpen={isConfirmationOpen}
-      />
-
       <div className="container">
         <NavBack routePath={paths.park(parkId)}>
           Back to {season.park.name} dates
@@ -569,7 +521,7 @@ export default function SubmitWinterFeesDates() {
           <button
             type="button"
             className="btn btn-outline-primary"
-            onClick={() => saveAsDraft(openConfirmation, showErrorFlash)}
+            onClick={saveAsDraft}
             disabled={!hasChanges()}
           >
             Save draft

--- a/frontend/src/router/pages/SubmitWinterFeesDates.jsx
+++ b/frontend/src/router/pages/SubmitWinterFeesDates.jsx
@@ -411,8 +411,12 @@ export default function SubmitWinterFeesDates() {
   const errors = {};
 
   const continueToPreviewEnabled = useMemo(() => {
+    // Form must be loaded
     if (!dates) return false;
 
+    // @TODO: Validate form too
+
+    // All date ranges must have start and end dates
     return (
       Object.values(dates).every((dateRanges) =>
         dateRanges.every(

--- a/frontend/src/router/pages/SubmitWinterFeesDates.jsx
+++ b/frontend/src/router/pages/SubmitWinterFeesDates.jsx
@@ -1,5 +1,5 @@
-import { useEffect, useState, createContext, useContext, useMemo } from "react";
-import { useParams, useNavigate, Link } from "react-router-dom";
+import { useState, useMemo } from "react";
+import { Link, useOutletContext } from "react-router-dom";
 import PropTypes from "prop-types";
 import classNames from "classnames";
 import cloneDeep from "lodash/cloneDeep";
@@ -17,7 +17,6 @@ import "react-datepicker/dist/react-datepicker.css";
 
 import TooltipWrapper from "@/components/TooltipWrapper";
 import NavBack from "@/components/NavBack";
-import LoadingBar from "@/components/LoadingBar";
 import FeatureIcon from "@/components/FeatureIcon";
 import ChangeLogsList from "@/components/ChangeLogsList";
 import ContactBox from "@/components/ContactBox";
@@ -25,7 +24,7 @@ import ReadyToPublishBox from "@/components/ReadyToPublishBox";
 import ConfirmationDialog from "@/components/ConfirmationDialog";
 import FlashMessage from "@/components/FlashMessage";
 
-import { useApiGet, useApiPost } from "@/hooks/useApi";
+import { useApiPost } from "@/hooks/useApi";
 import { useConfirmation } from "@/hooks/useConfirmation";
 import { useNavigationGuard } from "@/hooks/useNavigationGuard";
 import { useFlashMessage } from "@/hooks/useFlashMessage";
@@ -39,12 +38,6 @@ import paths from "@/router/paths";
 
 import "./SubmitWinterFeesDates.scss";
 
-// Context to provide dates to all the child components
-const datesContext = createContext();
-
-// Context to provide the data to all the child components
-const dataContext = createContext();
-
 function DateRange({
   dateableId,
   dateRange,
@@ -52,7 +45,7 @@ function DateRange({
   updateDateRange,
   removeDateRange,
 }) {
-  const data = useContext(dataContext);
+  const { season } = useOutletContext();
 
   // Keep local state until the field is blurred or Enter is pressed
   const [localDateRange, setLocalDateRange] = useState(dateRange);
@@ -105,8 +98,8 @@ function DateRange({
   const endErrors = false;
 
   // Limit the date range: Jan 1 - Dec 31 of the following year
-  const minDate = new Date(data.operatingYear, 0, 1);
-  const maxDate = new Date(data.operatingYear + 1, 11, 31);
+  const minDate = new Date(season.operatingYear, 0, 1);
+  const maxDate = new Date(season.operatingYear + 1, 11, 31);
 
   // Open the calendar to Jan 1 of the operating year if no date is set
   const openDateStart = parseInputDate(localDateRange.startDate) || minDate;
@@ -265,13 +258,13 @@ function getReservationDatesText(featureData) {
 }
 
 function CampgroundFeature({ featureData }) {
-  // Inject dates object from the root component
-  const { dates, setDates, setDeletedDateRangeIds } = useContext(datesContext);
+  // Get DateType info for the tooltip from the API data
+  const { season, dates, setDates, setDeletedDateRangeIds } =
+    useOutletContext();
   const dateableId = featureData.dateableId;
   const featureDates = dates[dateableId];
 
-  // Get DateType info for the tooltip from the API data
-  const { winterFeeDateType } = useContext(dataContext);
+  const winterFeeDateType = season.winterFeeDateType;
 
   function addDateRange() {
     setDates((prevDates) => {
@@ -407,17 +400,19 @@ function FeatureType({ featureTypeData }) {
 }
 
 export default function SubmitWinterFeesDates() {
-  const parkId = Number(useParams().parkId);
-  const seasonId = Number(useParams().seasonId);
-
-  const [season, setSeason] = useState(null);
-  const [dates, setDates] = useState({});
-  const [notes, setNotes] = useState("");
-  const [readyToPublish, setReadyToPublish] = useState(false);
-  // Track deleted date ranges
-  const [deletedDateRangeIds, setDeletedDateRangeIds] = useState([]);
-
-  const { data, loading, error } = useApiGet(`/winter-fees/${seasonId}`);
+  const {
+    parkId,
+    seasonId,
+    season,
+    dates,
+    notes,
+    setNotes,
+    readyToPublish,
+    setReadyToPublish,
+    navigateAndScroll,
+    deletedDateRangeIds,
+    saveAsDraft,
+  } = useOutletContext();
 
   const { sendData, loading: saving } = useApiPost(
     `/seasons/${seasonId}/save/`,
@@ -437,14 +432,8 @@ export default function SubmitWinterFeesDates() {
     isConfirmationOpen,
   } = useConfirmation();
 
-  const navigate = useNavigate();
-
   // @TODO: Implement validation
   const errors = {};
-
-  class ValidationError extends Error {}
-
-  function validateNotes() {}
 
   // Returns true if there are any form changes to save
   function hasChanges() {
@@ -461,7 +450,7 @@ export default function SubmitWinterFeesDates() {
     if (deletedDateRangeIds.length > 0) return true;
 
     // Ready to publish state has changed
-    if (readyToPublish !== data.readyToPublish) return true;
+    if (readyToPublish !== season.readyToPublish) return true;
 
     // Notes have been entered
     return notes;
@@ -469,7 +458,7 @@ export default function SubmitWinterFeesDates() {
 
   useNavigationGuard(hasChanges, openConfirmation);
 
-  async function saveChanges(savingDraft) {
+  async function saveChanges() {
     // @TODO: Validate form state before saving
 
     // Turn the `dates` structure into a flat array of date ranges
@@ -508,33 +497,7 @@ export default function SubmitWinterFeesDates() {
 
     const response = await sendData(payload);
 
-    if (savingDraft) {
-      navigate(`${paths.park(parkId)}?saved=${data.id}`);
-    }
-
     return response;
-  }
-
-  async function submitChanges(savingDraft = false) {
-    if (["pending review", "approved", "on API"].includes(season.status)) {
-      const confirm = await openConfirmation(
-        "Move back to draft?",
-        "The dates will be moved back to draft and need to be submitted again to be reviewed.",
-        "Move to draft",
-        "Cancel",
-        "If dates have already been published, they will not be updated until new dates are submitted, approved, and published.",
-      );
-
-      if (confirm) {
-        await saveChanges(savingDraft);
-        return true;
-      }
-    } else {
-      await saveChanges(savingDraft);
-      return true;
-    }
-
-    return false;
   }
 
   function showErrorFlash() {
@@ -542,22 +505,6 @@ export default function SubmitWinterFeesDates() {
       "Unable to save changes",
       "There was a problem saving these changes. Please try again.",
     );
-  }
-
-  async function saveAsDraft() {
-    try {
-      await submitChanges(true);
-    } catch (err) {
-      console.error(err);
-
-      if (err instanceof ValidationError) {
-        // @TODO: Handle validation errors
-        console.error(errors);
-      } else {
-        // Show a flash message for fatal server errors
-        showErrorFlash();
-      }
-    }
   }
 
   const continueToPreviewEnabled = useMemo(() => {
@@ -573,63 +520,8 @@ export default function SubmitWinterFeesDates() {
   }, [dates, season]);
 
   async function continueToPreview() {
-    try {
-      if (hasChanges()) {
-        const submitOk = await submitChanges();
-
-        if (submitOk) {
-          navigate(paths.winterFeesPreview(parkId, seasonId));
-        }
-      } else {
-        navigate(paths.winterFeesPreview(parkId, seasonId));
-      }
-    } catch (err) {
-      console.error(err);
-
-      if (err instanceof ValidationError) {
-        // @TODO: Handle validation errors
-        console.error(errors);
-      } else {
-        // Show a flash message for fatal server errors
-        showErrorFlash();
-      }
-    }
-  }
-
-  useEffect(() => {
-    if (!data) return;
-
-    // Format the data for the page state: flatten the features
-    const dateEntries = data.featureTypes.flatMap((featureType) =>
-      // Create object entries with the dateable ID and date ranges
-      featureType.features.map((feature) => [
-        feature.dateableId,
-        feature.currentWinterDates,
-      ]),
-    );
-
-    // Group by dateable IDs
-    const dateableGroups = Object.fromEntries(dateEntries);
-
-    setSeason(data);
-    setDates(dateableGroups);
-    setReadyToPublish(data.readyToPublish);
-  }, [data]);
-
-  if (loading || !season) {
-    return (
-      <div className="container">
-        <LoadingBar />
-      </div>
-    );
-  }
-
-  if (error) {
-    return (
-      <div className="container">
-        <p>Error loading season data: {error.message}</p>
-      </div>
-    );
+    // @TODO: Validate winter fees edit form
+    navigateAndScroll(paths.winterFeesPreview(parkId, seasonId));
   }
 
   return (
@@ -677,15 +569,9 @@ export default function SubmitWinterFeesDates() {
       </div>
 
       <div className="mb-5">
-        <dataContext.Provider value={data}>
-          <datesContext.Provider
-            value={{ dates, setDates, setDeletedDateRangeIds }}
-          >
-            {season.featureTypes.map((featureType) => (
-              <FeatureType key={featureType.id} featureTypeData={featureType} />
-            ))}
-          </datesContext.Provider>
-        </dataContext.Provider>
+        {season.featureTypes.map((featureType) => (
+          <FeatureType key={featureType.id} featureTypeData={featureType} />
+        ))}
       </div>
 
       <div className="container">
@@ -719,7 +605,6 @@ export default function SubmitWinterFeesDates() {
                 value={notes}
                 onChange={(ev) => {
                   setNotes(ev.target.value);
-                  validateNotes(ev.target.value);
                 }}
               ></textarea>
 
@@ -752,7 +637,9 @@ export default function SubmitWinterFeesDates() {
           <button
             type="button"
             className="btn btn-outline-primary"
-            onClick={saveAsDraft}
+            onClick={() =>
+              saveAsDraft(saveChanges, openConfirmation, showErrorFlash)
+            }
             disabled={!hasChanges()}
           >
             Save draft
@@ -764,7 +651,7 @@ export default function SubmitWinterFeesDates() {
             onClick={continueToPreview}
             disabled={!hasChanges() && !continueToPreviewEnabled}
           >
-            Save and continue to preview
+            Continue to preview
           </button>
 
           {saving && (

--- a/frontend/src/router/pages/WinterFeesSeasonPage.jsx
+++ b/frontend/src/router/pages/WinterFeesSeasonPage.jsx
@@ -212,6 +212,7 @@ export default function WinterFeesSeasonPage() {
           navigateAndScroll,
           setDeletedDateRangeIds,
           saveAsDraft,
+          saveChanges,
           saving,
           hasChanges,
           showErrorFlash,

--- a/frontend/src/router/pages/WinterFeesSeasonPage.jsx
+++ b/frontend/src/router/pages/WinterFeesSeasonPage.jsx
@@ -1,0 +1,115 @@
+import { useEffect, useState } from "react";
+import { Outlet, useNavigate, useParams } from "react-router-dom";
+
+import paths from "@/router/paths";
+import { useApiGet } from "@/hooks/useApi";
+
+import LoadingBar from "@/components/LoadingBar";
+
+export default function WinterFeesSeasonPage() {
+  // Render the SubmitWinterFeesDates (edit form) or PreviewWinterFeesChanges
+  // (read-only) component based on the current route.
+  // Provide the same date to either route and allow switching back and forth.
+
+  const { parkId, seasonId } = useParams();
+  const navigate = useNavigate();
+
+  const [season, setSeason] = useState(null);
+  const [dates, setDates] = useState(null);
+  const [readyToPublish, setReadyToPublish] = useState(false);
+  const [notes, setNotes] = useState("");
+
+  // Track deleted date ranges
+  const [deletedDateRangeIds, setDeletedDateRangeIds] = useState([]);
+
+  const { data, loading, error } = useApiGet(`/winter-fees/${seasonId}`);
+
+  useEffect(() => {
+    if (!data) return;
+
+    // Format the data for the page state: flatten the features
+    const dateEntries = data.featureTypes.flatMap((featureType) =>
+      // Create object entries with the dateable ID and date ranges
+      featureType.features.map((feature) => [
+        feature.dateableId,
+        feature.currentWinterDates,
+      ]),
+    );
+
+    // Group by dateable IDs
+    const dateableGroups = Object.fromEntries(dateEntries);
+
+    setSeason(data);
+    setDates(dateableGroups);
+    setReadyToPublish(data.readyToPublish);
+  }, [data]);
+
+  // Navigates to a new route and scrolls to the top of the page
+  function navigateAndScroll(to) {
+    navigate(to);
+    window.scrollTo(0, 0);
+  }
+
+  async function saveAsDraft(saveFunction, openConfirmation, showErrorFlash) {
+    try {
+      if (["pending review", "approved", "on API"].includes(season.status)) {
+        const confirm = await openConfirmation(
+          "Move back to draft?",
+          "The dates will be moved back to draft and need to be submitted again to be reviewed.",
+          "Move to draft",
+          "Cancel",
+          "If dates have already been published, they will not be updated until new dates are submitted, approved, and published.",
+        );
+
+        if (!confirm) return;
+      }
+
+      await saveFunction();
+      navigate(`${paths.park(parkId)}?saved=${seasonId}`);
+    } catch (err) {
+      console.error(err);
+
+      // @TODO: Handle validation errors
+
+      // Show a flash message for fatal server errors
+      showErrorFlash();
+    }
+  }
+
+  if (loading || !season) {
+    return (
+      <div className="container">
+        <LoadingBar />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="container">
+        <p>Error loading season data: {error.message}</p>
+      </div>
+    );
+  }
+
+  return (
+    <Outlet
+      context={{
+        parkId,
+        seasonId,
+        season,
+        dates,
+        setDates,
+        notes,
+        setNotes,
+        readyToPublish,
+        setReadyToPublish,
+        navigate,
+        navigateAndScroll,
+        deletedDateRangeIds,
+        setDeletedDateRangeIds,
+        saveAsDraft,
+      }}
+    />
+  );
+}

--- a/frontend/src/router/paths.js
+++ b/frontend/src/router/paths.js
@@ -4,22 +4,38 @@ function park(id) {
   return `/parks/${id}`;
 }
 
+function season(parkId, seasonId) {
+  return `${park(parkId)}/seasons/${seasonId}`;
+}
+
+function edit(rootPath) {
+  return `${rootPath}/edit`;
+}
+
+function preview(rootPath) {
+  return `${rootPath}/preview`;
+}
+
 export default {
   park,
+  season,
+
+  edit,
+  preview,
 
   seasonEdit(parkId, seasonId) {
-    return `${park(parkId)}/seasons/${seasonId}/edit`;
+    return edit(season(parkId, seasonId));
   },
 
   seasonPreview(parkId, seasonId) {
-    return `${park(parkId)}/seasons/${seasonId}/preview`;
+    return preview(season(parkId, seasonId));
   },
 
   winterFeesEdit(parkId, seasonId) {
-    return `${park(parkId)}/winter-fees/${seasonId}/edit`;
+    return edit(`${park(parkId)}/winter-fees/${seasonId}`);
   },
 
   winterFeesPreview(parkId, seasonId) {
-    return `${park(parkId)}/winter-fees/${seasonId}/preview`;
+    return preview(`${park(parkId)}/winter-fees/${seasonId}`);
   },
 };

--- a/frontend/src/router/paths.js
+++ b/frontend/src/router/paths.js
@@ -20,6 +20,10 @@ function preview(rootPath) {
   return `${rootPath}/preview`;
 }
 
+function review(rootPath) {
+  return `${rootPath}/review`;
+}
+
 export default {
   park,
   season,
@@ -36,11 +40,19 @@ export default {
     return preview(season(parkId, seasonId));
   },
 
+  seasonReview(parkId, seasonId) {
+    return review(season(parkId, seasonId));
+  },
+
   winterFeesEdit(parkId, seasonId) {
     return edit(winterFeesSeason(parkId, seasonId));
   },
 
   winterFeesPreview(parkId, seasonId) {
     return preview(winterFeesSeason(parkId, seasonId));
+  },
+
+  winterFeesReview(parkId, seasonId) {
+    return review(winterFeesSeason(parkId, seasonId));
   },
 };

--- a/frontend/src/router/paths.js
+++ b/frontend/src/router/paths.js
@@ -8,6 +8,10 @@ function season(parkId, seasonId) {
   return `${park(parkId)}/seasons/${seasonId}`;
 }
 
+function winterFeesSeason(parkId, seasonId) {
+  return `${park(parkId)}/winter-fees/${seasonId}`;
+}
+
 function edit(rootPath) {
   return `${rootPath}/edit`;
 }
@@ -19,6 +23,7 @@ function preview(rootPath) {
 export default {
   park,
   season,
+  winterFeesSeason,
 
   edit,
   preview,
@@ -32,10 +37,10 @@ export default {
   },
 
   winterFeesEdit(parkId, seasonId) {
-    return edit(`${park(parkId)}/winter-fees/${seasonId}`);
+    return edit(winterFeesSeason(parkId, seasonId));
   },
 
   winterFeesPreview(parkId, seasonId) {
-    return preview(`${park(parkId)}/winter-fees/${seasonId}`);
+    return preview(winterFeesSeason(parkId, seasonId));
   },
 };


### PR DESCRIPTION
### Jira Ticket

CMS-577

### Description
<!-- What did you change, and why? -->

A pretty huge branch. The main goal here is to add the "Review" page, but it involved a lot of fundamental changes to the editing and approval flow:
- Display and work with the live data edited in the browser, instead of just reading the saved data from the API
- Re-think how and where the data is validated
- The button on the Park details page for approvers now says Review and goes to the new Review page (instead of Preview). 
- The Review page re-uses the Preview page component with a prop `review=true` that simply changes some heading text, and the buttons at the bottom. Otherwise it's the same as the Preview page.

I refactored the Edit and Preview pages (for normal and winter seasons) to be sub routes of a "Season" page component. They share a lot of logic, so that's being provided via the outlet context. The "Season" route currently doesn't show anything, and it's not linked to anywhere, but maybe we should redirect to the edit page or the park page in that case?
