### PR TITLE
CMS-637: Add submitter role, "Pending review" state

### DIFF
--- a/frontend/src/components/ParkDetailsSeason.jsx
+++ b/frontend/src/components/ParkDetailsSeason.jsx
@@ -15,6 +15,7 @@ import FlashMessage from "@/components/FlashMessage";
 
 import { useConfirmation } from "@/hooks/useConfirmation";
 import { useFlashMessage } from "@/hooks/useFlashMessage";
+import useAccess from "@/hooks/useAccess";
 
 export default function ParkSeason({
   season,
@@ -25,6 +26,7 @@ export default function ParkSeason({
   DetailsComponent,
 }) {
   const { parkId } = useParams();
+  const { ROLES, checkAccess } = useAccess();
 
   const navigate = useNavigate();
 
@@ -73,10 +75,14 @@ export default function ParkSeason({
     setExpanded(!expanded);
   }
 
-  // @TODO: implement logic to show/hide preview button
-  const showReviewButton = true;
+  // Show/hide preview button based on the user roles
+  const showReviewButton = useMemo(
+    () => checkAccess(ROLES.APPROVER),
+    [checkAccess, ROLES.APPROVER],
+  );
 
-  // @TODO: implement logic to disable preview button
+  // Disable preview button based on the season status
+  // Only allow review if the status is "pending review"
   const disableReviewButton = useMemo(
     () => season.status !== "pending review",
     [season.status],

--- a/frontend/src/components/StatusBadge.jsx
+++ b/frontend/src/components/StatusBadge.jsx
@@ -13,9 +13,13 @@ export default function StatusBadge({ status }) {
 
   // Map status code to color class and display label
   const statusMap = new Map([
-    ["on API", { cssClass: "text-bg-primary", displayText: "on API" }],
+    ["on API", { cssClass: "text-bg-primary", displayText: "On API" }],
     ["approved", { cssClass: "text-bg-success", displayText: "Approved" }],
     ["requested", { cssClass: "text-bg-warning", displayText: "Requested" }],
+    [
+      "pending review",
+      { cssClass: "text-bg-dark", displayText: "Pending review" },
+    ],
     [
       "Not provided",
       { cssClass: "text-bg-disabled", displayText: "Not provided" },

--- a/frontend/src/config/permissions.js
+++ b/frontend/src/config/permissions.js
@@ -4,6 +4,7 @@
 export const ROLES = {
   SUPER_ADMIN: "doot-super-admin",
   APPROVER: "doot-approver",
+  SUBMITTER: "doot-submitter",
   RSO: "doot-rso",
   PO: "doot-po",
 };

--- a/frontend/src/hooks/useNavigationGuard.js
+++ b/frontend/src/hooks/useNavigationGuard.js
@@ -14,7 +14,8 @@ export function useNavigationGuard(hasChanges, openConfirmation) {
       nextPath.includes("/preview") ||
       nextPath.includes("/edit") ||
       queryString.has("approved") ||
-      queryString.has("saved")
+      queryString.has("saved") ||
+      queryString.has("submitted")
     ) {
       return false;
     }

--- a/frontend/src/router/layouts/LandingPageTabs.jsx
+++ b/frontend/src/router/layouts/LandingPageTabs.jsx
@@ -24,11 +24,13 @@ export default function LandingPageTabs() {
                 Edit{approver && " and review"}
               </NavLink>
             </li>
-            <li className="nav-item">
-              <NavLink className="nav-link" to="/publish">
-                Publish
-              </NavLink>
-            </li>
+            {approver && (
+              <li className="nav-item">
+                <NavLink className="nav-link" to="/publish">
+                  Publish
+                </NavLink>
+              </li>
+            )}
             <li className="nav-item">
               <NavLink className="nav-link" to="/export">
                 Export

--- a/frontend/src/router/layouts/LandingPageTabs.jsx
+++ b/frontend/src/router/layouts/LandingPageTabs.jsx
@@ -1,7 +1,17 @@
+import { useMemo } from "react";
 import { Outlet, NavLink } from "react-router-dom";
+import useAccess from "@/hooks/useAccess";
 import "./LandingPageTabs.scss";
 
 export default function LandingPageTabs() {
+  const { ROLES, checkAccess } = useAccess();
+
+  // Check if the user has permission to approve the season
+  const approver = useMemo(
+    () => checkAccess(ROLES.APPROVER),
+    [checkAccess, ROLES.APPROVER],
+  );
+
   return (
     <div className="layout landing-page-tabs">
       <header className="section-tabs d-flex flex-column">
@@ -11,7 +21,7 @@ export default function LandingPageTabs() {
           <ul className="nav nav-tabs px-2">
             <li className="nav-item">
               <NavLink className="nav-link" to="/">
-                Edit and review
+                Edit{approver && " and review"}
               </NavLink>
             </li>
             <li className="nav-item">

--- a/frontend/src/router/pages/ParkDetails.jsx
+++ b/frontend/src/router/pages/ParkDetails.jsx
@@ -31,6 +31,7 @@ function ParkDetails() {
 
     const approvedSeasonId = searchParams.get("approved");
     const savedSeasonId = searchParams.get("saved");
+    const submittedSeasonId = searchParams.get("submitted");
 
     let seasonId = null;
 
@@ -38,6 +39,8 @@ function ParkDetails() {
       seasonId = approvedSeasonId;
     } else if (savedSeasonId !== null) {
       seasonId = savedSeasonId;
+    } else if (submittedSeasonId !== null) {
+      seasonId = submittedSeasonId;
     }
 
     if (!park || seasonId === null) return;
@@ -46,6 +49,7 @@ function ParkDetails() {
     // Remove the query string so the flash message won't show again
     searchParams.delete("approved");
     searchParams.delete("saved");
+    searchParams.delete("submitted");
     setSearchParams(searchParams, { replace: true });
 
     // Find the season in the park data by its ID

--- a/frontend/src/router/pages/PreviewChanges.jsx
+++ b/frontend/src/router/pages/PreviewChanges.jsx
@@ -424,10 +424,12 @@ function PreviewChanges({ review = false }) {
 
             <ContactBox />
 
-            <ReadyToPublishBox
-              readyToPublish={readyToPublish}
-              setReadyToPublish={setReadyToPublish}
-            />
+            {approver && (
+              <ReadyToPublishBox
+                readyToPublish={readyToPublish}
+                setReadyToPublish={setReadyToPublish}
+              />
+            )}
 
             {validation.isValid === false && (
               <div

--- a/frontend/src/router/pages/PreviewWinterFeesChanges.jsx
+++ b/frontend/src/router/pages/PreviewWinterFeesChanges.jsx
@@ -316,10 +316,12 @@ function PreviewChanges({ review = false }) {
 
             <ContactBox />
 
-            <ReadyToPublishBox
-              readyToPublish={readyToPublish}
-              setReadyToPublish={setReadyToPublish}
-            />
+            {approver && (
+              <ReadyToPublishBox
+                readyToPublish={readyToPublish}
+                setReadyToPublish={setReadyToPublish}
+              />
+            )}
           </div>
         </div>
 

--- a/frontend/src/router/pages/PreviewWinterFeesChanges.jsx
+++ b/frontend/src/router/pages/PreviewWinterFeesChanges.jsx
@@ -1,8 +1,9 @@
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 import PropTypes from "prop-types";
 import { useOutletContext } from "react-router-dom";
 import { useApiPost } from "@/hooks/useApi";
 import { useMissingDatesConfirmation } from "@/hooks/useMissingDatesConfirmation";
+import useAccess from "@/hooks/useAccess";
 import paths from "@/router/paths";
 
 import { faPen } from "@fa-kit/icons/classic/solid";
@@ -37,6 +38,14 @@ function PreviewChanges({ review = false }) {
     saving,
   } = useOutletContext();
 
+ const { ROLES, checkAccess } = useAccess();
+
+  // Check if the user has permission to approve the season
+  const approver = useMemo(
+    () => checkAccess(ROLES.APPROVER),
+    [checkAccess, ROLES.APPROVER],
+  );
+
   const navigateToEdit = useCallback(
     (anchor = null) => {
       let anchorId;
@@ -53,6 +62,10 @@ function PreviewChanges({ review = false }) {
 
   const { sendData: approveData, loading: savingApproval } = useApiPost(
     `/seasons/${seasonId}/approve/`,
+  );
+
+  const { sendData: submitData, loading: sendingSubmit } = useApiPost(
+    `/seasons/${seasonId}/submit-for-approval/`,
   );
 
   const missingDatesConfirmation = useMissingDatesConfirmation();
@@ -108,8 +121,13 @@ function PreviewChanges({ review = false }) {
     navigateAndScroll(paths.winterFeesEdit(parkId, seasonId));
   }
 
-  // Saves and approves the changes
-  async function approve() {
+  /**
+   * Saves and sends the data to the API with the given POST function.
+   * @param {Function} postFunction Function to call to POST the data.
+   * @param {string|Object} redirectTo Router `to` object or string to redirect to.
+   * @returns {Promise<void>}
+   */
+  async function saveAndPost(postFunction, redirectTo) {
     const featuresWithMissingDates = getFeaturesWithMissingDates();
 
     try {
@@ -125,7 +143,7 @@ function PreviewChanges({ review = false }) {
           );
 
         if (confirm) {
-          await approveData({
+          await postFunction({
             notes: [confirmationMessage],
             readyToPublish,
           });
@@ -133,22 +151,38 @@ function PreviewChanges({ review = false }) {
           missingDatesConfirmation.setInputMessage("");
           // Redirect back to the Park Details page on success.
           // Use the "approved" query param to show a flash message.
-          navigate(`${paths.park(parkId)}?approved=${seasonId}`);
+          navigate(redirectTo);
         }
       } else {
-        await approveData({
+        await postFunction({
           notes: [], // Notes were saved with saveChanges,
           readyToPublish,
         });
         // Redirect back to the Park Details page on success.
         // Use the "approved" query param to show a flash message.
-        navigate(`${paths.park(parkId)}?approved=${seasonId}`);
+        navigate(redirectTo);
       }
     } catch (err) {
       console.error("Error approving preview", err);
 
       showErrorFlash();
     }
+  }
+
+  // Saves and approves the changes
+  async function approve() {
+    return saveAndPost(approveData, {
+      pathname: paths.park(parkId),
+      search: `?approved=${seasonId}`,
+    });
+  }
+
+  // Saves and submits the changes for review
+  async function submitForApproval() {
+    return saveAndPost(submitData, {
+      pathname: paths.park(parkId),
+      search: `?submitted=${seasonId}`,
+    });
   }
 
   function Feature({ feature }) {
@@ -307,11 +341,23 @@ function PreviewChanges({ review = false }) {
             Save draft
           </button>
 
-          <button type="button" className="btn btn-primary" onClick={approve}>
-            Mark approved
-          </button>
+          {approver && (
+            <button type="button" className="btn btn-primary" onClick={approve}>
+              Mark approved
+            </button>
+          )}
 
-          {(saving || savingApproval) && (
+          {!approver && (
+            <button
+              type="button"
+              className="btn btn-primary"
+              onClick={submitForApproval}
+            >
+              Submit for approval
+            </button>
+          )}
+
+          {(saving || savingApproval || sendingSubmit) && (
             <span
               className="spinner-border text-primary align-self-center me-2"
               aria-hidden="true"

--- a/frontend/src/router/pages/SubmitDates.jsx
+++ b/frontend/src/router/pages/SubmitDates.jsx
@@ -26,6 +26,7 @@ import {
   normalizeToUTCDate,
   normalizeToLocalDate,
 } from "@/lib/utils";
+import useAccess from "@/hooks/useAccess";
 import paths from "@/router/paths";
 
 import "./SubmitDates.scss";
@@ -49,6 +50,14 @@ function SubmitDates() {
     hasChanges,
     saving,
   } = useOutletContext();
+
+  const { ROLES, checkAccess } = useAccess();
+
+  // Check if the user has permission to approve the season
+  const approver = useMemo(
+    () => checkAccess(ROLES.APPROVER),
+    [checkAccess, ROLES.APPROVER],
+  );
 
   const { errors, formSubmitted, validateForm, ValidationError } = validation;
 
@@ -648,10 +657,12 @@ function SubmitDates() {
 
             <ContactBox />
 
-            <ReadyToPublishBox
-              readyToPublish={readyToPublish}
-              setReadyToPublish={setReadyToPublish}
-            />
+            {approver && (
+              <ReadyToPublishBox
+                readyToPublish={readyToPublish}
+                setReadyToPublish={setReadyToPublish}
+              />
+            )}
 
             {validation.isValid === false && (
               <div

--- a/frontend/src/router/pages/SubmitWinterFeesDates.jsx
+++ b/frontend/src/router/pages/SubmitWinterFeesDates.jsx
@@ -26,6 +26,7 @@ import {
   normalizeToUTCDate,
   normalizeToLocalDate,
 } from "@/lib/utils";
+import useAccess from "@/hooks/useAccess";
 import paths from "@/router/paths";
 
 import "./SubmitWinterFeesDates.scss";
@@ -410,6 +411,14 @@ export default function SubmitWinterFeesDates() {
     hasChanges,
   } = useOutletContext();
 
+  const { ROLES, checkAccess } = useAccess();
+
+  // Check if the user has permission to approve the season
+  const approver = useMemo(
+    () => checkAccess(ROLES.APPROVER),
+    [checkAccess, ROLES.APPROVER],
+  );
+
   // @TODO: Implement validation
   const errors = {};
 
@@ -509,10 +518,12 @@ export default function SubmitWinterFeesDates() {
 
             <ContactBox />
 
-            <ReadyToPublishBox
-              readyToPublish={readyToPublish}
-              setReadyToPublish={setReadyToPublish}
-            />
+            {approver && (
+              <ReadyToPublishBox
+                readyToPublish={readyToPublish}
+                setReadyToPublish={setReadyToPublish}
+              />
+            )}
           </div>
         </div>
 


### PR DESCRIPTION
### Jira Ticket

CMS-637

### Description
<!-- What did you change, and why? -->

This branch adds the "DOOT Submitter" user role. If a user has a "doot-submitter" role (and not a "doot-approver" or "doot-super-admin") they will see a few different elements in the UI:
- Removed buttons and wording for "Review" 
- Removed the "Approve" button and added a "Submit for approval" button
- Added a backend endpoint for the button above, which changes the season's status to "pending review" - mostly copied from the "approve" endpoint.
- On the frontend, we had a method to "save and approve" and we needed to add "save and submit" so I refactored them both to use "save and POST" and share most of their code.

Instead of specifically checking if the user is a submitter, the logic actually checks if the user _is not an approver_. There will be roles for RSOs and POs in the future, and it makes more sense to check for the approver role and show extra stuff, rather than check for the submitter role and selectively hide things. It's easier to make sense of the logic if we don't assume everyone is an approver, I think.