### PR TITLE
CMS-625: Scroll to sections on edit page

### DIFF
--- a/frontend/src/router/pages/PreviewChanges.jsx
+++ b/frontend/src/router/pages/PreviewChanges.jsx
@@ -39,9 +39,19 @@ function PreviewChanges({ review = false }) {
     saving,
   } = useOutletContext();
 
-  const navigateToEdit = useCallback(() => {
-    navigateAndScroll(paths.seasonEdit(parkId, seasonId));
-  }, [parkId, seasonId, navigateAndScroll]);
+  const navigateToEdit = useCallback(
+    (anchor = null) => {
+      let anchorId;
+
+      // If the anchor is provided, scroll to the specific date type
+      if (anchor?.dateType && anchor?.featureId) {
+        anchorId = `${anchor.dateType}-dates-${anchor.featureId}`;
+      }
+
+      navigateAndScroll(paths.seasonEdit(parkId, seasonId), anchorId);
+    },
+    [parkId, seasonId, navigateAndScroll],
+  );
 
   // Set formSubmitted to trigger full validation
   validation.formSubmitted.current = true;
@@ -246,7 +256,12 @@ function PreviewChanges({ review = false }) {
                 <td>{getCurrentSeasonDates(feature, "Operation")}</td>
                 <td>
                   <button
-                    onClick={navigateToEdit}
+                    onClick={() =>
+                      navigateToEdit({
+                        dateType: "Operation",
+                        featureId: feature.id,
+                      })
+                    }
                     className="btn btn-text text-primary"
                   >
                     <FontAwesomeIcon
@@ -265,7 +280,12 @@ function PreviewChanges({ review = false }) {
                   <td>{getCurrentSeasonDates(feature, "Reservation")}</td>
                   <td>
                     <button
-                      onClick={navigateToEdit}
+                      onClick={() =>
+                        navigateToEdit({
+                          dateType: "Reservation",
+                          featureId: feature.id,
+                        })
+                      }
                       className="btn btn-text text-primary"
                     >
                       <FontAwesomeIcon

--- a/frontend/src/router/pages/SeasonPage.jsx
+++ b/frontend/src/router/pages/SeasonPage.jsx
@@ -85,10 +85,25 @@ export default function SeasonPage() {
     }
   }, [data]);
 
-  // Navigates to a new route and scrolls to the top of the page
-  function navigateAndScroll(to) {
-    navigate(to);
-    window.scrollTo(0, 0);
+  // Navigates to a new route and scrolls to an anchor, or the top of the page
+  function navigateAndScroll(to, anchorId) {
+    navigate({
+      pathname: to,
+      hash: anchorId && `#${anchorId}`,
+    });
+
+    if (anchorId) {
+      // Wait for the component to render before scrolling
+      setTimeout(() => {
+        const anchor = document.getElementById(anchorId);
+
+        // Scroll to the anchor, if it exists
+        anchor?.scrollIntoView();
+      }, 150);
+    } else {
+      // Scroll to the top of the page
+      window.scrollTo(0, 0);
+    }
   }
 
   async function saveChanges() {

--- a/frontend/src/router/pages/SubmitDates.jsx
+++ b/frontend/src/router/pages/SubmitDates.jsx
@@ -451,7 +451,7 @@ function SubmitDates() {
         {feature.name && <h4 className="feature-name mb-4">{feature.name}</h4>}
         <div className="row">
           <div className="col-md-6">
-            <div>
+            <div id={`Operation-dates-${feature.id}`}>
               <span className="me-1">Operating dates</span>
               {season?.dateTypes?.Operation?.description && (
                 <TooltipWrapper
@@ -489,7 +489,7 @@ function SubmitDates() {
 
           {feature.hasReservations && (
             <div className="col-md-6">
-              <div>
+              <div id={`Reservation-dates-${feature.id}`}>
                 <span className="me-1">Reservation dates</span>
                 {season?.dateTypes?.Reservation?.description && (
                   <TooltipWrapper
@@ -544,6 +544,7 @@ function SubmitDates() {
 
   Feature.propTypes = {
     feature: PropTypes.shape({
+      id: PropTypes.number.isRequired,
       name: PropTypes.string.isRequired,
       dateable: PropTypes.shape({
         id: PropTypes.number.isRequired,


### PR DESCRIPTION
### Jira Ticket

CMS-625

### Description
<!-- What did you change, and why? -->

Added the ability to specify an anchor ID in `navigateAndScroll` to go to that anchor instead of the top of the page. Clicking the "edit" links for a specific feature and date on the Preview page will take you to that section of the Edit page.

The entire page re-renders and the child component states are all reset whenever the data changes 😭 so I couldn't think of a cleaner way to do this and had to resort to using a setTimeout. I hope we can improve this in the future.