### PR TITLE
CMS-929: Add modal windows and navigation guard

### DIFF
--- a/frontend/src/components/ConfirmationDialog.scss
+++ b/frontend/src/components/ConfirmationDialog.scss
@@ -8,7 +8,8 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  z-index: 100;
+  // Above the Offcanvas panel (1045) and the Flash message (1046)
+  z-index: 1047;
 }
 
 .confirmation-dialog-container {

--- a/frontend/src/components/ConfirmationDialog.scss
+++ b/frontend/src/components/ConfirmationDialog.scss
@@ -47,6 +47,9 @@
 
 .confirmation-dialog-message {
   margin-bottom: var(--layout-margin-large);
+
+  // Render line breaks in the message
+  white-space: pre-line;
 }
 
 .missing-dates-confirmation-dialog-message {

--- a/frontend/src/components/FormPanel.jsx
+++ b/frontend/src/components/FormPanel.jsx
@@ -204,6 +204,8 @@ function SeasonForm({
       gateDetail: season.gateDetail,
       readyToPublish: season.readyToPublish,
       notes,
+      dateRangeAnnuals: changedDateRangeAnnuals,
+      gateDetail: season.gateDetail,
     };
 
     return payload;

--- a/frontend/src/components/FormPanel.jsx
+++ b/frontend/src/components/FormPanel.jsx
@@ -388,6 +388,7 @@ SeasonForm.propTypes = {
   level: PropTypes.string.isRequired,
   closePanel: PropTypes.func.isRequired,
   onDataUpdate: PropTypes.func.isRequired,
+  setDataChanged: PropTypes.func.isRequired,
 };
 
 function FormPanel({ show, setShow, formData, onDataUpdate }) {

--- a/frontend/src/components/FormPanel.jsx
+++ b/frontend/src/components/FormPanel.jsx
@@ -222,7 +222,14 @@ function SeasonForm({
     if (changesPayload.deletedDateRangeIds.length) return true;
 
     // Check if readyToPublish changed
-    if (season.readyToPublish !== apiData?.current?.readyToPublish) return true;
+    if (changesPayload.readyToPublish !== apiData?.current?.readyToPublish)
+      return true;
+
+    // Check if any date annuals were updated
+    if (changesPayload.dateRangeAnnuals.length) return true;
+
+    // Check if any gateDetails changed
+    // @TODO: check changesPayload.gateDetail against apiData.gateDetail
 
     // If nothing else has changed, return true if notes are entered
     return changesPayload.notes.length > 0;

--- a/frontend/src/components/FormPanel.jsx
+++ b/frontend/src/components/FormPanel.jsx
@@ -165,7 +165,7 @@ function SeasonForm({
   }
 
   // Memoize the updated data for saving or detecting changes
-  const savePayload = useMemo(() => {
+  const changesPayload = useMemo(() => {
     if (!season) return null;
 
     // Format the data for the API
@@ -214,17 +214,17 @@ function SeasonForm({
     if (!season) return false;
 
     // Return true if date ranges were updated
-    if (savePayload.dateRanges.length) return true;
+    if (changesPayload.dateRanges.length) return true;
 
     // Return true if date ranges were deleted
-    if (savePayload.deletedDateRangeIds.length) return true;
+    if (changesPayload.deletedDateRangeIds.length) return true;
 
     // Check if readyToPublish changed
     if (season.readyToPublish !== apiData?.current?.readyToPublish) return true;
 
     // If nothing else has changed, return true if notes are entered
-    return savePayload.notes.length > 0;
-  }, [season, savePayload, apiData]);
+    return changesPayload.notes.length > 0;
+  }, [season, changesPayload, apiData]);
 
   // Update the parent component when dataChanged is updated
   useEffect(() => {
@@ -232,7 +232,7 @@ function SeasonForm({
   }, [dataChanged, setDataChanged]);
 
   async function onSave(close = true) {
-    await sendSave(savePayload);
+    await sendSave(changesPayload);
 
     // Start refreshing the main page data from the API
     onDataUpdate();

--- a/frontend/src/components/FormPanel.jsx
+++ b/frontend/src/components/FormPanel.jsx
@@ -204,8 +204,6 @@ function SeasonForm({
       gateDetail: season.gateDetail,
       readyToPublish: season.readyToPublish,
       notes,
-      dateRangeAnnuals: changedDateRangeAnnuals,
-      gateDetail: season.gateDetail,
     };
 
     return payload;

--- a/frontend/src/components/FormPanel.jsx
+++ b/frontend/src/components/FormPanel.jsx
@@ -88,6 +88,7 @@ function SeasonForm({
   closePanel,
   onDataUpdate,
   setDataChanged,
+  openModal,
 }) {
   // Global flash message context
   const flashMessage = useContext(globalFlashMessageContext);
@@ -252,6 +253,26 @@ function SeasonForm({
     }
   }
 
+  async function promptAndSave(close = true) {
+    if (dataChanged) {
+      const proceed = await openModal(
+        "Move back to draft?",
+        `The dates will be moved back to draft and need to be submitted again to be reviewed.
+
+If dates have already been published, they will not be updated until new dates are submitted, approved, and published. `,
+        "Move to draft",
+        "Cancel",
+      );
+
+      // If the user cancels in the confirmation modal, don't close the edit form
+      if (!proceed) {
+        return;
+      }
+    }
+
+    onSave(close);
+  }
+
   async function onApprove() {
     // Save first, then approve
     await onSave(false); // Don't close the form after saving
@@ -374,7 +395,7 @@ function SeasonForm({
         <Buttons
           approver={approver}
           onApprove={onApprove}
-          onSave={() => onSave(false)}
+          onSave={() => promptAndSave(false)}
           onSubmit={onSubmit}
           loading={sendingApprove || sendingSubmit || sendingSave}
         />
@@ -389,6 +410,7 @@ SeasonForm.propTypes = {
   closePanel: PropTypes.func.isRequired,
   onDataUpdate: PropTypes.func.isRequired,
   setDataChanged: PropTypes.func.isRequired,
+  openModal: PropTypes.func.isRequired,
 };
 
 function FormPanel({ show, setShow, formData, onDataUpdate }) {
@@ -440,6 +462,7 @@ function FormPanel({ show, setShow, formData, onDataUpdate }) {
             closePanel={closePanel}
             onDataUpdate={onDataUpdate}
             setDataChanged={setDataChanged}
+            openModal={modal.open}
           />
         )}
       </Offcanvas>

--- a/frontend/src/components/FormPanel.jsx
+++ b/frontend/src/components/FormPanel.jsx
@@ -14,6 +14,7 @@ import ConfirmationDialog from "@/components/ConfirmationDialog";
 import { useApiGet, useApiPost } from "@/hooks/useApi";
 import useAccess from "@/hooks/useAccess";
 import useConfirmation from "@/hooks/useConfirmation";
+import useNavigationGuard from "@/hooks/useNavigationGuard";
 import DataContext from "@/contexts/DataContext";
 import globalFlashMessageContext from "@/contexts/FlashMessageContext";
 
@@ -395,6 +396,9 @@ function FormPanel({ show, setShow, formData, onDataUpdate }) {
   const [dataChanged, setDataChanged] = useState(false);
   const modal = useConfirmation();
 
+  // Prevent navigating away if the data has changed
+  useNavigationGuard(dataChanged);
+
   // Functions
   function closePanel() {
     setShow(false);
@@ -402,8 +406,6 @@ function FormPanel({ show, setShow, formData, onDataUpdate }) {
 
   // Prompt the user if data has changed before closing
   async function promptAndClose() {
-    console.log("prompt and close called");
-
     if (dataChanged) {
       const proceed = await modal.open(
         "Discard changes?",

--- a/frontend/src/components/FormPanel.jsx
+++ b/frontend/src/components/FormPanel.jsx
@@ -423,11 +423,14 @@ function FormPanel({ show, setShow, formData, onDataUpdate }) {
   useNavigationGuard(dataChanged);
 
   // Functions
+
+  // Hides the form panel and resets the dataChanged state
   function closePanel() {
     setShow(false);
+    setDataChanged(false);
   }
 
-  // Prompt the user if data has changed before closing
+  // Prompts the user if data has changed before closing
   async function promptAndClose() {
     if (dataChanged) {
       const proceed = await modal.open(

--- a/frontend/src/components/FormPanel.jsx
+++ b/frontend/src/components/FormPanel.jsx
@@ -1,7 +1,7 @@
 import { useContext, useEffect, useMemo, useState } from "react";
 import Offcanvas from "react-bootstrap/Offcanvas";
 import PropTypes from "prop-types";
-import { omit } from "lodash-es";
+import { isEqual, omit } from "lodash-es";
 
 import FeatureIcon from "@/components/FeatureIcon";
 import InternalNotes from "@/components/InternalNotes";
@@ -228,8 +228,9 @@ function SeasonForm({
     // Check if any date annuals were updated
     if (changesPayload.dateRangeAnnuals.length) return true;
 
-    // Check if any gateDetails changed
-    // @TODO: check changesPayload.gateDetail against apiData.gateDetail
+    // Check if any gateDetail values changed
+    if (!isEqual(changesPayload.gateDetail, apiData?.current?.gateDetail))
+      return true;
 
     // If nothing else has changed, return true if notes are entered
     return changesPayload.notes.length > 0;

--- a/frontend/src/hooks/useConfirmation.js
+++ b/frontend/src/hooks/useConfirmation.js
@@ -37,14 +37,14 @@ export default function useConfirmation() {
     ],
   );
 
-  function handleConfirm() {
+  function onConfirm() {
     if (resolvePromise) {
       resolvePromise(true); // Resolve with true
     }
     setIsOpen(false);
   }
 
-  function handleCancel() {
+  function onCancel() {
     if (resolvePromise) {
       resolvePromise(false); // Resolve with false
     }
@@ -52,14 +52,17 @@ export default function useConfirmation() {
   }
 
   return {
-    title: titleText,
-    message: messageText,
-    confirmButtonText,
-    cancelButtonText,
-    notes,
     open,
-    handleConfirm,
-    handleCancel,
-    isOpen,
+
+    props: {
+      title: titleText,
+      message: messageText,
+      confirmButtonText,
+      cancelButtonText,
+      notes,
+      isOpen,
+      onConfirm,
+      onCancel,
+    },
   };
 }

--- a/frontend/src/hooks/useConfirmation.js
+++ b/frontend/src/hooks/useConfirmation.js
@@ -54,6 +54,7 @@ export default function useConfirmation() {
   return {
     open,
 
+    // Export all the component props as one object for convenience
     props: {
       title: titleText,
       message: messageText,

--- a/frontend/src/hooks/useConfirmation.js
+++ b/frontend/src/hooks/useConfirmation.js
@@ -1,25 +1,25 @@
 import { useCallback, useState } from "react";
 
-export function useConfirmation() {
+export default function useConfirmation() {
   const [isOpen, setIsOpen] = useState(false);
-  const [title, setTitle] = useState("");
-  const [message, setMessage] = useState("");
+  const [titleText, setTitleText] = useState("");
+  const [messageText, setMessageText] = useState("");
   const [notes, setNotes] = useState("");
   const [confirmButtonText, setConfirmButtonText] = useState("");
   const [cancelButtonText, setCancelButtonText] = useState("");
   const [resolvePromise, setResolvePromise] = useState(null);
 
-  const openConfirmation = useCallback(
+  const open = useCallback(
     (
-      confirmationTitle,
-      confirmationMessage,
+      title,
+      message,
       confirmText = "Confirm",
       cancelText = "Cancel",
       notesParam = "",
     ) =>
       new Promise((resolve) => {
-        setTitle(confirmationTitle);
-        setMessage(confirmationMessage);
+        setTitleText(title);
+        setMessageText(message);
         setNotes(notesParam);
         setConfirmButtonText(confirmText);
         setCancelButtonText(cancelText);
@@ -27,8 +27,8 @@ export function useConfirmation() {
         setIsOpen(true);
       }),
     [
-      setTitle,
-      setMessage,
+      setTitleText,
+      setMessageText,
       setNotes,
       setConfirmButtonText,
       setCancelButtonText,
@@ -52,14 +52,14 @@ export function useConfirmation() {
   }
 
   return {
-    title,
-    message,
+    title: titleText,
+    message: messageText,
     confirmButtonText,
     cancelButtonText,
-    confirmationDialogNotes: notes,
-    openConfirmation,
+    notes,
+    open,
     handleConfirm,
     handleCancel,
-    isConfirmationOpen: isOpen,
+    isOpen,
   };
 }

--- a/frontend/src/hooks/useMissingDatesConfirmation.js
+++ b/frontend/src/hooks/useMissingDatesConfirmation.js
@@ -6,7 +6,7 @@ export function useMissingDatesConfirmation() {
   const [inputMessage, setInputMessage] = useState("");
   const [resolvePromise, setResolvePromise] = useState(null);
 
-  function openConfirmation(featureNameList) {
+  function open(featureNameList) {
     return new Promise((resolve) => {
       setFeatureNames(featureNameList);
       setResolvePromise(() => resolve); // Store the resolve function
@@ -16,14 +16,14 @@ export function useMissingDatesConfirmation() {
 
   function handleConfirm() {
     if (resolvePromise) {
-      resolvePromise({ confirm: true, confirmationMessage: inputMessage }); // Resolve with true
+      resolvePromise({ confirm: true, message: inputMessage }); // Resolve with true
     }
     setIsOpen(false);
   }
 
   function handleCancel() {
     if (resolvePromise) {
-      resolvePromise({ confirm: false, confirmationMessage: inputMessage }); // Resolve with false
+      resolvePromise({ confirm: false, message: inputMessage }); // Resolve with false
     }
     setIsOpen(false);
   }
@@ -34,7 +34,7 @@ export function useMissingDatesConfirmation() {
     inputMessage,
     setInputMessage,
 
-    openConfirmation,
+    open,
     handleConfirm,
     handleCancel,
     isOpen,

--- a/frontend/src/hooks/useMissingDatesConfirmation.js
+++ b/frontend/src/hooks/useMissingDatesConfirmation.js
@@ -14,14 +14,14 @@ export function useMissingDatesConfirmation() {
     });
   }
 
-  function handleConfirm() {
+  function onConfirm() {
     if (resolvePromise) {
       resolvePromise({ confirm: true, message: inputMessage }); // Resolve with true
     }
     setIsOpen(false);
   }
 
-  function handleCancel() {
+  function onCancel() {
     if (resolvePromise) {
       resolvePromise({ confirm: false, message: inputMessage }); // Resolve with false
     }
@@ -35,8 +35,8 @@ export function useMissingDatesConfirmation() {
     setInputMessage,
 
     open,
-    handleConfirm,
-    handleCancel,
+    onConfirm,
+    onCancel,
     isOpen,
   };
 }

--- a/frontend/src/router/pages/EditAndReview.jsx
+++ b/frontend/src/router/pages/EditAndReview.jsx
@@ -54,15 +54,27 @@ function EditAndReview() {
   async function formPanelHandler(formDataObj) {
     const status = formDataObj.currentSeason.status;
 
-    console.log("check stuff here", status, formDataObj);
-
-    // If the season is already published to the CMS, prompt to continue
-    if (status === "published") {
+    // If the season is already approved, prompt to continue
+    if (status === "approved") {
       const proceed = await modal.open(
-        "@TODO: text here",
-        "@TODO: text here",
-        "@TODO: text here",
-        "@TODO: text here",
+        "Edit approved dates?",
+        "Dates will need to be reviewed again to be approved.",
+        "Edit",
+        "Cancel",
+      );
+
+      // If the user cancels in the confirmation modal, don't open the edit form
+      if (!proceed) {
+        return;
+      }
+    }
+    // If the season is already published to the CMS, prompt to continue
+    else if (status === "published") {
+      const proceed = await modal.open(
+        "Edit public dates on API?",
+        "Dates will need to be reviewed again to be approved and published. If reservations have already begun, visitors will be affected.",
+        "Continue to edit",
+        "Cancel",
       );
 
       // If the user cancels in the confirmation modal, don't open the edit form

--- a/frontend/src/router/pages/EditAndReview.jsx
+++ b/frontend/src/router/pages/EditAndReview.jsx
@@ -1,6 +1,7 @@
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faMagnifyingGlass, faFilter } from "@fa-kit/icons/classic/solid";
 import { useApiGet } from "@/hooks/useApi";
+import useConfirmation from "@/hooks/useConfirmation";
 import EditAndReviewTable from "@/components/EditAndReviewTable";
 import LoadingBar from "@/components/LoadingBar";
 import MultiSelect from "@/components/MultiSelect";
@@ -8,6 +9,7 @@ import { useMemo, useState } from "react";
 import PaginationBar from "@/components/PaginationBar";
 import FilterPanel from "@/components/FilterPanel";
 import FormPanel from "@/components/FormPanel";
+import ConfirmationDialog from "@/components/ConfirmationDialog";
 
 function EditAndReview() {
   const { data, loading, error, fetchData } = useApiGet("/parks");
@@ -46,8 +48,29 @@ function EditAndReview() {
   const [showFormPanel, setShowFormPanel] = useState(false);
   const [showFilterPanel, setShowFilterPanel] = useState(false);
 
+  const modal = useConfirmation();
+
   // open form panel when the Edit button is clicked
-  function formPanelHandler(formDataObj) {
+  async function formPanelHandler(formDataObj) {
+    const status = formDataObj.currentSeason.status;
+
+    console.log("check stuff here", status, formDataObj);
+
+    // If the season is already published to the CMS, prompt to continue
+    if (status === "published") {
+      const proceed = await modal.open(
+        "@TODO: text here",
+        "@TODO: text here",
+        "@TODO: text here",
+        "@TODO: text here",
+      );
+
+      // If the user cancels in the confirmation modal, don't open the edit form
+      if (!proceed) {
+        return;
+      }
+    }
+
     setFormData({
       seasonId: formDataObj.currentSeason.id,
       level: formDataObj.level,
@@ -358,6 +381,8 @@ function EditAndReview() {
         </div>
 
         {renderTable()}
+
+        <ConfirmationDialog {...modal.props} />
 
         <FormPanel
           show={showFormPanel}

--- a/frontend/src/router/pages/PublishPage.jsx
+++ b/frontend/src/router/pages/PublishPage.jsx
@@ -8,17 +8,7 @@ import LoadingBar from "@/components/LoadingBar";
 import NotReadyFlag from "@/components/NotReadyFlag";
 
 function PublishPage() {
-  const {
-    title,
-    message,
-    confirmButtonText,
-    cancelButtonText,
-    notes,
-    open: openConfirmation,
-    handleConfirm,
-    handleCancel,
-    isOpen,
-  } = useConfirmation();
+  const confirmation = useConfirmation();
 
   const successFlash = useFlashMessage();
   const errorFlash = useFlashMessage();
@@ -46,7 +36,7 @@ function PublishPage() {
   }
 
   async function publishToApi() {
-    const confirm = await openConfirmation(
+    const confirm = await confirmation.open(
       "Publish dates to API?",
       "All parks that are not flagged will be made public. This cannot be undone.",
       "Publish",
@@ -91,16 +81,7 @@ function PublishPage() {
           variant="error"
         />
 
-        <ConfirmationDialog
-          isOpen={isOpen}
-          onConfirm={handleConfirm}
-          onCancel={handleCancel}
-          title={title}
-          message={message}
-          confirmButtonText={confirmButtonText}
-          cancelButtonText={cancelButtonText}
-          notes={notes}
-        />
+        <ConfirmationDialog {...confirmation.props} />
 
         <div className="d-flex justify-content-end mb-2">
           <button className="btn btn-primary" onClick={publishToApi}>

--- a/frontend/src/router/pages/PublishPage.jsx
+++ b/frontend/src/router/pages/PublishPage.jsx
@@ -1,4 +1,4 @@
-import { useConfirmation } from "@/hooks/useConfirmation";
+import useConfirmation from "@/hooks/useConfirmation";
 import useFlashMessage from "@/hooks/useFlashMessage";
 import { useApiGet, useApiPost } from "@/hooks/useApi";
 
@@ -13,11 +13,11 @@ function PublishPage() {
     message,
     confirmButtonText,
     cancelButtonText,
-    confirmationDialogNotes,
-    openConfirmation,
+    notes,
+    open: openConfirmation,
     handleConfirm,
     handleCancel,
-    isConfirmationOpen,
+    isOpen,
   } = useConfirmation();
 
   const successFlash = useFlashMessage();
@@ -92,14 +92,14 @@ function PublishPage() {
         />
 
         <ConfirmationDialog
-          isOpen={isConfirmationOpen}
+          isOpen={isOpen}
           onConfirm={handleConfirm}
           onCancel={handleCancel}
           title={title}
           message={message}
           confirmButtonText={confirmButtonText}
           cancelButtonText={cancelButtonText}
-          notes={confirmationDialogNotes}
+          notes={notes}
         />
 
         <div className="d-flex justify-content-end mb-2">

--- a/frontend/src/router/pages/PublishPage.jsx
+++ b/frontend/src/router/pages/PublishPage.jsx
@@ -36,7 +36,7 @@ function PublishPage() {
   }
 
   async function publishToApi() {
-    const confirm = await confirmation.open(
+    const proceed = await confirmation.open(
       "Publish dates to API?",
       "All parks that are not flagged will be made public. This cannot be undone.",
       "Publish",
@@ -44,7 +44,7 @@ function PublishPage() {
       "Publishing may take up to one hour.",
     );
 
-    if (confirm) {
+    if (proceed) {
       try {
         await publishData();
 


### PR DESCRIPTION
### Jira Ticket

CMS-929

### Description
<!-- What did you change, and why? -->

Similar to the flash message changes in #228 , I renamed and removed some stuff with the existing modal window code to make it easier to use, and added it in some of the approve/save/close functions for the Edit form.

I moved the "save" payload stuff into a memoized variable, and used that to check if the form has any unsaved changes.

I also simplified the navigationGuard hook and re-implemented that now in the form component to prevent closing the tab when you have unsaved changes.