### PR TITLE
CMS-822: Add backup and restore sections to helm charts, add templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,5 +135,4 @@ dist
 # crunchy-postgres helm files (from https://github.com/bcgov/crunchy-postgres/tree/main/charts/crunchy-postgres)
 helm/crunchy-postgres/.helmignore
 helm/crunchy-postgres/Chart.yaml
-helm/crunchy-postgres/templates/
 helm/crunchy-postgres/values.yaml

--- a/helm/crunchy-postgres/templates/MonitoringNetworkPolicy.yml
+++ b/helm/crunchy-postgres/templates/MonitoringNetworkPolicy.yml
@@ -1,0 +1,22 @@
+{{ if .Values.pgmonitor.enabled }}
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: {{ template "crunchy-postgres.fullname" . }}-allow-crunchydb-monitoring
+  labels:
+    postgres-operator.crunchydata.com/cluster: {{ template "crunchy-postgres.fullname" . }}
+    {{ include "crunchy-postgres.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      postgres-operator.crunchydata.com/cluster: {{ template "crunchy-postgres.fullname" . }}
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              name: {{ .Values.pgmonitor.namespace }}
+              environment: tools
+      ports:
+        - protocol: TCP
+          port: 9187
+{{ end }}

--- a/helm/crunchy-postgres/templates/MonitoringRole.yml
+++ b/helm/crunchy-postgres/templates/MonitoringRole.yml
@@ -1,0 +1,16 @@
+{{ if .Values.pgmonitor.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels: {{ include "crunchy-postgres.labels" . | nindent 4 }}
+  name: {{ template "crunchy-postgres.fullname" . }}-crunchy-monitoring
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+{{ end }}

--- a/helm/crunchy-postgres/templates/MonitoringRoleBinding.yml
+++ b/helm/crunchy-postgres/templates/MonitoringRoleBinding.yml
@@ -1,0 +1,17 @@
+{{ if .Values.pgmonitor.enabled }}
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels: {{ include "crunchy-postgres.labels" . | nindent 4 }}
+  name: {{ template "crunchy-postgres.fullname" . }}-crunchy-monitoring
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "crunchy-postgres.fullname" . }}-crunchy-monitoring
+subjects:
+- kind: ServiceAccount
+  name: prometheus-sa
+  namespace: {{ .Values.pgmonitor.namespace }}-tools
+
+{{ end }}

--- a/helm/crunchy-postgres/templates/PostgresCluster.yaml
+++ b/helm/crunchy-postgres/templates/PostgresCluster.yaml
@@ -1,0 +1,232 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: {{ template "crunchy-postgres.fullname" . }}
+  labels: {{ include "crunchy-postgres.labels" . | nindent 4 }}
+spec:
+  metadata:
+    labels: {{ include "crunchy-postgres.labels" . | nindent 6 }}
+  {{ if .Values.crunchyImage }}
+  image: {{ .Values.crunchyImage }}
+  {{ end }}
+  imagePullPolicy: {{.Values.imagePullPolicy}}
+  postgresVersion: {{ .Values.postgresVersion }}
+  {{ if .Values.postGISVersion }}
+  postGISVersion: {{ .Values.postGISVersion | quote }}
+  {{ end }}
+
+  {{ if .Values.pgmonitor.enabled }}
+
+  monitoring:
+    pgmonitor:
+      # this stuff is for the "exporter" container in the "postgres-cluster-ha" set of pods
+      exporter:
+        {{ if .Values.pgmonitor.exporter.image}}
+        image: {{ .Values.pgmonitor.exporter.image}}
+        {{ end }}
+        resources:
+          requests:
+            cpu: {{ .Values.pgmonitor.exporter.requests.cpu }}
+            memory: {{ .Values.pgmonitor.exporter.requests.memory }}
+          limits:
+            cpu: {{ .Values.pgmonitor.exporter.limits.cpu }}
+            memory: {{ .Values.pgmonitor.exporter.limits.memory }}
+
+  {{ end }}
+
+  instances:
+    - name: {{ .Values.instances.name }}
+      replicas: {{ .Values.instances.replicas }}
+      resources:
+        requests:
+          cpu: {{ .Values.instances.requests.cpu }}
+          memory: {{ .Values.instances.requests.memory }}
+        limits:
+          cpu: {{ .Values.instances.limits.cpu }}
+          memory: {{ .Values.instances.limits.memory }}
+      sidecars:
+        replicaCertCopy:
+          resources:
+            requests:
+              cpu: {{ .Values.instances.replicaCertCopy.requests.cpu }}
+              memory: {{ .Values.instances.replicaCertCopy.requests.memory }}
+            limits:
+              cpu: {{ .Values.instances.replicaCertCopy.limits.cpu }}
+              memory: {{ .Values.instances.replicaCertCopy.limits.memory }}
+      dataVolumeClaimSpec:
+        accessModes:
+          - "ReadWriteOnce"
+        resources:
+          requests:
+            storage: {{ .Values.instances.dataVolumeClaimSpec.storage }}
+        storageClassName: {{ .Values.instances.dataVolumeClaimSpec.storageClassName }}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              podAffinityTerm:
+                topologyKey: topology.kubernetes.io/zone
+                labelSelector:
+                  matchLabels:
+                    postgres-operator.crunchydata.com/cluster:
+                      {{ template "crunchy-postgres.fullname" . }}
+                    postgres-operator.crunchydata.com/instance-set: {{ .Values.instances.name }}-ha
+
+  users:
+    - name: {{ template "crunchy-postgres.fullname" . }}
+      databases:
+        - {{ template "crunchy-postgres.fullname" . }}
+      options: "CREATEROLE"
+    - name: postgres
+      databases:
+        - {{ template "crunchy-postgres.fullname" . }}
+
+  {{ if .Values.dataSource.enabled }}
+  dataSource:
+    pgbackrest:
+      configuration:
+        - secret:
+            name: {{ .Values.dataSource.secretName }}
+      global:
+        repo2-path: {{ .Values.dataSource.repo.path }}
+      repo:
+        name: {{ .Values.dataSource.repo.name }}
+        s3:
+          bucket: {{ .Values.dataSource.repo.s3.bucket }}
+          endpoint: {{ .Values.dataSource.repo.s3.endpoint }}
+          region: {{ .Values.dataSource.repo.s3.region }}
+      stanza: {{ .Values.dataSource.stanza }}
+  {{ end }}
+
+  backups:
+    pgbackrest:
+      {{ if .Values.pgBackRest.image }}
+      image: {{ .Values.pgBackRest.image }}
+      {{ end }}
+      {{- if .Values.pgBackRest.s3.enabled }}
+      configuration:
+      - secret:
+          name: {{ .Values.pgBackRest.s3.s3Secret }}
+      {{- end }}
+      global:
+        # Support both PVC and s3 backups
+        repo1-retention-full: {{ .Values.pgBackRest.retention | quote }}
+        repo1-retention-full-type: {{ .Values.pgBackRest.retentionFullType }}
+        {{- if .Values.pgBackRest.s3.enabled }}
+        repo2-retention-full: {{ .Values.pgBackRest.retention | quote }}
+        repo2-retention-full-type: {{ .Values.pgBackRest.retentionFullType }}
+        repo2-path: {{ .Values.pgBackRest.s3.s3Path }}
+        repo2-s3-uri-style: {{ .Values.pgBackRest.s3.s3UriStyle }}
+        {{- end }}
+      repos:
+        # hardcoding repo1 until we solution allowing multiple repos
+        - name: repo1
+          schedules:
+            full: {{ .Values.pgBackRest.repos.schedules.full }}
+            incremental: {{ .Values.pgBackRest.repos.schedules.incremental }}
+          volume:
+            volumeClaimSpec:
+              accessModes:
+                - {{ .Values.pgBackRest.repos.volume.accessModes }}
+              resources:
+                requests:
+                  storage: {{ .Values.pgBackRest.repos.volume.storage }}
+              storageClassName: {{ .Values.pgBackRest.repos.volume.storageClassName }}
+        {{- if .Values.pgBackRest.s3.enabled }}
+        - name: repo2
+          schedules:
+            full: {{ if .Values.pgBackRest.s3.fullSchedule }}{{ .Values.pgBackRest.s3.fullSchedule }}{{ else }}{{ .Values.pgBackRest.repos.schedules.full }}{{ end }}
+            incremental: {{ if .Values.pgBackRest.s3.incrementalSchedule }}{{ .Values.pgBackRest.s3.incrementalSchedule }}{{ else }}{{ .Values.pgBackRest.repos.schedules.incremental }}{{ end }}
+          s3:
+            bucket: {{ .Values.pgBackRest.s3.bucket }}
+            endpoint: {{ .Values.pgBackRest.s3.endpoint }}
+            region: {{ .Values.pgBackRest.s3.region }}
+        {{- end }}
+
+      # Backup and recovery options
+      {{- if and .Values.pgBackRest.restore .Values.pgBackRest.restore.enabled }}
+      restore:
+        enabled: {{ .Values.pgBackRest.restore.enabled }}
+        repoName: {{ .Values.pgBackRest.restore.repo }}
+        options:
+          - --type=time
+          - --target="{{ .Values.pgBackRest.restore.target }}"
+      {{- end }}
+
+      manual:
+        options:
+          - --type=full
+        repoName: {{ .Values.pgBackRest.manual.repo }}
+
+      # this stuff is for the "pgbackrest" container (the only non-init container) in the "postgres-crunchy-repo-host" pod
+      repoHost:
+        resources:
+          requests:
+            cpu: {{ .Values.pgBackRest.repoHost.requests.cpu }}
+            memory: {{ .Values.pgBackRest.repoHost.requests.memory }}
+          limits:
+            cpu: {{ .Values.pgBackRest.repoHost.limits.cpu }}
+            memory: {{ .Values.pgBackRest.repoHost.limits.memory }}
+      sidecars:
+        # this stuff is for the "pgbackrest" container in the "postgres-crunchy-ha" set of pods
+        pgbackrest:
+          resources:
+            requests:
+              cpu: {{ .Values.pgBackRest.sidecars.requests.cpu }}
+              memory: {{ .Values.pgBackRest.sidecars.requests.memory }}
+            limits:
+              cpu: {{ .Values.pgBackRest.sidecars.limits.cpu }}
+              memory: {{ .Values.pgBackRest.sidecars.limits.memory }}
+        pgbackrestConfig:
+          resources:
+            requests:
+              cpu: {{ .Values.pgBackRest.sidecars.requests.cpu }}
+              memory: {{ .Values.pgBackRest.sidecars.requests.memory }}
+            limits:
+              cpu: {{ .Values.pgBackRest.sidecars.limits.cpu }}
+              memory: {{ .Values.pgBackRest.sidecars.limits.memory }}
+  standby:
+    enabled: {{ .Values.standby.enabled }}
+    repoName: {{ .Values.standby.repoName }}
+
+  patroni:
+    dynamicConfiguration:
+      postgresql:
+        pg_hba:
+          - {{ .Values.patroni.postgresql.pg_hba}}
+        parameters:
+          shared_buffers: {{ .Values.patroni.postgresql.parameters.shared_buffers }}
+          wal_buffers: {{ .Values.patroni.postgresql.parameters.wal_buffers }}
+          min_wal_size: {{ .Values.patroni.postgresql.parameters.min_wal_size }}
+          max_wal_size: {{ .Values.patroni.postgresql.parameters.max_wal_size }}
+          max_slot_wal_keep_size:  {{ .Values.patroni.postgresql.parameters.max_slot_wal_keep_size }}
+
+  proxy:
+    pgBouncer:
+      config:
+        global:
+          client_tls_sslmode: disable
+      {{ if .Values.proxy.pgBouncer.image }}
+      image: {{ .Values.proxy.pgBouncer.image }}
+      {{ end }}
+      replicas: {{ .Values.proxy.pgBouncer.replicas }}
+      # these resources are for the "pgbouncer" container in the "postgres-crunchy-ha-pgbouncer" set of pods
+      # there is a sidecar in these pods which are not mentioned here, but the requests/limits are teeny weeny by default so no worries there.
+      resources:
+        requests:
+          cpu: {{ .Values.proxy.pgBouncer.requests.cpu }}
+          memory: {{ .Values.proxy.pgBouncer.requests.memory }}
+        limits:
+          cpu: {{ .Values.proxy.pgBouncer.limits.cpu }}
+          memory: {{ .Values.proxy.pgBouncer.limits.memory }}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              podAffinityTerm:
+                topologyKey: topology.kubernetes.io/zone
+                labelSelector:
+                  matchLabels:
+                    postgres-operator.crunchydata.com/cluster:
+                      {{ .Values.instances.name }}
+                    postgres-operator.crunchydata.com/role: pgbouncer

--- a/helm/crunchy-postgres/templates/_helpers.tpl
+++ b/helm/crunchy-postgres/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "crunchy-postgres.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "crunchy-postgres.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "crunchy-postgres.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "crunchy-postgres.labels" -}}
+helm.sh/chart: {{ include "crunchy-postgres.chart" . }}
+{{ include "crunchy-postgres.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "crunchy-postgres.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "crunchy-postgres.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "crunchy-postgres.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "crunchy-postgres.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/helm/crunchy-postgres/templates/_s3.tpl
+++ b/helm/crunchy-postgres/templates/_s3.tpl
@@ -1,0 +1,18 @@
+{{/* Allow for S3 secret information to be stored in a Secret */}}
+{{- define "postgres.s3" }}
+[global]
+{{- if .s3 }}
+  {{- if .s3.key }}
+repo{{ add .index 1 }}-s3-key={{ .s3.key }}
+  {{- end }}
+  {{- if .s3.keySecret }}
+repo{{ add .index 1 }}-s3-key-secret={{ .s3.keySecret }}
+  {{- end }}
+  {{- if .s3.keyType }}
+repo{{ add .index 1 }}-s3-key-type={{ .s3.keyType }}
+  {{- end }}
+  {{- if .s3.encryptionPassphrase }}
+repo{{ add .index 1 }}-cipher-pass={{ .s3.encryptionPassphrase }}
+  {{- end }}
+{{- end }}
+{{ end }}

--- a/helm/crunchy-postgres/templates/s3Secret.yaml
+++ b/helm/crunchy-postgres/templates/s3Secret.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.pgBackRest.s3.enabled .Values.pgBackRest.s3.createS3Secret }}
+{{- if not (lookup "v1" "Secret" .Release.Namespace .Values.pgBackRest.s3.s3Secret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.pgBackRest.s3.s3Secret }}
+  annotations:
+    "helm.sh/resource-policy": "keep"
+type: Opaque
+data:
+  {{- $args := dict "s3" .Values.pgBackRest.s3 "index" 1 }}
+  s3.conf: |-
+        {{ include "postgres.s3" $args | b64enc }}
+{{- end }}
+{{- end }}

--- a/helm/crunchy-postgres/values-alpha-dev.yaml
+++ b/helm/crunchy-postgres/values-alpha-dev.yaml
@@ -102,6 +102,18 @@ pgBackRest:
     fullSchedule: "0 9 * * *"
     incrementalSchedule: "0 1,5,13,17,21 * * *"
 
+  # Restore from backup
+  restore:
+    enabled: false
+    # PVC=repo1 / S3=repo2
+    repoName: ~ # provide repo name
+    target: ~ # 2024-03-24 17:16:00-07 this is the target timestamp to go back to in current cluster
+
+  # Specify the repo to use for manual full backups
+  # PVC=repo1 / S3=repo2
+  manual:
+    repo: repo1
+
 patroni:
   postgresql:
     pg_hba: "host all all 0.0.0.0/0 md5"

--- a/helm/crunchy-postgres/values-alpha-test.yaml
+++ b/helm/crunchy-postgres/values-alpha-test.yaml
@@ -102,6 +102,18 @@ pgBackRest:
     fullSchedule: "0 9 * * *"
     incrementalSchedule: "0 1,5,13,17,21 * * *"
 
+  # Restore from backup
+  restore:
+    enabled: false
+    # PVC=repo1 / S3=repo2
+    repoName: ~ # provide repo name
+    target: ~ # 2024-03-24 17:16:00-07 this is the target timestamp to go back to in current cluster
+
+  # Specify the repo to use for manual full backups
+  # PVC=repo1 / S3=repo2
+  manual:
+    repo: repo1
+
 patroni:
   postgresql:
     pg_hba: "host all all 0.0.0.0/0 md5"

--- a/helm/crunchy-postgres/values-dev.yaml
+++ b/helm/crunchy-postgres/values-dev.yaml
@@ -102,6 +102,18 @@ pgBackRest:
     fullSchedule: "0 9 * * *"
     incrementalSchedule: "0 1,5,13,17,21 * * *"
 
+  # Restore from backup
+  restore:
+    enabled: false
+    # PVC=repo1 / S3=repo2
+    repoName: ~ # provide repo name
+    target: ~ # 2024-03-24 17:16:00-07 this is the target timestamp to go back to in current cluster
+
+  # Specify the repo to use for manual full backups
+  # PVC=repo1 / S3=repo2
+  manual:
+    repo: repo1
+
 patroni:
   postgresql:
     pg_hba: "host all all 0.0.0.0/0 md5"

--- a/helm/crunchy-postgres/values-prod.yaml
+++ b/helm/crunchy-postgres/values-prod.yaml
@@ -102,6 +102,18 @@ pgBackRest:
     fullSchedule: "0 9 * * *"
     incrementalSchedule: "0 1,5,13,17,21 * * *"
 
+  # Restore from backup
+  restore:
+    enabled: false
+    # PVC=repo1 / S3=repo2
+    repoName: ~ # provide repo name
+    target: ~ # 2024-03-24 17:16:00-07 this is the target timestamp to go back to in current cluster
+
+  # Specify the repo to use for manual full backups
+  # PVC=repo1 / S3=repo2
+  manual:
+    repo: repo1
+
 patroni:
   postgresql:
     pg_hba: "host all all 0.0.0.0/0 md5"

--- a/helm/crunchy-postgres/values-test.yaml
+++ b/helm/crunchy-postgres/values-test.yaml
@@ -102,6 +102,18 @@ pgBackRest:
     fullSchedule: "0 9 * * *"
     incrementalSchedule: "0 1,5,13,17,21 * * *"
 
+  # Restore from backup
+  restore:
+    enabled: false
+    # PVC=repo1 / S3=repo2
+    repoName: ~ # provide repo name
+    target: ~ # 2024-03-24 17:16:00-07 this is the target timestamp to go back to in current cluster
+
+  # Specify the repo to use for manual full backups
+  # PVC=repo1 / S3=repo2
+  manual:
+    repo: repo1
+
 patroni:
   postgresql:
     pg_hba: "host all all 0.0.0.0/0 md5"

--- a/helm/crunchy-postgres/values-training.yaml
+++ b/helm/crunchy-postgres/values-training.yaml
@@ -102,6 +102,18 @@ pgBackRest:
     fullSchedule: "0 9 * * *"
     incrementalSchedule: "0 1,5,13,17,21 * * *"
 
+  # Restore from backup
+  restore:
+    enabled: false
+    # PVC=repo1 / S3=repo2
+    repoName: ~ # provide repo name
+    target: ~ # 2024-03-24 17:16:00-07 this is the target timestamp to go back to in current cluster
+
+  # Specify the repo to use for manual full backups
+  # PVC=repo1 / S3=repo2
+  manual:
+    repo: repo1
+
 patroni:
   postgresql:
     pg_hba: "host all all 0.0.0.0/0 md5"


### PR DESCRIPTION
### Jira Ticket

CMS-822

### Description
<!-- What did you change, and why? -->

This branch adds 2 sections to the crunchy-postgres Helm charts so we can manually run one-off full backups, or point-in-time DB recoveries. I ran a couple of manual backups and then restored one this morning to test it. It's pretty much just following the directions in the [Crunchy PGO documentation](https://access.crunchydata.com/documentation/postgres-operator/5.7/tutorials/backups-disaster-recovery) but I hadn't actually tried a point-in-time recovery until today.

One big change in this branch is that I'm adding the Helm chart templates to the repo, which were previously in gitignore. I think the original plan was to have the charts come from a separate repo that Mike controls, which would be shared by multiple projects. At this point, I think it's best to just keep the template files for this project in the repo with the charts. 
I had to make a slight modification to add the backup/restore sections, so it's different from the base versions in Mike's repo now anyway.