### PR TITLE
CMS-896: Allow clicking outside of form panel to close it

### DIFF
--- a/frontend/src/components/FormPanel.jsx
+++ b/frontend/src/components/FormPanel.jsx
@@ -199,7 +199,6 @@ function FormPanel({ show, setShow, formData, approver }) {
   return (
     <Offcanvas
       show={show}
-      backdrop="static"
       onHide={handleClose}
       placement="end"
       className="form-panel"


### PR DESCRIPTION
### Jira Ticket

CMS-896

### Description
<!-- What did you change, and why? -->
- Allow clicking outside of the form panel to close it
- Note: Not urgent but it'd be good to come back here again to discuss whether we should display an alert/warning before closing it to avoid unintentional behaviour