### PR TITLE
CMS-846: Add support for Tier 1 & 2 dates

### DIFF
--- a/backend/migrations/20250527201506-add-park-tier-columns.js
+++ b/backend/migrations/20250527201506-add-park-tier-columns.js
@@ -1,0 +1,25 @@
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    // Add "hasTier1Dates" and "hasTier2Dates" columns to the "Parks" table
+    await queryInterface.addColumn("Parks", "hasTier1Dates", {
+      type: Sequelize.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+      comment: "Indicates if the Park can have the Tier 1 date type",
+    });
+
+    await queryInterface.addColumn("Parks", "hasTier2Dates", {
+      type: Sequelize.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+      comment: "Indicates if the Park can have the Tier 1 date type",
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    // Remove "hasTier1Dates" and "hasTier2Dates" columns from the "Parks" table
+    await queryInterface.removeColumn("Parks", "hasTier1Dates");
+    await queryInterface.removeColumn("Parks", "hasTier2Dates");
+  },
+};

--- a/backend/models/park.js
+++ b/backend/models/park.js
@@ -60,6 +60,18 @@ export default (sequelize) => {
       // since they're only needed for display in the CSV export
       managementAreas: DataTypes.JSONB,
       inReservationSystem: DataTypes.BOOLEAN,
+
+      hasTier1Dates: {
+        type: DataTypes.BOOLEAN,
+        allowNull: false,
+        defaultValue: false,
+      },
+
+      hasTier2Dates: {
+        type: DataTypes.BOOLEAN,
+        allowNull: false,
+        defaultValue: false,
+      },
     },
     {
       sequelize,

--- a/backend/tasks/create-seasons.js
+++ b/backend/tasks/create-seasons.js
@@ -123,7 +123,7 @@ async function createSeason(publishableId, year) {
  * @param {Park} park Park record to check and create dates for
  * @param {number} year The operating year for the current season
  * @param {number} tier2DateTypeId The ID of the Tier 2 date type
- * @returns {Promise<void>}
+ * @returns {Promise<DateRange[]>|Promise<boolean>} Returns a Promise that resolves to an array of created DateRanges, or false if creation was skipped.
  */
 async function createTier2Dates(
   dateableId,
@@ -266,10 +266,6 @@ const parksQueries = parks.map(async (park) => {
 });
 
 await Promise.all(parksQueries);
-
-// exit with 0 status
-transaction?.rollback();
-process.exit(0);
 
 console.log(`Added ${publishablesAdded} missing Park Publishables`);
 console.log(`Added ${dateablesAdded} missing Park Dateables`);

--- a/backend/tasks/populate-park-tier-types/2025-tier-data.json
+++ b/backend/tasks/populate-park-tier-types/2025-tier-data.json
@@ -1,0 +1,226 @@
+[
+  {
+    "parkName": "Alice Lake Park",
+    "orcs": "90",
+    "note": "T1 in effect March 14, 2025 - Nov 2, 2025",
+    "tierType": "t1",
+    "startDate": "2025-03-14",
+    "endDate": "2025-11-02"
+  },
+  {
+    "parkName": "Cultus Lake Park",
+    "orcs": "41",
+    "note": "T2 in effect January 1, 2025 - March 27, 2025",
+    "tierType": "t2",
+    "startDate": "2025-01-01",
+    "endDate": "2025-03-27"
+  },
+  {
+    "parkName": "Cultus Lake Park",
+    "orcs": "41",
+    "note": "T1 in effect March 28, 2025 - November 16, 2025",
+    "tierType": "t1",
+    "startDate": "2025-03-28",
+    "endDate": "2025-11-16"
+  },
+  {
+    "parkName": "Cultus Lake Park",
+    "orcs": "41",
+    "note": "T2 in effect November 17, 2025 - December 31, 2025",
+    "tierType": "t2",
+    "startDate": "2025-11-17",
+    "endDate": "2025-12-31"
+  },
+  {
+    "parkName": "Fintry Park",
+    "orcs": "9213",
+    "note": "T1 in effect April 4, 2025 - October 13, 2025",
+    "tierType": "t1",
+    "startDate": "2025-04-04",
+    "endDate": "2025-10-13"
+  },
+  {
+    "parkName": "Goldstream Park",
+    "orcs": "96",
+    "note": "T2 in effect May 2, 2025 - May 15, 2025",
+    "tierType": "t2",
+    "startDate": "2025-05-02",
+    "endDate": "2025-05-15"
+  },
+  {
+    "parkName": "Goldstream Park",
+    "orcs": "96",
+    "note": "T1 in effect May 16, 2025 - Sept 1, 2025",
+    "tierType": "t1",
+    "startDate": "2025-05-16",
+    "endDate": "2025-09-01"
+  },
+  {
+    "parkName": "Goldstream Park",
+    "orcs": "96",
+    "note": "T2 in effect Sept 2, 2025 - Sept 13, 2025",
+    "tierType": "t2",
+    "startDate": "2025-09-02",
+    "endDate": "2025-09-13"
+  },
+  {
+    "parkName": "Golden Ears Park",
+    "orcs": "8",
+    "note": "T2 in effect **Note: Golden Ears will remain in Tier 2 until further notice due to internet connectivity issues.",
+    "tierType": "t2",
+    "startDate": "2025-01-01",
+    "endDate": "2026-01-01"
+  },
+  {
+    "parkName": "Gordon Bay Park",
+    "orcs": "210",
+    "note": "T2 in effect January 1, 2025 - May 9, 2025",
+    "tierType": "t2",
+    "startDate": "2025-01-01",
+    "endDate": "2025-05-09"
+  },
+  {
+    "parkName": "Gordon Bay Park",
+    "orcs": "210",
+    "note": "T1 in effect May 10, 2025 - Aug 31, 2025",
+    "tierType": "t1",
+    "startDate": "2025-05-10",
+    "endDate": "2025-08-31"
+  },
+  {
+    "parkName": "Gordon Bay Park",
+    "orcs": "210",
+    "note": "T2 in effect Sept. 1, 2025 - Dec. 31, 2025",
+    "tierType": "t2",
+    "startDate": "2025-09-01",
+    "endDate": "2025-12-31"
+  },
+  {
+    "parkName": "Kikomun Creek Park",
+    "orcs": "235",
+    "note": "T2 in effect May 5 - June 24, 2025",
+    "tierType": "t2",
+    "startDate": "2025-05-05",
+    "endDate": "2025-06-24"
+  },
+  {
+    "parkName": "Kikomun Creek Park",
+    "orcs": "235",
+    "note": "T1 in effect June 25 - Sept 1, 2025",
+    "tierType": "t1",
+    "startDate": "2025-06-25",
+    "endDate": "2025-09-01"
+  },
+  {
+    "parkName": "Kikomun Creek Park",
+    "orcs": "235",
+    "note": "T2 in effect Sept 2 - Oct 1, 2025",
+    "tierType": "t2",
+    "startDate": "2025-09-02",
+    "endDate": "2025-10-01"
+  },
+  {
+    "parkName": "Lakelse Lake Park",
+    "orcs": "70",
+    "note": "T1 in effect May 2, 2025 - September 14, 2025",
+    "tierType": "t1",
+    "startDate": "2025-05-02",
+    "endDate": "2025-09-14"
+  },
+  {
+    "parkName": "Lakelse Lake Park",
+    "orcs": "70",
+    "note": "T2 in effect September 15 - October 6, 2025",
+    "tierType": "t2",
+    "startDate": "2025-09-15",
+    "endDate": "2025-10-06"
+  },
+  {
+    "parkName": "Miracle Beach Park",
+    "orcs": "45",
+    "note": "T2 in effect March 14, 2025 - June 12, 2025",
+    "tierType": "t2",
+    "startDate": "2025-03-14",
+    "endDate": "2025-06-12"
+  },
+  {
+    "parkName": "Miracle Beach Park",
+    "orcs": "45",
+    "note": "T1 in effect June 13, 2025 - Sept 6, 2025",
+    "tierType": "t1",
+    "startDate": "2025-06-13",
+    "endDate": "2025-09-06"
+  },
+  {
+    "parkName": "Miracle Beach Park",
+    "orcs": "45",
+    "note": "T2 in effect Sept 7, 2025 - October 30, 2025",
+    "tierType": "t2",
+    "startDate": "2025-09-07",
+    "endDate": "2025-10-30"
+  },
+  {
+    "parkName": "Okanagan Lake Park",
+    "orcs": "54",
+    "note": "T2 in effect March 28, 2025 - June 10, 2025",
+    "tierType": "t2",
+    "startDate": "2025-03-28",
+    "endDate": "2025-06-10"
+  },
+  {
+    "parkName": "Okanagan Lake Park",
+    "orcs": "54",
+    "note": "T1 in effect June 11, 2025 - September 1, 2025",
+    "tierType": "t1",
+    "startDate": "2025-06-11",
+    "endDate": "2025-09-01"
+  },
+  {
+    "parkName": "Okanagan Lake Park",
+    "orcs": "54",
+    "note": "T2 in effect September 2, 2025 - October 13, 2025",
+    "tierType": "t2",
+    "startDate": "2025-09-02",
+    "endDate": "2025-10-13"
+  },
+  {
+    "parkName": "Porteau Cove Park",
+    "orcs": "314",
+    "note": "T1 in effect Year Round",
+    "tierType": "t1",
+    "startDate": "2025-01-01",
+    "endDate": "2026-01-01"
+  },
+  {
+    "parkName": "Rathtrevor Beach Park",
+    "orcs": "193",
+    "note": "T2 in effect Apr 11, 2025 - May 15, 2025",
+    "tierType": "t2",
+    "startDate": "2025-04-11",
+    "endDate": "2025-05-15"
+  },
+  {
+    "parkName": "Rathtrevor Beach Park",
+    "orcs": "193",
+    "note": "T1 in effect May 16, 2025 - Sept 1, 2025",
+    "tierType": "t1",
+    "startDate": "2025-05-16",
+    "endDate": "2025-09-01"
+  },
+  {
+    "parkName": "Rathtrevor Beach Park",
+    "orcs": "193",
+    "note": "T2 in effect Sept 2, 2025 - Oct 12, 2025",
+    "tierType": "t2",
+    "startDate": "2025-09-02",
+    "endDate": "2025-10-12"
+  },
+  {
+    "parkName": "Shuswap Lake Park",
+    "orcs": "89",
+    "note": "T1 in effect May 1, 2024 - Oct 14, 2024",
+    "tierType": "t1",
+    "startDate": "2024-05-01",
+    "endDate": "2024-10-14"
+  }
+]

--- a/backend/tasks/populate-park-tier-types/README.md
+++ b/backend/tasks/populate-park-tier-types/README.md
@@ -1,0 +1,8 @@
+# Populate Park Tier1/Tier2 flags
+
+The Park model has 2 columns: `hasTier1Dates` and `hasTier1Dates` that indicate if the Park has Tier1/Tier2 dates.
+This script sets the flags based on provided JSON data.
+
+This script is designed to run one time in each environment, to intially populate the fields. If the data changes, you can reset all the parks to "false" and re-run the script with a new JSON file.
+
+Small updates can be done through AdminJS.

--- a/backend/tasks/populate-park-tier-types/populate-park-tier-types.js
+++ b/backend/tasks/populate-park-tier-types/populate-park-tier-types.js
@@ -1,0 +1,43 @@
+import fs from "node:fs";
+import path from "node:path";
+import { Park } from "../../models/index.js";
+
+// Load JSON data
+const jsonPath = path.join(import.meta.dirname, "2025-tier-data.json");
+const jsonData = JSON.parse(fs.readFileSync(jsonPath, "utf8"));
+
+// Update each  park
+const updateQueries = jsonData.map(async (parkData) => {
+  const { orcs, tierType } = parkData;
+  const columnName = tierType === "t1" ? "hasTier1Dates" : "hasTier2Dates";
+
+  try {
+    const park = await Park.findOne({
+      where: { orcs },
+    });
+
+    if (!park) {
+      throw new Error(`Park with orcs ${orcs} not found.`);
+    }
+
+    // Update the
+    const updateQuery = await park.update({
+      [columnName]: true,
+      where: {
+        orcs,
+      },
+    });
+
+    console.log(`Updated park ${orcs} with tierType ${tierType}`);
+
+    return updateQuery;
+  } catch (error) {
+    console.error(`Error updating park ${orcs}:`, error);
+  }
+
+  return null;
+});
+
+await Promise.all(updateQueries);
+
+console.log("Done");


### PR DESCRIPTION
### Jira Ticket

CMS-846

### Description
<!-- What did you change, and why? -->

This branch adds some extra fields for requesting Tier 1 and 2 dates at the park level. (Only some of the parks will have these special date types, specified in the [2025-tier-data.json](https://github.com/bcgov/bcparks-staff-portal/compare/alpha...CMS-846-tier1-tier2?expand=1#diff-90e7d42e2b3a63c019b1d38b8dfc8c4fc59df3c588c5d3b51eac5c1c5ac38b12) data file)

- Adds two columns to the Park model: hasTier1Dates and hasTier2Dates
- Adds a script, [populate-park-tier-types.js](https://github.com/bcgov/bcparks-staff-portal/compare/alpha...CMS-846-tier1-tier2?expand=1#diff-f8ab9935fa66cbde755d70ef916edf08625b4c1bc3846978f86502d4fc6eac61) which will populate the new columns from some data provided by the client. (We only need to run this once)
- Updated the "create-seasons" script with the logic below:

# create-seasons script updates
When creating new seasons for a Park, if that Park supports tier 2 dates:
If the Park had any tier 2 dates last year, create the same number of blank date ranges in the new park season so users don't have to manually add Tier 2 dates.
If the existing season already  has any tier 2 dates, it will just skip to avoid adding too many.