### PR TITLE
CMS-759: Memoize hasChanges

### DIFF
--- a/frontend/src/hooks/useNavigationGuard.js
+++ b/frontend/src/hooks/useNavigationGuard.js
@@ -18,7 +18,7 @@ export function useNavigationGuard(hasChanges, openConfirmation) {
     ) {
       return false;
     }
-    return hasChanges();
+    return hasChanges;
   });
 
   useEffect(() => {
@@ -44,7 +44,7 @@ export function useNavigationGuard(hasChanges, openConfirmation) {
 
   const handleBeforeUnload = useCallback(
     async (e) => {
-      if (hasChanges()) {
+      if (hasChanges) {
         e.preventDefault();
       }
     },

--- a/frontend/src/router/pages/PreviewChanges.jsx
+++ b/frontend/src/router/pages/PreviewChanges.jsx
@@ -184,7 +184,7 @@ function PreviewChanges({ review = false }) {
 
     try {
       // Save changes first, if necessary
-      if (hasChanges()) {
+      if (hasChanges) {
         await saveChanges();
       }
 
@@ -423,7 +423,7 @@ function PreviewChanges({ review = false }) {
             type="button"
             className="btn btn-outline-primary"
             onClick={saveAsDraft}
-            disabled={!hasChanges()}
+            disabled={!hasChanges}
           >
             Save draft
           </button>

--- a/frontend/src/router/pages/PreviewWinterFeesChanges.jsx
+++ b/frontend/src/router/pages/PreviewWinterFeesChanges.jsx
@@ -114,7 +114,7 @@ function PreviewChanges({ review = false }) {
 
     try {
       // Save changes first, if necessary
-      if (hasChanges()) {
+      if (hasChanges) {
         await saveChanges();
       }
 
@@ -302,7 +302,7 @@ function PreviewChanges({ review = false }) {
             type="button"
             className="btn btn-outline-primary"
             onClick={saveAsDraft}
-            disabled={!hasChanges()}
+            disabled={!hasChanges}
           >
             Save draft
           </button>

--- a/frontend/src/router/pages/SeasonPage.jsx
+++ b/frontend/src/router/pages/SeasonPage.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Outlet, useNavigate, useParams } from "react-router-dom";
 import { omit } from "lodash-es";
 
@@ -182,7 +182,7 @@ export default function SeasonPage() {
   }
 
   // Returns true if there are any form changes to save
-  function hasChanges() {
+  const hasChanges = useMemo(() => {
     if (!dates) return false;
 
     // Any existing dates changed
@@ -204,7 +204,7 @@ export default function SeasonPage() {
 
     // Notes have been entered
     return notes;
-  }
+  }, [dates, deletedDateRangeIds.length, notes, readyToPublish, season]);
 
   useNavigationGuard(hasChanges, confirmationDialog.openConfirmation);
 

--- a/frontend/src/router/pages/SubmitDates.jsx
+++ b/frontend/src/router/pages/SubmitDates.jsx
@@ -681,7 +681,7 @@ function SubmitDates() {
             type="button"
             className="btn btn-outline-primary"
             onClick={saveAsDraft}
-            disabled={!hasChanges()}
+            disabled={!hasChanges}
           >
             Save draft
           </button>

--- a/frontend/src/router/pages/SubmitWinterFeesDates.jsx
+++ b/frontend/src/router/pages/SubmitWinterFeesDates.jsx
@@ -529,7 +529,7 @@ export default function SubmitWinterFeesDates() {
             type="button"
             className="btn btn-outline-primary"
             onClick={saveAsDraft}
-            disabled={!hasChanges()}
+            disabled={!hasChanges}
           >
             Save draft
           </button>

--- a/frontend/src/router/pages/WinterFeesSeasonPage.jsx
+++ b/frontend/src/router/pages/WinterFeesSeasonPage.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Outlet, useNavigate, useParams } from "react-router-dom";
 import { omit } from "lodash-es";
 
@@ -153,7 +153,9 @@ export default function WinterFeesSeasonPage() {
   }
 
   // Returns true if there are any form changes to save
-  function hasChanges() {
+  const hasChanges = useMemo(() => {
+    if (!dates) return false;
+
     // Any existing dates changed
     if (
       Object.values(dates).some((dateRanges) =>
@@ -171,7 +173,7 @@ export default function WinterFeesSeasonPage() {
 
     // Notes have been entered
     return notes;
-  }
+  }, [dates, deletedDateRangeIds.length, notes, readyToPublish, season]);
 
   useNavigationGuard(hasChanges, confirmationDialog.openConfirmation);
 


### PR DESCRIPTION
### Jira Ticket

CMS-759

### Description
<!-- What did you change, and why? -->

This is a small change to turn the `hasChanges` function into a `useMemo` hook. I didn't think of it when I initially wrote that code. 😅  Hopefully it will cut down on unnecessary re-renders, or at least make the code a bit more maintainable. 

It's the same changes in the regular seasons and the winter seasons.