### PR TITLE
CMS-482: Add helm charts for training environment

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -73,6 +73,12 @@ helm -n a7dd13-dev install alpha . -f values-alpha-dev.yaml
 helm -n a7dd13-test install alpha . -f values-alpha-test.yaml
 ```
 
+### Training (for RSOs and POs)
+
+```sh
+helm -n a7dd13-test install training . -f values-training.yaml
+```
+
 ### Create the Postgres user and db
 
 If this is the first time deploying the app then you will also need to create a Postgres user and an empty database.
@@ -134,6 +140,12 @@ helm -n a7dd13-dev upgrade alpha . -f values-alpha-dev.yaml
 helm -n a7dd13-test upgrade alpha . -f values-alpha-test.yaml
 ```
 
+### Training
+
+```sh
+helm -n a7dd13-test upgrade training . -f values-training.yaml
+```
+
 ## Teardown
 
 The `uninstall` command ca be used to remove all resources defined by the Helm chart. Please note that secrets and PVCs created by the Helm chart are not automatically removed.
@@ -170,4 +182,10 @@ helm -n a7dd13-dev uninstall alpha
 
 ```sh
 helm -n a7dd13-test uninstall alpha
+```
+
+### Training
+
+```sh
+helm -n a7dd13-test uninstall training
 ```

--- a/helm/crunchy-postgres/README.md
+++ b/helm/crunchy-postgres/README.md
@@ -24,6 +24,9 @@ helm -n a7dd13-test install crunchy . -f values-test.yaml
 
 # alpha test:
 helm -n a7dd13-test install crunchy-alpha . -f values-alpha-test.yaml
+
+# training: (a third test environment, for RSOs and POs)
+helm -n a7dd13-test install crunchy-training . -f values-training.yaml
 ```
 
 ### Prod
@@ -74,6 +77,9 @@ helm -n a7dd13-test upgrade crunchy . -f values-test.yaml
 
 # alpha-test:
 helm -n a7dd13-test upgrade crunchy-alpha . -f values-alpha-test.yaml
+
+# training: (a third test environment, for RSOs and POs)
+helm -n a7dd13-test upgrade crunchy-training . -f values-training.yaml
 ```
 
 ### Prod

