### PR TITLE
CMS-753: Migrate date range to park-feature-dates collection

### DIFF
--- a/backend/strapi-sync/new-structure-migration.js
+++ b/backend/strapi-sync/new-structure-migration.js
@@ -9,17 +9,15 @@ import {
 import { post } from "../routes/api/strapi-api.js";
 
 // This will only need to run once to migrate the dates from the old structure to the new structure in Strapi
-// This will only migrate the Winter fee date type including the admin notes for each date range
 
 async function getDatesToSend() {
   const dateRanges = await DateRange.findAll({
-    attributes: ["startDate", "endDate"],
+    attributes: ["startDate", "endDate", "adminNote"],
     include: [
       {
         model: DateType,
         as: "dateType",
         attributes: ["name"],
-        where: { name: "Winter fee" },
       },
       {
         model: Dateable,


### PR DESCRIPTION
### Jira Ticket
CMS-753

### Description
- Migrate `adminNote` from `park-operation-sub-area-date` to `dateRange`
    - In `dateRange`, `adminNote` wasn't migrated so that needed to update sync.js and re-import Strapi data
    - Remove `attributes` from `park-operation-sub-area` data and `park-operation-sub-area-date` data in sync.js
    - ^ No longer nested structure in `park-operation-sub-area` and `park-operation-sub-area-date` since this change https://github.com/bcgov/bcparks.ca/pull/1598
- Migrate all `dateRange` data to `park-feature-date`
   - In park-feature-date 2641, in date ranges 3010, according to Diego, it's because we won’t import any date that is inactive or that belongs to an inactive subare