### PR TITLE
CMS-634: Fix menu breakpoints

### DIFF
--- a/frontend/src/components/TouchMenu.jsx
+++ b/frontend/src/components/TouchMenu.jsx
@@ -42,7 +42,7 @@ export default function TouchMenu({
 
   return (
     <div
-      className={classNames("navbar-collapse collapse d-md-none", {
+      className={classNames("navbar-collapse collapse d-lg-none", {
         show,
       })}
       id="touch-menu"

--- a/frontend/src/router/layouts/MainLayout.jsx
+++ b/frontend/src/router/layouts/MainLayout.jsx
@@ -50,7 +50,7 @@ export default function MainLayout() {
           </div>
         </Link>
 
-        <div className="user-controls d-none d-md-flex text-white align-items-center ms-auto">
+        <div className="user-controls d-none d-lg-flex text-white align-items-center ms-auto">
           <div className="user-name me-3">{userName}</div>
 
           <button
@@ -63,7 +63,7 @@ export default function MainLayout() {
         </div>
 
         <button
-          className="navbar-toggler d-block d-md-none"
+          className="navbar-toggler d-block d-lg-none"
           type="button"
           data-toggle="collapse"
           data-target="#touch-menu"


### PR DESCRIPTION
### Jira Ticket

CMS-634

### Description
<!-- What did you change, and why? -->

A quick fix for the header menus ticket to fix the breakpoints where the menus show/hide.
The touch menu button was hiding at the `md`/medium breakpoint, but the side menu wouldn't show until the `lg`/large breakpoint, so there was a gap in between where no menus would be accessible. This fixes it so the touch menu shows until the `lg` breakpoint. (`md` felt a bit too cramped with the sidebar next to the dense table on the homepage)