### PR TITLE
CMS-000: Specify openshift: true in PGO spec

### DIFF
--- a/helm/crunchy-postgres/templates/PostgresCluster.yaml
+++ b/helm/crunchy-postgres/templates/PostgresCluster.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ template "crunchy-postgres.fullname" . }}
   labels: {{ include "crunchy-postgres.labels" . | nindent 4 }}
 spec:
+  openshift: true
   metadata:
     labels: {{ include "crunchy-postgres.labels" . | nindent 6 }}
   {{ if .Values.crunchyImage }}


### PR DESCRIPTION
### Jira Ticket

No ticket

### Description
<!-- What did you change, and why? -->

We had to make this change to the Crunchy DB deployment helm charts yesterday after something changed on the server and everyone's deployments stopped working. Some details from the chat:

> A quick update to the `spec.openshift: true` issue! according to the docs, if the `spec.openshift` flag isn't set, the operator is supposed to detect the environment automatically. It seems that the operator is normally able to detect this correctly and so nobody really needed to set it before. However, there was a problem with the openshift API last night and my current guess is that this caused the operator to fail to detect the correct environment when restarting your containers. This would explain why the fix is a config change despite the fact that nobody changed anything that would normally cause this sort of issue.
> 
> So, I recommend that everyone (including those on gold and emerald) should update your PostgresCluster to include `spec.openshift: true`. Even if this turns out not to be the cause, there's no good reason to risk your deployment by depending on the operator to correctly guess the openshift environment. That's why I'm happy recommending this to everyone even though I still have some testing to do to confirm that this is actually the cause of this issue.

This has already been applied, so I'll merge this right away, but I'm doing it as a PR just so everyone's aware 👍 