### PR TITLE
CMS-633: Add flag icon to "Ready to publish" text

### DIFF
--- a/frontend/src/components/ReadyToPublishBox.jsx
+++ b/frontend/src/components/ReadyToPublishBox.jsx
@@ -1,4 +1,6 @@
 import PropTypes from "prop-types";
+import { faFlag } from "@awesome.me/kit-c1c3245051/icons/classic/solid";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 export default function ReadyToPublishBox({
   readyToPublish,
@@ -10,9 +12,12 @@ export default function ReadyToPublishBox({
 
       <p>
         Are these dates ready to be made available to the public the next time
-        dates are published? When turned off, they will be flagged and held in
-        the ‘Approved’ state until it is marked ‘Ready to publish’. Approved
-        dates are included in exported files.
+        dates are published? When turned off, they will be flagged{" "}
+        <span className="text-nowrap">
+          (<FontAwesomeIcon className="text-danger mx-1" icon={faFlag} />)
+        </span>{" "}
+        and held in the ‘Approved’ state until it is marked ‘Ready to publish’.
+        Approved dates are included in exported files.
       </p>
 
       <div className="form-check form-switch">


### PR DESCRIPTION
### Jira Ticket

CMS-633

### Description
<!-- What did you change, and why? -->

A small change to add a flag icon to the text in the "Ready to publish" section of the Edit/Preview pages