### PR TITLE
CMS-969: Move hasWinterFeeDates to Park level

### DIFF
--- a/backend/migrations/20250611230755-add-park-winter-col.js
+++ b/backend/migrations/20250611230755-add-park-winter-col.js
@@ -1,0 +1,26 @@
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    // Remove hasWinterFeeDates field from Feature
+    await queryInterface.removeColumn("Features", "hasWinterFeeDates");
+
+    // Add hasWinterFeeDates field to Park
+    await queryInterface.addColumn("Parks", "hasWinterFeeDates", {
+      type: Sequelize.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    // Remove hasWinterFeeDates field from Park
+    await queryInterface.removeColumn("Parks", "hasWinterFeeDates");
+
+    // Add hasWinterFeeDates field back to Feature
+    await queryInterface.addColumn("Features", "hasWinterFeeDates", {
+      type: Sequelize.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    });
+  },
+};

--- a/backend/models/feature.js
+++ b/backend/models/feature.js
@@ -51,7 +51,6 @@ export default (sequelize) => {
       parkAreaId: DataTypes.INTEGER,
       active: DataTypes.BOOLEAN,
       strapiId: DataTypes.INTEGER,
-      hasWinterFeeDates: DataTypes.BOOLEAN,
       inReservationSystem: DataTypes.BOOLEAN,
     },
     {

--- a/backend/models/park.js
+++ b/backend/models/park.js
@@ -73,6 +73,12 @@ export default (sequelize) => {
         allowNull: false,
         defaultValue: false,
       },
+
+      hasWinterFeeDates: {
+        type: DataTypes.BOOLEAN,
+        allowNull: false,
+        defaultValue: false,
+      },
     },
     {
       sequelize,

--- a/backend/routes/api/publish.js
+++ b/backend/routes/api/publish.js
@@ -90,7 +90,7 @@ router.get(
           seasonMap[key] = {
             fetchConditions: {
               parkId: season.parkId,
-              hasWinterFeeDates: true,
+              // hasWinterFeeDates: true, // removed in v2 data model
             },
             seasons: [],
           };
@@ -122,13 +122,7 @@ router.get(
       where: {
         [Op.or]: parkFeaturePairs,
       },
-      attributes: [
-        "id",
-        "name",
-        "strapiId",
-        "featureTypeId",
-        "hasWinterFeeDates",
-      ],
+      attributes: ["id", "name", "strapiId", "featureTypeId"],
       include: [
         {
           model: Park,

--- a/backend/strapi-sync/create-missing-dates-and-seasons.js
+++ b/backend/strapi-sync/create-missing-dates-and-seasons.js
@@ -34,7 +34,6 @@ export async function createMissingDatesAndSeasons() {
         "parkId",
         "featureTypeId",
         "hasReservations",
-        "hasWinterFeeDates",
       ],
       include: [
         {
@@ -150,33 +149,35 @@ export async function createMissingDatesAndSeasons() {
     }
 
     // add winter fee seasons
-    if (feature.hasWinterFeeDates) {
-      const winterKey = `${feature.parkId}-${winterFeatureType.id}`;
+    // @TODO: reimplement winter fee dates logic for v2 data structure
+    // (winter fee dates are now at the Park level instead of Feature level)
+    // if (feature.hasWinterFeeDates) {
+    //   const winterKey = `${feature.parkId}-${winterFeatureType.id}`;
 
-      // get 2024 winter season
-      const winterSeason2024 = seasonMap2024.get(winterKey);
+    //   // get 2024 winter season
+    //   const winterSeason2024 = seasonMap2024.get(winterKey);
 
-      if (winterSeason2024) {
-        const winterSeason = await getOrCreateSeason(
-          feature.parkId,
-          winterFeatureType.id,
-        );
+    //   if (winterSeason2024) {
+    //     const winterSeason = await getOrCreateSeason(
+    //       feature.parkId,
+    //       winterFeatureType.id,
+    //     );
 
-        const existingWinterDates = feature.dateable.dateRanges.filter(
-          (dateRange) => dateRange.seasonId === winterSeason.id,
-        );
+    //     const existingWinterDates = feature.dateable.dateRanges.filter(
+    //       (dateRange) => dateRange.seasonId === winterSeason.id,
+    //     );
 
-        if (existingWinterDates.length === 0) {
-          datesToCreate.push({
-            startDate: null,
-            endDate: null,
-            dateTypeId: dateTypeMap.get("Winter fee").id,
-            dateableId: feature.dateable.id,
-            seasonId: winterSeason.id,
-          });
-        }
-      }
-    }
+    //     if (existingWinterDates.length === 0) {
+    //       datesToCreate.push({
+    //         startDate: null,
+    //         endDate: null,
+    //         dateTypeId: dateTypeMap.get("Winter fee").id,
+    //         dateableId: feature.dateable.id,
+    //         seasonId: winterSeason.id,
+    //       });
+    //     }
+    //   }
+    // }
   }
 
   if (datesToCreate.length > 0) {

--- a/backend/strapi-sync/sync.js
+++ b/backend/strapi-sync/sync.js
@@ -674,18 +674,6 @@ export async function createDatesAndSeasons(datesData) {
   }
 
   await DateRange.bulkCreate(winterDatesToCreate);
-  await Feature.update(
-    {
-      hasWinterFeeDates: true,
-    },
-    {
-      where: {
-        id: {
-          [Op.in]: Array.from(featuresWithWinterFees),
-        },
-      },
-    },
-  );
 }
 
 /**

--- a/backend/tasks/populate-park-tier-types/populate-park-tier-types.js
+++ b/backend/tasks/populate-park-tier-types/populate-park-tier-types.js
@@ -6,7 +6,7 @@ import { Park } from "../../models/index.js";
 const jsonPath = path.join(import.meta.dirname, "2025-tier-data.json");
 const jsonData = JSON.parse(fs.readFileSync(jsonPath, "utf8"));
 
-// Update each  park
+// Update each park
 const updateQueries = jsonData.map(async (parkData) => {
   const { orcs, tierType } = parkData;
   const columnName = tierType === "t1" ? "hasTier1Dates" : "hasTier2Dates";

--- a/backend/tasks/populate-park-winter-fee-flag/2025-winter-parks.json
+++ b/backend/tasks/populate-park-winter-fee-flag/2025-winter-parks.json
@@ -1,0 +1,70 @@
+[
+  {
+    "orcs": "8",
+    "name": "Golden Ears Park"
+  },
+  {
+    "orcs": "28",
+    "name": "Elk Falls Park"
+  },
+  {
+    "orcs": "41",
+    "name": "Cultus Lake Park"
+  },
+  {
+    "orcs": "45",
+    "name": "Miracle Beach Park"
+  },
+  {
+    "orcs": "48",
+    "name": "Fillongley Park"
+  },
+  {
+    "orcs": "92",
+    "name": "Liard River Hot Springs Park"
+  },
+  {
+    "orcs": "96",
+    "name": "Goldstream Park"
+  },
+  {
+    "orcs": "104",
+    "name": "Montague Harbour Marine Park"
+  },
+  {
+    "orcs": "117",
+    "name": "Bamberton Park"
+  },
+  {
+    "orcs": "122",
+    "name": "Rolley Lake Park"
+  },
+  {
+    "orcs": "190",
+    "name": "Morton Lake Park"
+  },
+  {
+    "orcs": "193",
+    "name": "Rathtrevor Beach Park"
+  },
+  {
+    "orcs": "210",
+    "name": "Gordon Bay Park"
+  },
+  {
+    "orcs": "262",
+    "name": "French Beach Park"
+  },
+  {
+    "orcs": "267",
+    "name": "Ruckle Park"
+  },
+  {
+    "orcs": "314",
+    "name": "Porteau Cove Park"
+  },
+  {
+    "orcs": "6161",
+    "name": "Cowichan River Park"
+  }
+]

--- a/backend/tasks/populate-park-winter-fee-flag/README.md
+++ b/backend/tasks/populate-park-winter-fee-flag/README.md
@@ -1,0 +1,8 @@
+# Populate Park Winter fee dates flags
+
+The Park model has a `hasWinterFeeDates` flag column that indicates if the Park has Winter fee dates.
+This script sets the flag based on provided JSON data.
+
+This script is designed to run one time in each environment, to intially populate the field. If the data changes, you can reset all the parks to "false" and re-run the script with a new JSON file.
+
+Small updates can be done through AdminJS.

--- a/backend/tasks/populate-park-winter-fee-flag/populate-park-winter-fee-flag.js
+++ b/backend/tasks/populate-park-winter-fee-flag/populate-park-winter-fee-flag.js
@@ -1,0 +1,27 @@
+import { Op } from "sequelize";
+import fs from "node:fs";
+import path from "node:path";
+import { Park } from "../../models/index.js";
+
+// Load JSON data (originally from strapi-sync/park-winter-dates.json)
+const jsonPath = path.join(import.meta.dirname, "2025-winter-parks.json");
+const jsonData = JSON.parse(fs.readFileSync(jsonPath, "utf8"));
+
+const orcsCodes = jsonData.map((park) => park.orcs);
+
+// Update each park
+// set hasWinterFeeDates true if orcs is in orcsCodes
+const [numUpdated] = await Park.update(
+  { hasWinterFeeDates: true },
+  {
+    where: {
+      orcs: {
+        [Op.in]: orcsCodes,
+      },
+    },
+  },
+);
+
+console.log(`Updated ${numUpdated} parks with winter fee dates`);
+
+console.log("Done");


### PR DESCRIPTION
### Jira Ticket

CMS-969

### Description
<!-- What did you change, and why? -->

This ticket removes the `hasWinterFeeDates` field from the Feature model and puts it in the Park model.
I added a one-time script to populate the columns using the same parks list we already had from the client. The `hasWinterFeeDates` field is not used by anything at the moment but it will be used by the Season edit form, and the scripts to publish approved dates / create requested dates when we eventually implement them.