### PR TITLE
CMS-465: Add create-seasons script

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -88,3 +88,15 @@ Just recreate the DB and readd the data from Strapi.
 2. `npx sequelize-cli db:create`
 3. `npm run migrate`
 4. `npm run import-data`
+
+### Creating new seasons
+
+Add blank seasons for new operating years with the `create-seasons` NPM script:
+
+```bash
+# Example: create seasons for 2028
+# (This will also create Group Camping seasons for the next year, 2029)
+npm run create-seasons 2028
+```
+
+This will create new records in the Seasons table for all Parks, ParkAreas, and Features that will be requesting dates for the 2028 operating year. Group Campground features for the year after (2029) will also be requested by this script.

--- a/backend/package.json
+++ b/backend/package.json
@@ -11,7 +11,8 @@
     "migrate": "sequelize-cli db:migrate",
     "test": "echo \"Error: no test specified\" && exit 1",
     "sync-data": "node strapi-sync/re-sync-data.js",
-    "import-data": "node strapi-sync/import-data.js"
+    "import-data": "node strapi-sync/import-data.js",
+    "create-seasons": "node tasks/create-seasons.js"
   },
   "author": "",
   "license": "ISC",

--- a/backend/tasks/create-seasons.js
+++ b/backend/tasks/create-seasons.js
@@ -114,9 +114,9 @@ async function createSeason(publishableId, year) {
   return newSeason.id;
 }
 
-console.log(`Creating seasons for ${operatingYear}`);
+console.log(`Creating Seasons for ${operatingYear}`);
 
