### PR TITLE
CMS-634: Add portal nav menus

### DIFF
--- a/frontend-legacy/src/components/composite/responsiveDrawer/responsiveDrawer.js
+++ b/frontend-legacy/src/components/composite/responsiveDrawer/responsiveDrawer.js
@@ -19,6 +19,12 @@ const ResponsiveDrawer = ({ handleTabChange }) => {
   };
 
   const handleClick = (item) => {
+    // If the item has a href, navigate to that URL
+    if (item.href) {
+      window.location.href = item.href;
+      return;
+    }
+
     handleTabChange(null, item.value);
     setMobileOpen(false);
   };
@@ -26,8 +32,9 @@ const ResponsiveDrawer = ({ handleTabChange }) => {
   const items = [
     { "value": 0, "text": "Advisories" },
     { "value": 1, "text": "Park Access Status" },
-    { "value": 2, "text": "Activities & Facilities" }
-  ]
+    { "value": 2, "text": "Activities & Facilities" },
+    { "value": 3, "text": "Dates of Operation", "href": "/v2/" },
+  ];
 
   const drawer = (
     <div>

--- a/frontend-legacy/src/components/page/appDashboard/AppDashboard.css
+++ b/frontend-legacy/src/components/page/appDashboard/AppDashboard.css
@@ -25,6 +25,11 @@
   overflow: visible !important;
 }
 
