### PR TITLE
CMS-932: Hide contents until userData is loaded

### DIFF
--- a/frontend/src/router/layouts/MainLayout.jsx
+++ b/frontend/src/router/layouts/MainLayout.jsx
@@ -7,6 +7,7 @@ import useAccess from "@/hooks/useAccess";
 import { useApiGet } from "@/hooks/useApi";
 import NavSidebar from "@/components/NavSidebar.jsx";
 import TouchMenu from "@/components/TouchMenu";
+import LoadingBar from "@/components/LoadingBar";
 
 export default function MainLayout() {
   const { logOut } = useAccess();
@@ -84,7 +85,17 @@ export default function MainLayout() {
         <NavSidebar />
 
         <div className="flex-fill">
-          <Outlet />
+          {/*
+            Don't render the body until userDetails are loaded.
+            The body makes API requests, and race conditions could create duplicate User records.
+          */}
+          {userDetails.loading ? (
+            <div className="container mt-3">
+              <LoadingBar />
+            </div>
+          ) : (
+            <Outlet />
+          )}
         </div>
       </main>
 


### PR DESCRIPTION
### Jira Ticket

CMS-932

### Description
<!-- What did you change, and why? -->

When you first log into DOOT, the template makes a request to get your User info (to display your name in the header). It only does that once, and the template stays the same as you navigate between pages. 

# usersMiddleware

There's a middleware to get your user details from the JWT token on every API request, and it adds you to the Users table if you're not there already:

```js
/* middleware/users.js */

// Find or create user in the database
const [user] = await User.findOrCreate({
  attributes: ["id", "email", "name"],
  where: { email },
  defaults: { name },
});
```

# Race condition

Currently, a page will render the template _and_ the contents at the same time. If you're a new user, it will be requesting the user details and the page contents at the same time. These two (or more) requests might all try to create new User records, and you could end up with multiple User records for the same person.

It doesn't break anything because it would just use the first one found in the table, but it's still undesirable. This branch adds a quick fix: 
1. First, request the user details for the template, and block the page contents from rendering.
2. Once the use details are loaded (and your email is in the Users table for sure), then allow the rest of the site to load.

You can check the Users table on your local or the other environments; there are probably multiple records for the same user in there.

#208 adds a UNIQUE constraint to the User's email, so we'll need to fix this (and delete any duplicates) before deploying that change.