-// Step 1: Create new seasons for every Park
+// Step 1: Create new Seasons for every Park
 
 // Get all the Parks with Features
 const parks = await Park.findAll({
@@ -134,7 +134,7 @@ const parks = await Park.findAll({
   transaction,
 });
 
-console.log(`Found ${parks.length} parks with features`);
+console.log(`Found ${parks.length} Parks with Features`);
 
 const parksQueries = parks.map(async (park) => {
   // If the park doesn't have a publishableId, add one and associate it
@@ -182,7 +182,7 @@ const parkAreasMap = new Map(
 );
 const parkAreas = Array.from(parkAreasMap.values());
 
-console.log(`Found ${parkAreas.length} park areas with features`);
+console.log(`Found ${parkAreas.length} ParkAreas with Features`);
 
 const parkAreasQueries = parkAreas.map(async (parkArea) => {
   // If the parkArea doesn't have a publishableId, add one and associate it
@@ -217,7 +217,7 @@ const features = await Feature.findAll({
   transaction,
 });
 
-console.log(`Found ${features.length} features with no park area`);
+console.log(`Found ${features.length} Features with no ParkArea`);
 
 const featuresQueries = features.map(async (feature) => {
   // If the feature doesn't have a publishableId, add one and associate it
@@ -263,7 +263,7 @@ const groupCampingFeatures = await Feature.findAll({
   transaction,
 });
 
-console.log(`Found ${groupCampingFeatures.length} Group Camping features`);
+console.log(`Found ${groupCampingFeatures.length} Group Camping Features`);
 
 const groupCampingQueries = groupCampingFeatures.map(async (feature) => {
   // If the feature doesn't have a publishableId, add one and associate it

--- a/backend/tasks/create-seasons.js
+++ b/backend/tasks/create-seasons.js
@@ -239,6 +239,8 @@ console.log(`Added ${seasonsAdded} new Feature Seasons`);
 // Step 4: Create new seasons for the following year for every Group Camping Feature
 const nextYear = operatingYear + 1;
 
+console.log(`Creating Group Camping seasons for ${nextYear}`);
+
 publishablesAdded = 0;
 dateablesAdded = 0;
 seasonsAdded = 0;

--- a/backend/tasks/create-seasons.js
+++ b/backend/tasks/create-seasons.js
@@ -1,0 +1,115 @@
+// This script creates new blank seasons for upcoming years in the DOOT database.
+// It will skip creating a season if one already exists for the given operating year and publishable.
+// Also creates Group Camping seasons for the year after the operating year.
+
+import "../env.js";
+
+import {
+  Dateable,
+  DateRange,
+  DateType,
+  Feature,
+  FeatureType,
+  Park,
+  Publishable,
+  Season,
+} from "../models/index.js";
+// import { createModel } from "./utils.js";
+import { Op } from "sequelize";
+
+// Run all queries in a transaction
+const transaction = await Season.sequelize.transaction();
+
+process.on("uncaughtException", (err) => {
+  console.error(`\n${err.message}\n`);
+  transaction.rollback();
+  throw new Error(err);
+});
+
+// Get the operating year from command line arguments
+const operatingYear = process.argv[2];
+
+if (!operatingYear) {
+  console.info("Usage example: npm run create-seasons 2027");
+  throw new Error("Missing operating year");
+}
+
+console.log(`Creating seasons for ${operatingYear}`);
+
+// Step 1: Create new seasons for every Park
+
+// Get all the Parks with Features
+const parks = await Park.findAll({
+  attributes: ["id", "name", "publishableId", "dateableId"],
+  include: [
+    {
+      model: Feature,
+      as: "features",
+      required: true,
+    },
+  ],
+  transaction,
+});
+
+console.log(`Found ${parks.length} parks with features`);
+
+let publishablesAdded = 0;
+let dateablesAdded = 0;
+let seasonsAdded = 0;
+
+const parksQueries = parks.map(async (park) => {
+  // If the park doesn't have a publishableId, add one and associate it
+  if (!park.publishableId) {
+    const publishable = await Publishable.create({}, { transaction });
+
+    park.publishableId = publishable.id;
+    await park.save({ transaction });
+    publishablesAdded++;
+  }
+
+  // If the park doesn't have a dateableId, add one and associate it
+  if (!park.dateableId) {
+    const dateable = await Dateable.create({}, { transaction });
+
+    park.dateableId = dateable.id;
+    await park.save({ transaction });
+    dateablesAdded++;
+  }
+
+  // Create a season for this park's Publishable ID and Operating Year, if it doesn't exist
+  const season = await Season.findOne({
+    where: {
+      publishableId: park.publishableId,
+      operatingYear,
+    },
+    transaction,
+  });
+
+  if (!season) {
+    await Season.create(
+      {
+        publishableId: park.publishableId,
+        operatingYear,
+        status: "requested",
+      },
+      { transaction },
+    );
+    seasonsAdded++;
+  }
+});
+
+await Promise.all(parksQueries);
+
+console.log(`Added ${publishablesAdded} missing Park Publishables`);
+console.log(`Added ${dateablesAdded} missing Park Dateables`);
+console.log(`Added ${seasonsAdded} new Park Seasons`);
+
+// Step 2: Create new seasons for every ParkArea with Features in it
+// Step 3: Create new seasons for every Feature that doesn't belong to a ParkArea
+// Step 4: Create new seasons for the following year for every Group Camping Feature
+
+await transaction.commit();
+
+console.log("done");
+
+// throw new Error("Not implemented yet");

--- a/backend/tasks/create-seasons.js
+++ b/backend/tasks/create-seasons.js
@@ -6,33 +6,31 @@ import "../env.js";
 
 import {
   Dateable,
-  DateRange,
-  DateType,
   Feature,
-  FeatureType,
   Park,
+  ParkArea,
   Publishable,
   Season,
 } from "../models/index.js";
-// import { createModel } from "./utils.js";
-import { Op } from "sequelize";
 
 // Run all queries in a transaction
 const transaction = await Season.sequelize.transaction();
 
 process.on("uncaughtException", (err) => {
   console.error(`\n${err.message}\n`);
-  transaction.rollback();
+  transaction?.rollback();
   throw new Error(err);
 });
 
 // Get the operating year from command line arguments
-const operatingYear = process.argv[2];
+let operatingYear = process.argv[2];
 
 if (!operatingYear) {
   console.info("Usage example: npm run create-seasons 2027");
   throw new Error("Missing operating year");
 }
+
+operatingYear = Number(operatingYear);
 
 console.log(`Creating seasons for ${operatingYear}`);
 
@@ -105,11 +103,145 @@ console.log(`Added ${dateablesAdded} missing Park Dateables`);
 console.log(`Added ${seasonsAdded} new Park Seasons`);
 
 // Step 2: Create new seasons for every ParkArea with Features in it
+
+publishablesAdded = 0;
+dateablesAdded = 0;
+seasonsAdded = 0;
+
+const parkAreaFeatures = await Feature.findAll({
+  include: [
+    {
+      model: ParkArea,
+      as: "parkArea",
+      required: true,
+      attributes: ["id", "name", "publishableId", "dateableId"],
+    },
+  ],
+  transaction,
+});
+
+// Get all the ParkAreas with Features
+const parkAreasMap = new Map(
+  parkAreaFeatures.map((feature) => [feature.parkArea.id, feature.parkArea]),
+);
+const parkAreas = Array.from(parkAreasMap.values());
+
+console.log(`Found ${parkAreas.length} park areas with features`);
+
+const parkAreasQueries = parkAreas.map(async (parkArea) => {
+  // If the parkArea doesn't have a publishableId, add one and associate it
+  if (!parkArea.publishableId) {
+    const publishable = await Publishable.create({}, { transaction });
+
+    parkArea.publishableId = publishable.id;
+    await parkArea.save({ transaction });
+    publishablesAdded++;
+  }
+
+  // If the parkArea doesn't have a dateableId, add one and associate it
+  if (!parkArea.dateableId) {
+    const dateable = await Dateable.create({}, { transaction });
+
+    parkArea.dateableId = dateable.id;
+    await parkArea.save({ transaction });
+    dateablesAdded++;
+  }
+
+  // Create a season for this parkArea's Publishable ID and Operating Year, if it doesn't exist
+  const season = await Season.findOne({
+    where: {
+      publishableId: parkArea.publishableId,
+      operatingYear,
+    },
+    transaction,
+  });
+
+  if (!season) {
+    await Season.create(
+      {
+        publishableId: parkArea.publishableId,
+        operatingYear,
+        status: "requested",
+      },
+      { transaction },
+    );
+    seasonsAdded++;
+  }
+});
+
+await Promise.all(parkAreasQueries);
+
+console.log(`Added ${publishablesAdded} missing ParkArea Publishables`);
+console.log(`Added ${dateablesAdded} missing ParkArea Dateables`);
+console.log(`Added ${seasonsAdded} new ParkArea Seasons`);
+
 // Step 3: Create new seasons for every Feature that doesn't belong to a ParkArea
+
+publishablesAdded = 0;
+dateablesAdded = 0;
+seasonsAdded = 0;
+
+const features = await Feature.findAll({
+  where: {
+    // Find Features with null parkAreaId
+    parkAreaId: null,
+  },
+  transaction,
+});
+
+console.log(`Found ${features.length} features with no park area`);
+
+const featuresQueries = features.map(async (feature) => {
+  // If the feature doesn't have a publishableId, add one and associate it
+  if (!feature.publishableId) {
+    const publishable = await Publishable.create({}, { transaction });
+
+    feature.publishableId = publishable.id;
+    await feature.save({ transaction });
+    publishablesAdded++;
+  }
+
+  // If the feature doesn't have a dateableId, add one and associate it
+  if (!feature.dateableId) {
+    const dateable = await Dateable.create({}, { transaction });
+
+    feature.dateableId = dateable.id;
+    await feature.save({ transaction });
+    dateablesAdded++;
+  }
+
+  // Create a season for this feature's Publishable ID and Operating Year, if it doesn't exist
+  const season = await Season.findOne({
+    where: {
+      publishableId: feature.publishableId,
+      operatingYear,
+    },
+    transaction,
+  });
+
+  if (!season) {
+    await Season.create(
+      {
+        publishableId: feature.publishableId,
+        operatingYear,
+        status: "requested",
+      },
+      { transaction },
+    );
+    seasonsAdded++;
+  }
+});
+
+await Promise.all(featuresQueries);
+
+console.log(`Added ${publishablesAdded} missing Feature Publishables`);
+console.log(`Added ${dateablesAdded} missing Feature Dateables`);
+console.log(`Added ${seasonsAdded} new Feature Seasons`);
+
 // Step 4: Create new seasons for the following year for every Group Camping Feature
 
-await transaction.commit();
+console.log("Committing transaction...");
 
-console.log("done");
+await transaction?.commit();
 
-// throw new Error("Not implemented yet");
+console.log("Done");


### PR DESCRIPTION
### Jira Ticket

CMS-465

### Description
<!-- What did you change, and why? -->

Added a `npm run create-seasons <operating year>` script to create new records in the Seasons table to request dates for new operating years.

The script basically takes a year as input and then loops over all of the relevant Parks/ParkAreas/Features it finds and creates a new Season for it.

I updated the documentation to include instructions, but let me know if you have questions!