### PR TITLE
CMS-655: Replace lodash with lodash-es, simplify imports

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,7 +19,7 @@
         "date-fns": "^4.1.0",
         "date-fns-tz": "^3.2.0",
         "file-saver": "^2.0.5",
-        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21",
         "oidc-client-ts": "^3.1.0",
         "prop-types": "^15.8.1",
         "react": "^18.3.1",
@@ -4032,10 +4032,10 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/lodash": {
+    "node_modules/lodash-es": {
       "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
       "license": "MIT"
     },
     "node_modules/lodash.merge": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,7 +21,7 @@
     "date-fns": "^4.1.0",
     "date-fns-tz": "^3.2.0",
     "file-saver": "^2.0.5",
-    "lodash": "^4.17.21",
+    "lodash-es": "^4.17.21",
     "oidc-client-ts": "^3.1.0",
     "prop-types": "^15.8.1",
     "react": "^18.3.1",

--- a/frontend/src/components/PaginationBar.jsx
+++ b/frontend/src/components/PaginationBar.jsx
@@ -1,5 +1,5 @@
 import classNames from "classnames";
-import range from "lodash/range";
+import { range } from "lodash-es";
 import PropTypes from "prop-types";
 
 export default function PaginationBar({

--- a/frontend/src/components/ParkDetailsSeasonDates.jsx
+++ b/frontend/src/components/ParkDetailsSeasonDates.jsx
@@ -1,5 +1,4 @@
-import groupBy from "lodash/groupBy";
-import orderBy from "lodash/orderBy";
+import { groupBy, orderBy } from "lodash-es";
 import PropTypes from "prop-types";
 import DateRange from "@/components/DateRange";
 import ChangeLogsList from "@/components/ChangeLogsList.jsx";

--- a/frontend/src/hooks/useValidation.js
+++ b/frontend/src/hooks/useValidation.js
@@ -1,5 +1,5 @@
 import { useEffect, useState, useCallback, useMemo, useRef } from "react";
-import { omit, mapValues, minBy, maxBy, orderBy } from "lodash";
+import { omit, mapValues, minBy, maxBy, orderBy } from "lodash-es";
 import { differenceInCalendarDays, parseISO, isBefore, max } from "date-fns";
 
 // Returns a chronological list of date ranges with overlapping ranges combined

--- a/frontend/src/router/pages/EditAndReview.jsx
+++ b/frontend/src/router/pages/EditAndReview.jsx
@@ -5,7 +5,7 @@ import EditAndReviewTable from "@/components/EditAndReviewTable";
 import LoadingBar from "@/components/LoadingBar";
 import MultiSelect from "@/components/MultiSelect";
 import { useMemo, useState } from "react";
-import orderBy from "lodash/orderBy";
+import { orderBy } from "lodash-es";
 import PaginationBar from "@/components/PaginationBar";
 
 function EditAndReview() {

--- a/frontend/src/router/pages/SeasonPage.jsx
+++ b/frontend/src/router/pages/SeasonPage.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { Outlet, useNavigate, useParams } from "react-router-dom";
-import omit from "lodash/omit";
+import { omit } from "lodash-es";
 
 import paths from "@/router/paths";
 import { useApiGet, useApiPost } from "@/hooks/useApi";

--- a/frontend/src/router/pages/SubmitDates.jsx
+++ b/frontend/src/router/pages/SubmitDates.jsx
@@ -1,6 +1,6 @@
 import { Link, useOutletContext } from "react-router-dom";
 import { useState, useMemo } from "react";
-import { cloneDeep, set as lodashSet } from "lodash";
+import { cloneDeep, set as lodashSet } from "lodash-es";
 import {
   faCalendarCheck,
   faCircleInfo,

--- a/frontend/src/router/pages/SubmitWinterFeesDates.jsx
+++ b/frontend/src/router/pages/SubmitWinterFeesDates.jsx
@@ -2,7 +2,7 @@ import { useState, useMemo } from "react";
 import { Link, useOutletContext } from "react-router-dom";
 import PropTypes from "prop-types";
 import classNames from "classnames";
-import cloneDeep from "lodash/cloneDeep";
+import { cloneDeep } from "lodash-es";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
   faCalendarCheck,

--- a/frontend/src/router/pages/WinterFeesSeasonPage.jsx
+++ b/frontend/src/router/pages/WinterFeesSeasonPage.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { Outlet, useNavigate, useParams } from "react-router-dom";
-import omit from "lodash/omit";
+import { omit } from "lodash-es";
 
 import paths from "@/router/paths";
 import { useApiGet, useApiPost } from "@/hooks/useApi";


### PR DESCRIPTION
### Jira Ticket

CMS-655

### Description
<!-- What did you change, and why? -->

Swapped out the 686KB `lodash` package for the tree-shakable `lodash-es`. Now it's only 123KB in the bundle, accounting for just 6.68% of the total app size, where it was 28.1% before.

I also simplified the imports, because now they can be tree-shaken. Importing submodules makes no difference to the bundle size.