### PR TITLE
CMS-894: Update dates management table

### DIFF
--- a/backend/middleware/adminJs.js
+++ b/backend/middleware/adminJs.js
@@ -204,6 +204,17 @@ const SeasonResource = {
 
   options: {
     actions: getSeasonActions(),
+    listProperties: [
+      "id",
+      "publishableId",
+      "featureTypeId",
+      "operatingYear",
+      "status",
+      "readyToPublish",
+      "editable",
+      "createdAt",
+      "updatedAt",
+    ]
   },
 };
 

--- a/backend/routes/api/parks.js
+++ b/backend/routes/api/parks.js
@@ -52,23 +52,19 @@ function getParkStatus(seasons) {
 // group dateRanges by date type name then by year
 // e.g. {Operation: {2024: [...], 2025: [...]}, Winter: {2024: [...], 2025: [...]}, ...}
 function groupDateRangesByTypeAndYear(dateRanges) {
-  const grouped = {};
+  // filter out invalid dateRanges
+  const validRanges = dateRanges.filter(
+    (dateRange) => dateRange.dateType && dateRange.startDate,
+  );
 
-  dateRanges.forEach((dateRange) => {
-    if (!dateRange.dateType || !dateRange.startDate) return;
-
-    const type = dateRange.dateType.name;
-    const startYear = new Date(dateRange.startDate).getFullYear();
-
-    if (!grouped[type]) grouped[type] = {};
-    if (!grouped[type][startYear]) grouped[type][startYear] = [];
-    grouped[type][startYear].push({
-      id: dateRange.id,
-      startDate: dateRange.startDate,
-      endDate: dateRange.endDate,
-    });
-  });
-  return grouped;
+  // group by dateType name
+  return _.mapValues(
+    _.groupBy(validRanges, (dateRange) => dateRange.dateType.name),
+    (ranges) =>
+      _.groupBy(ranges, (dateRange) =>
+        new Date(dateRange.startDate).getFullYear(),
+      ),
+  );
 }
 
 // build a date range output object

--- a/backend/routes/api/parks.js
+++ b/backend/routes/api/parks.js
@@ -104,22 +104,14 @@ function buildFeatureOutput(feature, allDateRanges, parkSeasons) {
 
   // get season for park.feature
   // filter park.seasons by feature.publishableId
-  let matchedSeason = parkSeasons.find(
-    (parkSeason) => parkSeason.publishableId === feature.publishableId,
+  // backwards compatibility - filter park.seasons by feature.featureType.publishableId
+  const featureSeasons = parkSeasons.filter(
+    (parkSeason) =>
+      parkSeason.publishableId === feature.publishableId ||
+      (feature.featureType &&
+        feature.featureType.publishableId &&
+        parkSeason.publishableId === feature.featureType.publishableId),
   );
-
-  // backwards compatibility
-  // if matchedSeason is not found, try to match by feature.featureType.publishableId
-  if (
-    !matchedSeason &&
-    feature.featureType &&
-    feature.featureType.publishableId
-  ) {
-    matchedSeason = parkSeasons.find(
-      (parkSeason) =>
-        parkSeason.publishableId === feature.featureType.publishableId,
-    );
-  }
 
   return {
     id: feature.id,
@@ -133,7 +125,7 @@ function buildFeatureOutput(feature, allDateRanges, parkSeasons) {
       publishableId: feature.featureType.publishableId,
       name: feature.featureType.name,
     },
-    season: matchedSeason ? buildSeasonOutput(matchedSeason) : null,
+    status: getParkStatus(featureSeasons),
     groupedDateRanges: groupDateRangesByTypeAndYear(featureDateRanges),
   };
 }
@@ -296,22 +288,15 @@ router.get(
 
           // get season for park.parkArea
           // filter park.seasons by parkArea.publishableId
-          let matchedSeason = park.seasons.find(
-            (parkSeason) => parkSeason.publishableId === parkArea.publishableId,
-          );
+          // backwards compatibility - filter park.seasons by parkArea.featureType.publishableId
 
-          // backwards compatibility
-          // if matchedSeason is not found, try to match by parkArea.featureType.publishableId
-          if (
-            !matchedSeason &&
-            parkArea.featureType &&
-            parkArea.featureType.publishableId
-          ) {
-            matchedSeason = park.seasons.find(
-              (parkSeason) =>
-                parkSeason.publishableId === parkArea.featureType.publishableId,
-            );
-          }
+          const parkAreaSeasons = park.seasons.filter(
+            (parkSeason) =>
+              parkSeason.publishableId === parkArea.publishableId ||
+              (featureType &&
+                featureType.publishableId &&
+                parkSeason.publishableId === featureType.publishableId),
+          );
 
           return {
             id: parkArea.id,
@@ -320,7 +305,7 @@ router.get(
             name: parkArea.name,
             features: parkAreaFeatures,
             ...(featureType && { featureType }),
-            season: matchedSeason ? buildSeasonOutput(matchedSeason) : null,
+            status: getParkStatus(parkAreaSeasons),
             groupedDateRanges: groupDateRangesByTypeAndYear(parkAreaDateRanges),
           };
         }),

--- a/backend/routes/api/parks.js
+++ b/backend/routes/api/parks.js
@@ -16,6 +16,39 @@ import asyncHandler from "express-async-handler";
 const router = Router();
 
 // Functions
+function getParkStatus(seasons) {
+  // if any season has status==requested, return requested
+  // else if any season has status==pending review, return pending review
+  // else if any season has status==approved, return approved
+  // if all seasons have status==on API, return on API
+
+  const requested = seasons.some((s) => s.status === "requested");
+
+  if (requested) {
+    return "requested";
+  }
+
+  const pendingReview = seasons.some((s) => s.status === "pending review");
+
+  if (pendingReview) {
+    return "pending review";
+  }
+
+  const approved = seasons.some((s) => s.status === "approved");
+
+  if (approved) {
+    return "approved";
+  }
+
+  const onAPI = seasons.some((s) => s.status === "on API");
+
+  if (onAPI) {
+    return "on API";
+  }
+
+  return null;
+}
+
 // group dateRanges by date type name then by year
 // e.g. {Operation: {2024: [...], 2025: [...]}, Winter: {2024: [...], 2025: [...]}, ...}
 function groupDateRangesByTypeAndYear(dateRanges) {
@@ -226,7 +259,7 @@ router.get(
         section: park.managementAreas.map((area) => area.section),
         managementArea: park.managementAreas.map((area) => area.mgmtArea),
         inReservationSystem: park.inReservationSystem,
-        status: park.status,
+        status: getParkStatus(park.seasons),
         groupedDateRanges: groupDateRangesByTypeAndYear(parkDateRanges),
         features: park.features.map((feature) =>
           buildFeatureOutput(feature, allDateRanges, park.seasons),

--- a/frontend/src/components/EditAndReviewTable.jsx
+++ b/frontend/src/components/EditAndReviewTable.jsx
@@ -49,11 +49,16 @@ IconButton.propTypes = {
 // renders all date ranges for a given year as a list
 // e.g. [{ startDate: "Mon Jan 1", endDate: "Tue Jan 2" }, { startDate: "Mon Dec 30", endDate: "Tue Dec 31" }]
 // => Mon, 1 Jan – Tue, 2 Jan / Mon, 30 Dec – Tue, 31 Dec
-function DateRangesList({ year }) {
-  if (!year || year.length === 0) return null;
+function DateRangesList({ dateRanges, isLastYear }) {
+  // leave it blank when date information is not available
+  // display 'Not provided' when the year has passed and there are no dates
+  if (!dateRanges || dateRanges.length === 0) {
+    return isLastYear ? <span className="text-muted">Not provided</span> : null;
+  }
+
   return (
     <ul className="list-unstyled mb-0">
-      {year.map((dateRange) => (
+      {dateRanges.map((dateRange) => (
         <li key={dateRange.id}>
           {formattedDateRange(dateRange.startDate, dateRange.endDate)}
         </li>
@@ -63,13 +68,14 @@ function DateRangesList({ year }) {
 }
 
 DateRangesList.propTypes = {
-  year: PropTypes.arrayOf(
+  dateRanges: PropTypes.arrayOf(
     PropTypes.shape({
       id: PropTypes.number.isRequired,
       startDate: PropTypes.instanceOf(Date).isRequired,
       endDate: PropTypes.instanceOf(Date).isRequired,
     }),
   ),
+  isLastYear: PropTypes.bool,
 };
 
 function DateTypeTableRow({ groupedDateRanges }) {
@@ -94,10 +100,10 @@ function DateTableRow({ groupedDateRanges }) {
     <tr key={dateTypeName} className="table-row--date">
       <td className="fw-bold">{dateTypeName}</td>
       <td>
-        <DateRangesList year={yearsObj[lastYear]} />
+        <DateRangesList dateRanges={yearsObj[lastYear]} isLastYear={true} />
       </td>
       <td>
-        <DateRangesList year={yearsObj[currentYear]} />
+        <DateRangesList dateRanges={yearsObj[currentYear]} />
       </td>
     </tr>
   ));

--- a/frontend/src/components/EditAndReviewTable.jsx
+++ b/frontend/src/components/EditAndReviewTable.jsx
@@ -203,7 +203,7 @@ function Table({ park, formPanelHandler }) {
               level="park-area"
               name={`${park.name} - ${parkArea.name}`}
               typeName={parkArea.featureType.name}
-              status={parkArea.season?.status}
+              status={parkArea.status}
               formPanelHandler={() =>
                 formPanelHandler({ ...parkArea, level: "park-area" })
               }
@@ -240,7 +240,7 @@ function Table({ park, formPanelHandler }) {
                 level="feature"
                 name={`${park.name} - ${feature.name}`}
                 typeName={feature.featureType.name}
-                status={feature.season?.status}
+                status={feature.status}
                 formPanelHandler={() =>
                   formPanelHandler({ ...feature, level: "feature" })
                 }

--- a/frontend/src/components/EditAndReviewTable.jsx
+++ b/frontend/src/components/EditAndReviewTable.jsx
@@ -1,110 +1,303 @@
-import { useMemo } from "react";
+import React from "react";
 import PropTypes from "prop-types";
-import { Link, useNavigate } from "react-router-dom";
 import classNames from "classnames";
-import {
-  faSort,
-  faSortUp,
-  faSortDown,
-  faChevronRight,
-} from "@fa-kit/icons/classic/solid";
+import { faCheck } from "@fa-kit/icons/classic/solid";
+import { faPen } from "@fa-kit/icons/classic/regular";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import paths from "@/router/paths";
 import StatusBadge from "@/components/StatusBadge";
-import NotReadyFlag from "@/components/NotReadyFlag";
+// TODO: add it to DateRangesList once status is implemented
+// import NotReadyFlag from "@/components/NotReadyFlag";
+import { formatDateShort } from "@/lib/utils";
+import "./EditAndReviewTable.scss";
 
-function TableRow(park) {
-  const navigate = useNavigate();
-  const parkLink = useMemo(() => paths.park(park.orcs), [park.orcs]);
+// Constants
+const currentYear = new Date().getFullYear();
+const lastYear = currentYear - 1;
 
-  // navigate to park details page
-  function navigateToPark() {
-    navigate(parkLink);
-  }
-
+// Functions
+// formats a single date range
+// e.g. startDate – endDate => Mon, 1 Jan – Tue, 31 Dec
+function formattedDateRange(startDate, endDate) {
+  if (!startDate || !endDate) return null;
   return (
-    <tr onClick={navigateToPark} role="button">
-      <th scope="row">{park.name}</th>
-      <td>
-        <StatusBadge status={park.status} />
-        <NotReadyFlag show={!park.readyToPublish} />
-      </td>
-      <td className="text-end">
-        <Link to={parkLink} aria-label={`View ${park.name} park details`}>
-          <FontAwesomeIcon
-            className="me-2 text-body"
-            icon={faChevronRight}
-            aria-hidden="true"
-          />
-          <span className="visually-hidden">View park details</span>
-        </Link>
-      </td>
+    <>
+      {formatDateShort(startDate)} &ndash; {formatDateShort(endDate)}
+    </>
+  );
+}
+
+// Components
+function IconButton({ icon, label, onClick, textColor }) {
+  return (
+    <button
+      onClick={onClick}
+      className={classNames("btn btn-text text-link", textColor)}
+    >
+      <FontAwesomeIcon icon={icon} />
+      <span className="ms-1">{label}</span>
+    </button>
+  );
+}
+
+IconButton.propTypes = {
+  icon: PropTypes.object.isRequired,
+  label: PropTypes.string.isRequired,
+  onClick: PropTypes.func,
+  textColor: PropTypes.string,
+};
+
+// renders all date ranges for a given year as a list
+// e.g. [{ startDate: "Mon Jan 1", endDate: "Tue Jan 2" }, { startDate: "Mon Dec 30", endDate: "Tue Dec 31" }]
+// => Mon, 1 Jan – Tue, 2 Jan / Mon, 30 Dec – Tue, 31 Dec
+function DateRangesList({ year }) {
+  if (!year || year.length === 0) return null;
+  return (
+    <ul className="list-unstyled mb-0">
+      {year.map((dateRange) => (
+        <li key={dateRange.id}>
+          {formattedDateRange(dateRange.startDate, dateRange.endDate)}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+DateRangesList.propTypes = {
+  year: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.number.isRequired,
+      startDate: PropTypes.instanceOf(Date).isRequired,
+      endDate: PropTypes.instanceOf(Date).isRequired,
+    }),
+  ),
+};
+
+function DateTypeTableRow({ groupedDateRanges }) {
+  if (!groupedDateRanges || Object.keys(groupedDateRanges).length === 0)
+    return null;
+  return (
+    <tr className="table-row--date-type">
+      <th scope="col">Type of date</th>
+      <th scope="col">{lastYear}</th>
+      <th scope="col">{currentYear}</th>
     </tr>
   );
 }
 
-export default function EditAndReviewTable({
-  data,
-  onSort,
-  onResetFilters,
-  sortOrder,
-  sortColumn,
+DateTypeTableRow.propTypes = {
+  groupedDateRanges: PropTypes.object,
+};
+
+function DateTableRow({ groupedDateRanges }) {
+  if (!groupedDateRanges) return null;
+  return Object.entries(groupedDateRanges).map(([dateTypeName, yearsObj]) => (
+    <tr key={dateTypeName} className="table-row--date">
+      <td className="fw-bold">{dateTypeName}</td>
+      <td>
+        <DateRangesList year={yearsObj[lastYear]} />
+      </td>
+      <td>
+        <DateRangesList year={yearsObj[currentYear]} />
+      </td>
+    </tr>
+  ));
+}
+
+DateTableRow.propTypes = {
+  groupedDateRanges: PropTypes.object,
+};
+
+function StatusTableRow({
+  id,
+  level,
+  nameCellClass,
+  name,
+  typeName,
+  status,
+  color,
 }) {
-  function getSortClasses(columnId) {
-    return classNames({
-      sortable: true,
-      sorting: sortColumn === columnId,
-      "sort-asc": sortOrder === columnId,
-    });
-  }
+  return (
+    <tr key={id} className={classNames(level && `table-row--${level}`)}>
+      <th
+        scope="col"
+        colSpan="2"
+        className={classNames("align-middle", nameCellClass)}
+      >
+        {name}
+        {typeName && (
+          <div className="fw-normal">
+            <small>{typeName}</small>
+          </div>
+        )}
+      </th>
+      <th scope="col" className="align-middle text-end">
+        <StatusBadge status={status} />
+        <IconButton icon={faPen} label="Edit" textColor={color} />
+        <IconButton icon={faCheck} label="Approve" textColor={color} />
+      </th>
+    </tr>
+  );
+}
 
-  // updates the table sort column, or toggles the sort order
-  function updateSort(columnId) {
-    if (sortColumn === columnId) {
-      onSort(columnId, sortOrder === "asc" ? "desc" : "asc");
-    } else {
-      onSort(columnId, "asc");
-    }
-  }
+StatusTableRow.propTypes = {
+  id: PropTypes.number,
+  level: PropTypes.string,
+  nameCellClass: PropTypes.string,
+  name: PropTypes.string.isRequired,
+  typeName: PropTypes.string,
+  status: PropTypes.string.isRequired,
+  color: PropTypes.string,
+};
 
-  // returns the column sort icon, based on table sorting state
-  function getSortIcon(columnId) {
-    if (sortColumn === columnId) {
-      return sortOrder === "asc" ? faSortUp : faSortDown;
-    }
+function Table(park) {
+  // Constants
+  const parkAreas = park.parkAreas || [];
+  const features = park.features || [];
 
-    return faSort;
-  }
+  // TODO: replace dummy data with real data
+  // dummy data for park
+  const parkGroupedDateRanges = {
+    Operation: {
+      2024: [
+        {
+          id: 1,
+          startDate: new Date("2024-05-15T00:00:00.000Z"),
+          endDate: new Date("2024-10-15T00:00:00.000Z"),
+        },
+      ],
+      2025: [
+        {
+          id: 2,
+          startDate: new Date("2025-11-15T00:00:00.000Z"),
+          endDate: new Date("2025-12-15T00:00:00.000Z"),
+        },
+      ],
+    },
+    Tier1: {
+      2024: [
+        {
+          id: 3,
+          startDate: new Date("2024-05-15T00:00:00.000Z"),
+          endDate: new Date("2024-10-15T00:00:00.000Z"),
+        },
+      ],
+      2025: [],
+    },
+  };
 
   return (
-    <div className="table-responsive">
-      <table className="table table-striped table-hover has-header-row">
-        <thead>
-          <tr>
-            <th
-              scope="col"
-              className={getSortClasses("parkName")}
-              role="button"
-              onClick={() => updateSort("parkName")}
-            >
-              Park name{" "}
-              <FontAwesomeIcon
-                className="ms-1"
-                icon={getSortIcon("parkName")}
-              />
-            </th>
-            <th scope="col" colSpan="2">
-              Status
-            </th>
-          </tr>
-        </thead>
+    <table key={park.id} className="table has-header-row mb-0">
+      <thead>
+        <StatusTableRow
+          level="park"
+          nameCellClass="fw-normal text-white"
+          name={park.name}
+          status={park.status}
+          color="text-white"
+        />
+      </thead>
 
-        <tbody>
-          {data.map((park) => (
-            <TableRow key={park.id} {...park} />
+      <tbody>
+        {/* 1 - park level */}
+        {/* TODO: replace dummy data with real data */}
+        <DateTypeTableRow groupedDateRanges={parkGroupedDateRanges} />
+        <DateTableRow groupedDateRanges={parkGroupedDateRanges} />
+
+        {/* 2 - park area level */}
+        {parkAreas.length > 0 &&
+          parkAreas.map((parkArea) => (
+            <React.Fragment key={parkArea.id}>
+              {/* TODO: replace dummy status */}
+              <StatusTableRow
+                id={parkArea.id}
+                level="park-area"
+                name={`${park.name} - ${parkArea.name}`}
+                status={park.status}
+              />
+              <DateTypeTableRow
+                groupedDateRanges={parkAreas.groupedDateRanges}
+              />
+
+              {/* features that belong to park area */}
+              {parkArea.features.length > 0 &&
+                parkArea.features.map((parkFeature) => (
+                  <React.Fragment key={parkFeature.id}>
+                    <tr className="table-row--park-area-feature">
+                      <th scope="colgroup" colSpan="3">
+                        {parkFeature.name}
+                      </th>
+                    </tr>
+                    <DateTypeTableRow
+                      groupedDateRanges={parkFeature.groupedDateRanges}
+                    />
+                    <DateTableRow
+                      groupedDateRanges={parkFeature.groupedDateRanges}
+                    />
+                  </React.Fragment>
+                ))}
+            </React.Fragment>
           ))}
-        </tbody>
-      </table>
+
+        {/* 3 - feature level */}
+        {features.length > 0 &&
+          features
+            .filter((feature) => !feature.parkAreaId)
+            .map((feature) => (
+              <React.Fragment key={feature.id}>
+                {/* TODO: replace dummy status */}
+                <StatusTableRow
+                  id={feature.id}
+                  level="feature"
+                  name={`${park.name} - ${feature.name}`}
+                  typeName={feature.featureType.name}
+                  status={park.status}
+                />
+                <DateTypeTableRow
+                  groupedDateRanges={feature.groupedDateRanges}
+                />
+                <DateTableRow groupedDateRanges={feature.groupedDateRanges} />
+              </React.Fragment>
+            ))}
+      </tbody>
+    </table>
+  );
+}
+
+Table.propTypes = {
+  id: PropTypes.number.isRequired,
+  name: PropTypes.string.isRequired,
+  status: PropTypes.string.isRequired,
+  parkAreas: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.number.isRequired,
+      name: PropTypes.string.isRequired,
+      features: PropTypes.arrayOf(
+        PropTypes.shape({
+          id: PropTypes.number.isRequired,
+          name: PropTypes.string.isRequired,
+          groupedDateRanges: PropTypes.object,
+        }),
+      ),
+    }),
+  ),
+  features: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.number.isRequired,
+      name: PropTypes.string.isRequired,
+      featureType: PropTypes.shape({
+        name: PropTypes.string.isRequired,
+      }),
+      groupedDateRanges: PropTypes.object,
+    }),
+  ),
+};
+
+export default function EditAndReviewTable({ data, onResetFilters }) {
+  return (
+    <div className="table-responsive">
+      {data.map((park) => (
+        <Table key={park.id} {...park} />
+      ))}
 
       {data.length === 0 && (
         <div className="text-center">
@@ -129,8 +322,5 @@ EditAndReviewTable.propTypes = {
       status: PropTypes.string,
     }),
   ),
-  onSort: PropTypes.func,
   onResetFilters: PropTypes.func,
-  sortOrder: PropTypes.string,
-  sortColumn: PropTypes.string,
 };

--- a/frontend/src/components/EditAndReviewTable.jsx
+++ b/frontend/src/components/EditAndReviewTable.jsx
@@ -142,7 +142,11 @@ function StatusTableRow({
         )}
       </th>
       <th scope="col" className="align-middle text-end text-nowrap">
-        <StatusBadge status={status} />
+        {status && (
+          <div className="d-inline-block me-2">
+            <StatusBadge status={status} />
+          </div>
+        )}
         <IconButton
           icon={faPen}
           label="Edit"
@@ -163,7 +167,7 @@ StatusTableRow.propTypes = {
   nameCellClass: PropTypes.string,
   name: PropTypes.string.isRequired,
   typeName: PropTypes.string,
-  status: PropTypes.string.isRequired,
+  status: PropTypes.string,
   formPanelHandler: PropTypes.func,
   color: PropTypes.string,
 };
@@ -194,12 +198,12 @@ function Table({ park, formPanelHandler }) {
         {/* 2 - park area level */}
         {parkAreas.map((parkArea) => (
           <React.Fragment key={parkArea.id}>
-            {/* TODO: replace dummy status */}
             <StatusTableRow
               id={parkArea.id}
               level="park-area"
               name={`${park.name} - ${parkArea.name}`}
-              status={park.status}
+              typeName={parkArea.featureType.name}
+              status={parkArea.season?.status}
               formPanelHandler={() =>
                 formPanelHandler({ ...parkArea, level: "park-area" })
               }
@@ -231,13 +235,12 @@ function Table({ park, formPanelHandler }) {
           .filter((feature) => !feature.parkAreaId && feature.publishableId)
           .map((feature) => (
             <React.Fragment key={feature.id}>
-              {/* TODO: replace dummy status */}
               <StatusTableRow
                 id={feature.id}
                 level="feature"
                 name={`${park.name} - ${feature.name}`}
                 typeName={feature.featureType.name}
-                status={park.status}
+                status={feature.season?.status}
                 formPanelHandler={() =>
                   formPanelHandler({ ...feature, level: "feature" })
                 }

--- a/frontend/src/components/EditAndReviewTable.jsx
+++ b/frontend/src/components/EditAndReviewTable.jsx
@@ -204,7 +204,7 @@ function Table({ park, formPanelHandler }) {
                 formPanelHandler({ ...parkArea, level: "park-area" })
               }
             />
-            <DateTypeTableRow groupedDateRanges={parkAreas.groupedDateRanges} />
+            <DateTypeTableRow groupedDateRanges={parkArea.groupedDateRanges} />
 
             {/* features that belong to park area */}
             {parkArea.features.map((parkFeature) => (

--- a/frontend/src/components/EditAndReviewTable.scss
+++ b/frontend/src/components/EditAndReviewTable.scss
@@ -1,0 +1,20 @@
+table {
+  tr.table-row {
+    &--park {
+      th {
+        background-color: var(--theme-primary-blue);
+      }
+    }
+    &--park-area,
+    &--feature {
+      th {
+        background-color: var(--theme-blue-10);
+      }
+    }
+    &--park-area-feature {
+      th {
+        background-color: var(--theme-gray-10);
+      }
+    }
+  }
+}

--- a/frontend/src/components/FormPanel.jsx
+++ b/frontend/src/components/FormPanel.jsx
@@ -1,0 +1,39 @@
+import PropTypes from "prop-types";
+import Offcanvas from "react-bootstrap/Offcanvas";
+import "./FormPanel.scss";
+
+function FormPanel({ show, setShow, formData }) {
+  // Constants
+  const data = formData || {};
+  const currentYear = new Date().getFullYear();
+
+  // Functions
+  function handleClose() {
+    setShow(false);
+  }
+
+  return (
+    <Offcanvas
+      show={show}
+      onHide={handleClose}
+      placement="end"
+      className="form-panel"
+    >
+      <Offcanvas.Header closeButton>
+        <Offcanvas.Title>
+          <h2>{data.name}</h2>
+          <h2 className="fw-normal">{currentYear} dates</h2>
+        </Offcanvas.Title>
+      </Offcanvas.Header>
+      <Offcanvas.Body></Offcanvas.Body>
+    </Offcanvas>
+  );
+}
+
+export default FormPanel;
+
+FormPanel.propTypes = {
+  show: PropTypes.bool.isRequired,
+  setShow: PropTypes.func.isRequired,
+  formData: PropTypes.object,
+};

--- a/frontend/src/components/FormPanel.jsx
+++ b/frontend/src/components/FormPanel.jsx
@@ -15,6 +15,7 @@ function FormPanel({ show, setShow, formData }) {
   return (
     <Offcanvas
       show={show}
+      backdrop="static"
       onHide={handleClose}
       placement="end"
       className="form-panel"

--- a/frontend/src/components/FormPanel.scss
+++ b/frontend/src/components/FormPanel.scss
@@ -1,0 +1,9 @@
+.form-panel {
+  &.offcanvas.offcanvas-end {
+    width: 100%;
+    padding: var(--layout-padding-medium);
+    @include from-md {
+      width: 80%;
+    }
+  }
+}

--- a/frontend/src/components/PublishTable.jsx
+++ b/frontend/src/components/PublishTable.jsx
@@ -1,0 +1,140 @@
+// TODO: CMS-848, 899 Create a publish table
+// Copied from EditAndReviewTable.jsx (v1) since it had a similar structure to the publish table design
+// Current EditAndReviewTable.jsx has a different structure
+
+import { useMemo } from "react";
+import PropTypes from "prop-types";
+import { Link, useNavigate } from "react-router-dom";
+import classNames from "classnames";
+import {
+  faSort,
+  faSortUp,
+  faSortDown,
+  faChevronRight,
+} from "@fa-kit/icons/classic/solid";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import paths from "@/router/paths";
+import StatusBadge from "@/components/StatusBadge";
+import NotReadyFlag from "@/components/NotReadyFlag";
+
+function TableRow(park) {
+  const navigate = useNavigate();
+  const parkLink = useMemo(() => paths.park(park.orcs), [park.orcs]);
+
+  // navigate to park details page
+  function navigateToPark() {
+    navigate(parkLink);
+  }
+
+  return (
+    <tr onClick={navigateToPark} role="button">
+      <th scope="row">{park.name}</th>
+      <td>
+        <StatusBadge status={park.status} />
+        <NotReadyFlag show={!park.readyToPublish} />
+      </td>
+      <td className="text-end">
+        <Link to={parkLink} aria-label={`View ${park.name} park details`}>
+          <FontAwesomeIcon
+            className="me-2 text-body"
+            icon={faChevronRight}
+            aria-hidden="true"
+          />
+          <span className="visually-hidden">View park details</span>
+        </Link>
+      </td>
+    </tr>
+  );
+}
+
+export default function PublishTable({
+  data,
+  onSort,
+  onResetFilters,
+  sortOrder,
+  sortColumn,
+}) {
+  function getSortClasses(columnId) {
+    return classNames({
+      sortable: true,
+      sorting: sortColumn === columnId,
+      "sort-asc": sortOrder === columnId,
+    });
+  }
+
+  // updates the table sort column, or toggles the sort order
+  function updateSort(columnId) {
+    if (sortColumn === columnId) {
+      onSort(columnId, sortOrder === "asc" ? "desc" : "asc");
+    } else {
+      onSort(columnId, "asc");
+    }
+  }
+
+  // returns the column sort icon, based on table sorting state
+  function getSortIcon(columnId) {
+    if (sortColumn === columnId) {
+      return sortOrder === "asc" ? faSortUp : faSortDown;
+    }
+
+    return faSort;
+  }
+
+  return (
+    <div className="table-responsive">
+      <table className="table table-striped table-hover has-header-row">
+        <thead>
+          <tr>
+            <th
+              scope="col"
+              className={getSortClasses("parkName")}
+              role="button"
+              onClick={() => updateSort("parkName")}
+            >
+              Park name{" "}
+              <FontAwesomeIcon
+                className="ms-1"
+                icon={getSortIcon("parkName")}
+              />
+            </th>
+            <th scope="col" colSpan="2">
+              Status
+            </th>
+          </tr>
+        </thead>
+
+        <tbody>
+          {data.map((park) => (
+            <TableRow key={park.id} {...park} />
+          ))}
+        </tbody>
+      </table>
+
+      {data.length === 0 && (
+        <div className="text-center">
+          <p>No records match your filters. </p>
+          <p>
+            <button onClick={onResetFilters} className="btn btn-primary">
+              Reset filters to show all records
+            </button>
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// Define prop types for PublishTable
+PublishTable.propTypes = {
+  data: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.number,
+      name: PropTypes.string,
+      status: PropTypes.string,
+    }),
+  ),
+  onSort: PropTypes.func,
+  onResetFilters: PropTypes.func,
+  sortOrder: PropTypes.string,
+  sortColumn: PropTypes.string,
+};

--- a/frontend/src/components/StatusBadge.scss
+++ b/frontend/src/components/StatusBadge.scss
@@ -1,5 +1,5 @@
 .status-badge {
-  outline: var(--layout-border-width-medium) solid var(--bs-white);
+  outline: var(--layout-border-width-medium) solid var(--theme-gray-white);
   &.text-bg-disabled {
     background-color: var(--surface-color-primary-disabled);
     color: var(--typography-color-primary) !important;

--- a/frontend/src/components/StatusBadge.scss
+++ b/frontend/src/components/StatusBadge.scss
@@ -1,4 +1,5 @@
 .status-badge {
+  outline: var(--layout-border-width-medium) solid var(--bs-white);
   &.text-bg-disabled {
     background-color: var(--surface-color-primary-disabled);
     color: var(--typography-color-primary) !important;

--- a/frontend/src/router/pages/EditAndReview.jsx
+++ b/frontend/src/router/pages/EditAndReview.jsx
@@ -8,7 +8,7 @@ import { useMemo, useState } from "react";
 import { orderBy } from "lodash-es";
 import PaginationBar from "@/components/PaginationBar";
 import FilterPanel from "@/components/FilterPanel";
-import FormPanel from "../../components/FormPanel";
+import FormPanel from "@/components/FormPanel";
 
 function EditAndReview() {
   const { data, loading, error } = useApiGet("/parks");

--- a/frontend/src/router/pages/EditAndReview.jsx
+++ b/frontend/src/router/pages/EditAndReview.jsx
@@ -8,6 +8,7 @@ import { useMemo, useState } from "react";
 import { orderBy } from "lodash-es";
 import PaginationBar from "@/components/PaginationBar";
 import FilterPanel from "@/components/FilterPanel";
+import FormPanel from "../../components/FormPanel";
 
 function EditAndReview() {
   const { data, loading, error } = useApiGet("/parks");
@@ -42,7 +43,15 @@ function EditAndReview() {
     isInReservationSystem: false,
     hasDateNote: false,
   });
+  const [formData, setFormData] = useState({});
+  const [showFormPanel, setShowFormPanel] = useState(false);
   const [showFilterPanel, setShowFilterPanel] = useState(false);
+
+  // open form panel when the Edit button is clicked
+  function formPanelHandler(formDataObj) {
+    setFormData(formDataObj);
+    setShowFormPanel(!showFormPanel);
+  }
 
   // table sorting state
   const [sortColumn, setSortColumn] = useState("parkName");
@@ -207,10 +216,8 @@ function EditAndReview() {
         <div className="mb-3">
           <EditAndReviewTable
             data={pageData}
-            onSort={updateSort}
             onResetFilters={resetFilters}
-            sortOrder={sortOrder}
-            sortColumn={sortColumn}
+            formPanelHandler={formPanelHandler}
           />
         </div>
 
@@ -304,6 +311,12 @@ function EditAndReview() {
         </div>
 
         {renderTable()}
+
+        <FormPanel
+          show={showFormPanel}
+          setShow={setShowFormPanel}
+          formData={formData}
+        />
 
         <FilterPanel
           show={showFilterPanel}

--- a/frontend/src/router/pages/EditAndReview.jsx
+++ b/frontend/src/router/pages/EditAndReview.jsx
@@ -28,7 +28,7 @@ function EditAndReview() {
 
   // table pagination
   const [page, setPage] = useState(1);
-  const pageSize = 25;
+  const pageSize = 5;
 
   // table filter state
   const [filters, setFilters] = useState({

--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -220,8 +220,13 @@ label.form-check-label {
 table {
   // override bootstrap table border
   &.has-header-row {
+    border: var(--layout-border-width-medium) solid var(--theme-primary-blue);
     thead {
       border-bottom: 2px solid var(--surface-color-border-dark);
+    }
+    tbody {
+      border-bottom: var(--layout-border-width-small) solid
+        var(--surface-color-border-default);
     }
   }
 }


### PR DESCRIPTION
### Jira Ticket

CMS-894

### Description
- BE: Display `operatingYear` in the Season on AdminJS (not related to this ticket)
- BE: Modify the `/park` endpoint
  - Add `parkArea`
  - Get `dateRange` by `deatableId` and group the dates by `dateType`
  - Get the custom date range group in `park`, `parkArea` and `feature` - use it as `groupedDateRanges`
  - Get `feature` by `parkAreaId` in `parkArea`
  - Get `featureType` in `parkArea` if `parkArea.features` have the same `featureType`
  - Get `season` by `publishableId` in `parkArea` and `feature`
  - Get `season` by `feaureType.publishableId` in `parkArea` and `feature`
  - Filter `season` by `operatingYear` - no need to get data if it's before last year
- FE: Update the dates management table
  - Display Park, Park Area, and Feature level information
  - Remove the Park Details page 
  - Display `feature.name` in its own row if there are Features under the Park Area grouping
  - Add a form panel component 
- TODO: Display the flag next to dates if it's not ready to publish
- TODO: CMS-909 Make the form panel component functional