### PR TITLE
CMS-606: Transform date strings in useApi

### DIFF
--- a/frontend/src/components/DateRange.jsx
+++ b/frontend/src/components/DateRange.jsx
@@ -31,7 +31,7 @@ export default function DateRange({ start, end, formatWithYear = false }) {
 }
 
 DateRange.propTypes = {
-  start: PropTypes.string,
-  end: PropTypes.string,
+  start: PropTypes.instanceOf(Date),
+  end: PropTypes.instanceOf(Date),
   formatWithYear: PropTypes.bool,
 };

--- a/frontend/src/components/ParkDetailsSeason.jsx
+++ b/frontend/src/components/ParkDetailsSeason.jsx
@@ -216,7 +216,7 @@ ParkSeason.propTypes = {
     id: PropTypes.number.isRequired,
     operatingYear: PropTypes.number.isRequired,
     status: PropTypes.string.isRequired,
-    updatedAt: PropTypes.string,
+    updatedAt: PropTypes.instanceOf(Date),
     editable: PropTypes.bool.isRequired,
     readyToPublish: PropTypes.bool.isRequired,
   }),

--- a/frontend/src/components/ParkDetailsSeasonDates.jsx
+++ b/frontend/src/components/ParkDetailsSeasonDates.jsx
@@ -96,8 +96,8 @@ export default function SeasonDates({ data }) {
 // prop validation
 const dateRangePropShape = PropTypes.shape({
   id: PropTypes.number.isRequired,
-  startDate: PropTypes.string,
-  endDate: PropTypes.string,
+  startDate: PropTypes.instanceOf(Date),
+  endDate: PropTypes.instanceOf(Date),
   dateType: PropTypes.shape({
     name: PropTypes.string.isRequired,
   }).isRequired,

--- a/frontend/src/components/ParkDetailsWinterFeesDates.jsx
+++ b/frontend/src/components/ParkDetailsWinterFeesDates.jsx
@@ -77,8 +77,8 @@ DateTypeRow.propTypes = {
   dateRanges: PropTypes.arrayOf(
     PropTypes.shape({
       id: PropTypes.number.isRequired,
-      startDate: PropTypes.string.isRequired,
-      endDate: PropTypes.string.isRequired,
+      startDate: PropTypes.instanceOf(Date).isRequired,
+      endDate: PropTypes.instanceOf(Date).isRequired,
     }),
   ).isRequired,
 };

--- a/frontend/src/lib/utils.js
+++ b/frontend/src/lib/utils.js
@@ -1,4 +1,3 @@
-import { parseISO, formatISO } from "date-fns";
 import { formatInTimeZone } from "date-fns-tz";
 
 // Month, day, year
@@ -43,30 +42,16 @@ export function normalizeToLocalDate(dateObject) {
   );
 }
 
-/**
- * Formats an ISO date string into a human-readable string
- * @param {string} isoString ISO date string
- * @param {string} formatString date-fns formatting string
- * @param {string} timezone timezone to format the date in
- * @returns {string} The formatted date string
- */
-function isoToFormattedString(isoString, formatString, timezone = "UTC") {
-  if (!isoString) return "";
-
-  const date = parseISO(isoString);
-
-  return formatInTimeZone(date, timezone, formatString);
-}
-
 export function formatDate(date, timezone = "UTC") {
-  return isoToFormattedString(date, DATE_FORMAT_DEFAULT, timezone);
+  return formatInTimeZone(date, timezone, DATE_FORMAT_DEFAULT);
 }
 
-export function formatDateShort(date) {
-  return isoToFormattedString(date, DATE_FORMAT_SHORT);
+export function formatDateShort(date, timezone = "UTC") {
+  return formatInTimeZone(date, timezone, DATE_FORMAT_SHORT);
 }
-export function formatDateShortWithYear(date) {
-  return isoToFormattedString(date, DATE_FORMAT_SHORT_WITH_YEAR);
+
+export function formatDateShortWithYear(date, timezone = "UTC") {
+  return formatInTimeZone(date, timezone, DATE_FORMAT_SHORT_WITH_YEAR);
 }
 
 /**
@@ -79,22 +64,10 @@ export function formatDateRange(dateRange) {
     return "Not submitted";
   }
 
-  const startDate = isoToFormattedString(
-    dateRange.startDate,
-    DATE_FORMAT_SHORT_WITH_YEAR,
-  );
-  const endDate = isoToFormattedString(
-    dateRange.endDate,
-    DATE_FORMAT_SHORT_WITH_YEAR,
-  );
+  const startDate = formatDateShortWithYear(dateRange.startDate);
+  const endDate = formatDateShortWithYear(dateRange.endDate);
 
   return `${startDate} – ${endDate}`;
-}
-
-export function formatDatetoISO(date) {
-  if (!date) return "";
-
-  return formatISO(date, { representation: "date" });
 }
 
 // used to properly compare paths


### PR DESCRIPTION
### Jira Ticket

CMS-606

### Description
<!-- What did you change, and why? -->

We currently convert between date strings and date objects in several places when dates are stored or manipulated. This branch transforms all dates to date objects when the data is loaded (in the Axios instance) and then the dates are objects for the whole lifecycle of the app until they're sent back to the API. This will reduce complexity where we had to convert formats (and in some cases, time zones).

The changes involve mostly removing places where ISO date strings are parsed, and overall it simplifies things a bit. 

A future change we could make would be to store the date ranges as DATEONLY types in the db, so they wouldn't have the hour part and suffer from time-zone complications. But that can happen later on if we decide it will be helpful.