+/* External link tabs should still inherit parent colors, not link colors */
+.app-tabs .external-link.MuiTab-textColorInherit {
+  color: inherit !important;
+}
+
 .app-tab .MuiTab-wrapper {
   font-weight: bold !important;
   align-items: unset !important;

--- a/frontend-legacy/src/components/page/appDashboard/AppDashboard.js
+++ b/frontend-legacy/src/components/page/appDashboard/AppDashboard.js
@@ -76,6 +76,12 @@ export default function AppDashboard({
                 {...a11yProps(2, "dashboard-tab")}
               />
             )}
+            <Tab
+              className="external-link"
+              label="Dates of Operation"
+              component="a"
+              href="/v2/"
+            />
           </Tabs>
           <TabPanel value={tabIndex} index={0} label="dashboard">
             <AdvisoryDashboard page={{ setError, cmsData, setCmsData }} />

--- a/frontend/src/components/NavSidebar.jsx
+++ b/frontend/src/components/NavSidebar.jsx
@@ -1,0 +1,51 @@
+import { Link } from "react-router-dom";
+import classNames from "classnames";
+import "./NavSidebar.scss";
+
+const navItems = [
+  {
+    label: "Advisories",
+    Tag: "a",
+    href: "/advisories",
+  },
+  {
+    label: "Park Access Status",
+    Tag: "a",
+    href: "/park-access-status",
+  },
+  {
+    label: "Activities & Facilities",
+    Tag: "a",
+    href: "/activities-and-facilities",
+  },
+  {
+    label: "Dates of Operation",
+    Tag: Link,
+    to: "/",
+    // This menu only displays on DOOT right now,
+    // so Dates of Operation is always the active item.
+    active: true,
+  },
+];
+
+export default function NavSidebar() {
+  return (
+    <aside id="portal-nav-sidebar" className="collapse d-lg-block">
+      <ul className="nav nav-pills flex-column mb-auto">
+        {navItems.map(({ Tag, label, active, ...itemProps }) => (
+          <li key={label} className="nav-item">
+            {/* Use "a" for external links and Router Link components for internal links */}
+            <Tag
+              className={classNames("nav-link text-truncate", {
+                active,
+              })}
+              {...itemProps}
+            >
+              {label}
+            </Tag>
+          </li>
+        ))}
+      </ul>
+    </aside>
+  );
+}

--- a/frontend/src/components/NavSidebar.jsx
+++ b/frontend/src/components/NavSidebar.jsx
@@ -31,7 +31,7 @@ const navItems = [
 export default function NavSidebar() {
   return (
     <aside id="portal-nav-sidebar" className="collapse d-lg-block">
-      <ul className="nav nav-pills flex-column mb-auto">
+      <ul className="nav flex-column mb-auto">
         {navItems.map(({ Tag, label, active, ...itemProps }) => (
           <li key={label} className="nav-item">
             {/* Use "a" for external links and Router Link components for internal links */}

--- a/frontend/src/components/NavSidebar.scss
+++ b/frontend/src/components/NavSidebar.scss
@@ -1,6 +1,6 @@
 #portal-nav-sidebar {
   background: var(--theme-gray-10);
-  width: clamp(15em, 20%, 20em);
+  width: clamp(18em, 20%, 20em);
   padding: 1.5rem 1rem;
   position: sticky;
   top: 0;

--- a/frontend/src/components/NavSidebar.scss
+++ b/frontend/src/components/NavSidebar.scss
@@ -1,13 +1,28 @@
 #portal-nav-sidebar {
-  background: var(--theme-gray-10);
-  width: clamp(18em, 20%, 20em);
-  padding: 1.5rem 1rem;
+  background: var(--theme-gray-20);
+  width: clamp(17em, 20%, 20em);
+  padding: 3rem 0;
   position: sticky;
   top: 0;
   height: 100vh;
   overflow: auto;
 
   .nav-link {
+    padding: 0.75rem 1.5rem;
+    text-align: right;
     font-weight: 700;
+    opacity: 0.6;
+    transition: opacity 150ms ease-in-out;
+
+    &:hover {
+      text-decoration: none;
+      opacity: 0.8;
+    }
+
+    &.active {
+      opacity: 1;
+      background: var(--surface-color-background-white);
+      color: var(--theme-primary-blue);
+    }
   }
 }

--- a/frontend/src/components/NavSidebar.scss
+++ b/frontend/src/components/NavSidebar.scss
@@ -1,0 +1,13 @@
+#portal-nav-sidebar {
+  background: var(--theme-gray-10);
+  width: clamp(15em, 20%, 20em);
+  padding: 1.5rem 1rem;
+  position: sticky;
+  top: 0;
+  height: 100vh;
+  overflow: auto;
+
+  .nav-link {
+    font-weight: 700;
+  }
+}

--- a/frontend/src/components/TouchMenu.jsx
+++ b/frontend/src/components/TouchMenu.jsx
@@ -1,0 +1,88 @@
+import { Link } from "react-router-dom";
+import classNames from "classnames";
+import PropTypes from "prop-types";
+import "./TouchMenu.scss";
+
+const navItems = [
+  {
+    label: "Advisories",
+    Tag: "a",
+    href: "/advisories",
+  },
+  {
+    label: "Park Access Status",
+    Tag: "a",
+    href: "/park-access-status",
+  },
+  {
+    label: "Activities & Facilities",
+    Tag: "a",
+    href: "/activities-and-facilities",
+  },
+  {
+    label: "Dates of Operation",
+    Tag: Link,
+    to: "/",
+    // This menu only displays on DOOT right now,
+    // so Dates of Operation is always the active item.
+    active: true,
+  },
+];
+
+export default function TouchMenu({
+  show = true,
+  closeMenu,
+  logOut,
+  userName,
+}) {
+  function onLogoutClick() {
+    closeMenu();
+    logOut();
+  }
+
+  return (
+    <div
+      className={classNames("navbar-collapse collapse d-md-none", {
+        show,
+      })}
+      id="touch-menu"
+    >
+      <ul className="navbar-nav">
+        {navItems.map(({ Tag, label, active, ...itemProps }) => (
+          <li key={label} className="nav-item">
+            {/* Use "a" for external links and Router Link components for internal links */}
+            <Tag
+              className={classNames("nav-link", {
+                active,
+              })}
+              {...itemProps}
+              onClick={closeMenu}
+            >
+              {label}
+            </Tag>
+          </li>
+        ))}
+        <li className="nav-item">
+          {/* Full width logout button with the user's name */}
+          <button
+            type="button"
+            className="btn btn-text w-100 text-start nav-link"
+            onClick={onLogoutClick}
+          >
+            {userName}
+            <br />
+            Logout
+          </button>
+        </li>
+      </ul>
+    </div>
+  );
+}
+
+// Prop validation
+TouchMenu.propTypes = {
+  show: PropTypes.bool,
+  closeMenu: PropTypes.func.isRequired,
+  logOut: PropTypes.func.isRequired,
+  userName: PropTypes.string,
+};

--- a/frontend/src/components/TouchMenu.scss
+++ b/frontend/src/components/TouchMenu.scss
@@ -1,0 +1,28 @@
+// Make the menu show over the content
+#touch-menu {
+  position: absolute;
+  top: var(--top-nav-height);
+  left: 0;
+  right: 0;
+  z-index: 999;
+  background: var(--surface-color-menus-default);
+  box-shadow: var(--surface-shadow-small);
+
+  .nav-item {
+    border-bottom: 1px solid var(--surface-color-border-default);
+
+    &:hover {
+      background: var(--surface-color-menus-hover);
+    }
+
+    .nav-link {
+      color: var(--theme-primary-blue);
+      padding: 1.25em 1.5em;
+      line-height: 1.5;
+
+      &:hover {
+        text-decoration: none;
+      }
+    }
+  }
+}

--- a/frontend/src/router/layouts/MainLayout.jsx
+++ b/frontend/src/router/layouts/MainLayout.jsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { Outlet, Link } from "react-router-dom";
 import "./MainLayout.scss";
 import logo from "@/assets/bc-parks-logo.svg";
@@ -6,12 +6,16 @@ import logoVertical from "@/assets/bc-parks-logo-vertical.svg";
 import useAccess from "@/hooks/useAccess";
 import { useApiGet } from "@/hooks/useApi";
 import NavSidebar from "@/components/NavSidebar.jsx";
+import TouchMenu from "@/components/TouchMenu";
 
 export default function MainLayout() {
   const { logOut } = useAccess();
 
   // Fetch the user name to display in the header
   const userDetails = useApiGet("/user");
+
+  // Show or hide the touch menu
+  const [showTouchMenu, setShowTouchMenu] = useState(true);
 
   const userName = useMemo(() => {
     if (userDetails.loading || userDetails.error) return "";
@@ -21,7 +25,7 @@ export default function MainLayout() {
 
   return (
     <div className="layout main">
-      <header className="bcparks-global d-flex align-items-center container-fluid py-1 bg-primary-nav">
+      <header className="bcparks-global navbar navbar-dark px-3 d-flex align-items-center container-fluid py-1 bg-primary-nav">
         <Link
           to={`/`}
           className="d-inline-block d-flex align-items-center align-items-md-end logo-link"
@@ -46,8 +50,8 @@ export default function MainLayout() {
           </div>
         </Link>
 
-        <div className="user-controls text-white d-flex align-items-center ms-auto me-2">
-          <div className="d-none d-md-block user-name me-3">{userName}</div>
+        <div className="user-controls d-none d-md-flex text-white d-flex align-items-center ms-auto">
+          <div className="user-name me-3">{userName}</div>
 
           <button
             type="button"
@@ -57,7 +61,24 @@ export default function MainLayout() {
             Logout
           </button>
         </div>
+
+        <button
+          className="navbar-toggler d-block d-md-none"
+          type="button"
+          data-toggle="collapse"
+          data-target="#touch-menu"
+          onClick={() => setShowTouchMenu(!showTouchMenu)}
+        >
+          <span className="navbar-toggler-icon"></span>
+        </button>
       </header>
+
+      <TouchMenu
+        show={showTouchMenu}
+        closeMenu={() => setShowTouchMenu(false)}
+        logOut={logOut}
+        userName={userName}
+      />
 
       <main className="p-0 d-flex flex-column flex-md-row">
         <NavSidebar />

--- a/frontend/src/router/layouts/MainLayout.jsx
+++ b/frontend/src/router/layouts/MainLayout.jsx
@@ -50,7 +50,7 @@ export default function MainLayout() {
           </div>
         </Link>
 
-        <div className="user-controls d-none d-md-flex text-white d-flex align-items-center ms-auto">
+        <div className="user-controls d-none d-md-flex text-white align-items-center ms-auto">
           <div className="user-name me-3">{userName}</div>
 
           <button

--- a/frontend/src/router/layouts/MainLayout.jsx
+++ b/frontend/src/router/layouts/MainLayout.jsx
@@ -5,6 +5,7 @@ import logo from "@/assets/bc-parks-logo.svg";
 import logoVertical from "@/assets/bc-parks-logo-vertical.svg";
 import useAccess from "@/hooks/useAccess";
 import { useApiGet } from "@/hooks/useApi";
+import NavSidebar from "@/components/NavSidebar.jsx";
 
 export default function MainLayout() {
   const { logOut } = useAccess();
@@ -58,8 +59,12 @@ export default function MainLayout() {
         </div>
       </header>
 
-      <main className="p-0">
-        <Outlet />
+      <main className="p-0 d-flex flex-column flex-md-row">
+        <NavSidebar />
+
+        <div className="flex-fill">
+          <Outlet />
+        </div>
       </main>
 
       <footer className="bcparks-global py-2 py-md-0 d-flex justify-content-md-end align-items-center container-fluid text-bg-primary-nav">

--- a/frontend/src/router/layouts/MainLayout.scss
+++ b/frontend/src/router/layouts/MainLayout.scss
@@ -3,7 +3,10 @@
   flex-direction: column;
   min-height: 100vh;
 
+  --top-nav-height: 4.5rem;
+
   & > header {
+    height: var(--top-nav-height);
     border-bottom: 2px solid var(--theme-primary-gold);
 
     .logo-link {


### PR DESCRIPTION
### Jira Ticket

CMS-634

### Description
<!-- What did you change, and why? -->

This branch adds a navigation sidebar, and a mobile touch menu to navigate between the different sections of the Staff Portal. I also added a DOOT link to the legacy staff portal's nav menus. Internal links use React router/MUI tabs etc. but external links between the two portals just use a plain `a` tag with `href`.

**Note** that the links won't work in local dev because the legacy portal and DOOT dev servers run on different ports. But on alpha-dev etc they use the same hostname.

I used bootstrap styles and tweaked it a bit to _resemble_ the old menu. I wasn't trying to get it to match exactly because the "v2" section of the Staff Portal (DOOT) doesn't use Material UI. The sizes and colors in the old menus aren't all in the design tokens, but I tried to get it "close enough" without doing a bunch of non-standard custom stuff, since we might change all of this anyway. DOOT also doesn't have any custom animations or transitions defined, so there's no MUI "ripple effect" or slide-out animation right now.

There is no design mockup for the menus that I know of, so I just tried to make it similar enough so it's not jarring when you click back and forth.