--- a/helm/crunchy-postgres/values-training.yaml
+++ b/helm/crunchy-postgres/values-training.yaml
@@ -1,0 +1,137 @@
+fullnameOverride: crunchy-postgres-training
+
+crunchyImage: # it's not necessary to specify an image as the images specified in the Crunchy Postgres Operator will be pulled by default
+#crunchyImage: artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-postgres-gis:ubi8-15.2-3.3-0 # use this image for POSTGIS
+postgresVersion: 15
+#postGISVersion: '3.3' # use this version of POSTGIS. both crunchyImage and this property needs to have valid values for POSTGIS to be enabled.
+imagePullPolicy: IfNotPresent
+
+# enable to bootstrap a standby cluster from backup. Then disable to promote this standby to primary
+standby:
+  enabled: false
+  # If you want to recover from PVC, use repo1. If you want to recover from S3, use repo2
+  repoName: repo2
+
+instances:
+  name: ha # high availability
+  replicas: 1
+  dataVolumeClaimSpec:
+    storage: 2Gi
+    storageClassName: netapp-block-standard
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    cpu: 400m
+    memory: 512Mi
+  replicaCertCopy:
+    requests:
+      cpu: 1m
+      memory: 32Mi
+    limits:
+      cpu: 50m
+      memory: 64Mi
+
+# If we need to restore the cluster from a backup, we need to set the following values
+# assuming restore from repo2 (s3), adjust as needed if your S3 repo is different
+dataSource:
+  enabled: false
+  # should have the same name and contain the same keys as the pgbackrest secret
+  secretName: s3-pgbackrest
+  repo:
+    name: repo2
+    path: "/habackup"
+    s3:
+      bucket: "bucketName"
+      endpoint: "s3.ca-central-1.amazonaws.com"
+      region: "ca-central-1"
+    stanza: db
+
+pgBackRest:
+  image: # it's not necessary to specify an image as the images specified in the Crunchy Postgres Operator will be pulled by default
+  retention: "2" # Ideally a larger number such as 30 backups/days
+  # If retention-full-type set to 'count' then the oldest backups will expire when the number of backups reach the number defined in retention
+  # If retention-full-type set to 'time' then the number defined in retention will take that many days worth of full backups before expiration
+  retentionFullType: count
+  repos:
+    schedules:
+      full: 0 8 * * *
+      incremental: 0 0,4,12,16,20 * * *
+    volume:
+      accessModes: "ReadWriteOnce"
+      storage: 1Gi
+      storageClassName: netapp-file-backup
+  repoHost:
+    requests:
+      cpu: 1m
+      memory: 64Mi
+    limits:
+      cpu: 50m
+      memory: 128Mi
+  sidecars:
+    requests:
+      cpu: 1m
+      memory: 64Mi
+    limits:
+      cpu: 50m
+      memory: 128Mi
+  s3:
+    enabled: false
+    createS3Secret: true
+    # the s3 secret name
+    s3Secret: s3-pgbackrest
+    # the path start with /, it will be created under bucket if it doesn't exist
+    s3Path: "/habackup"
+    # s3UriStyle is host or path
+    s3UriStyle: path
+    # bucket specifies the S3 bucket to use,
+    bucket: "bucketName"
+    # endpoint specifies the S3 endpoint to use.
+    endpoint: "endpointName"
+    # region specifies the S3 region to use. If your S3 storage system does not
+    # use "region", fill this in with a random value.
+    region: "ca-central-1"
+    # key is the S3 key. This is stored in a Secret.
+    # Please DO NOT push this value to GitHub
+    key: "s3keyValue"
+    # keySecret is the S3 key secret. This is stored in a Secret.
+    # Please DO NOT push this value to GitHub
+    keySecret: "s3SecretValue"
+    # setting the below to be one plus of the default schedule
+    # to avoid conflicts
+    fullSchedule: "0 9 * * *"
+    incrementalSchedule: "0 1,5,13,17,21 * * *"
+
+patroni:
+  postgresql:
+    pg_hba: "host all all 0.0.0.0/0 md5"
+    parameters:
+      shared_buffers: 16MB # default is 128MB; a good tuned default for shared_buffers is 25% of the memory allocated to the pod
+      wal_buffers: "64kB" # this can be set to -1 to automatically set as 1/32 of shared_buffers or 64kB, whichever is larger
+      min_wal_size: 32MB
+      max_wal_size: 64MB # default is 1GB
+      max_slot_wal_keep_size: 128MB # default is -1, allowing unlimited wal growth when replicas fall behind
+
+proxy:
+  pgBouncer:
+    image: # it's not necessary to specify an image as the images specified in the Crunchy Postgres Operator will be pulled by default
+    replicas: 1
+    requests:
+      cpu: 1m
+      memory: 64Mi
+    limits:
+      cpu: 50m
+      memory: 128Mi
+
+# Postgres Cluster resource values:
+pgmonitor:
+  enabled: false
+  namespace: a7dd13 #The high level namespace of your project without the -tools -dev, etc part.
+  exporter:
+    image: # it's not necessary to specify an image as the images specified in the Crunchy Postgres Operator will be pulled by default
+    requests:
+      cpu: 1m
+      memory: 64Mi
+    limits:
+      cpu: 50m
+      memory: 128Mi

--- a/helm/deployment/values-training.yaml
+++ b/helm/deployment/values-training.yaml
@@ -1,0 +1,20 @@
+cluster:
+  ssoAuthUrl: https://test.loginproxy.gov.bc.ca/auth
+  cmsUrl: https://test-cms.bcparks.ca
+
+images:
+  frontend:
+    tag: test
+  backend:
+    tag: test
+
+frontend:
+  env:
+    externalUrl: https://training-staff.bcparks.ca
+    publicUrl: https://test.bcparks.ca
+
+backend:
+  env:
+    externalUrl: https://training-staff-api.bcparks.ca
+    devTestMode: "true"
+  postgresSecret: crunchy-postgres-training-pguser-postgres


### PR DESCRIPTION
### Jira Ticket

CMS-482

### Description
<!-- What did you change, and why? -->

Adding a new environment to the `test` namespace for training RSOs and POs. This is kind of a mix of the `test` and `alpha-test` environments:
- Same deployment specs as `alpha-test` - 1 DB replica, no cloud backups, same RAM/CPU
- Pulls from the `alpha-test` Strapi API - Still confirming that this is correct
- Builds from the `test` tag so it will deploy the same image as the one used for UAT