### PR TITLE
CMS-1046: Upgrade CrunchyDB to Postgres 17

### DIFF
--- a/helm/crunchy-postgres/Upgrade-Notes.md
+++ b/helm/crunchy-postgres/Upgrade-Notes.md
@@ -1,0 +1,54 @@
+# This is based on these instructions
+
+https://access.crunchydata.com/documentation/postgres-operator/5.7/guides/major-postgres-version-upgrade
+
+# Create PGUpgrade.yml file
+
+```
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PGUpgrade
+metadata:
+  name: crunchy-postgres-upgrade
+spec:
+  postgresClusterName: crunchy-postgres
+  fromPostgresVersion: 15
+  toPostgresVersion: 17
+```
+
+# Create the resource on OpenShit
+
+```
+oc create -n a7dd13-prod -f PGUpgrade.yml
+```
+
+# Annotate the postgrescluster to allow upgrade and patch it to shutdown
+
+```
+kubectl -n a7dd13-prod annotate postgrescluster crunchy-postgres postgres-operator.crunchydata.com/allow-upgrade="crunchy-postgres-upgrade"
+kubectl -n a7dd13-prod patch postgrescluster crunchy-postgres --type=merge -p '{"spec":{"shutdown":true}}'
+```
+
+# After about 1-3 minutes the pods will shut down
+
+# Check the status of the PGUpgrade and WAIT FOR IT TO FINISH
+
+```
+oc describe -n a7dd13-prod PGUpgrade crunchy-postgres-upgrade
+```
+
+# Remove the annotations and set the version number to 17
+
+```
+kubectl -n a7dd13-prod annotate postgrescluster crunchy-postgres postgres-operator.crunchydata.com/allow-upgrade-
+kubectl -n a7dd13-prod patch postgrescluster crunchy-postgres --type=merge -p '{"spec":{"shutdown":false,"postgresVersion":17}}'
+```
+
+# Wait for the pod to start by checking the Stateful set with "-ha" in its name.
+
+Go to the terminal and enter `psql -version` to confirm the version. Also check the logs for errors
+
+# Delete the PGUpgrade resource
+
+```
+oc delete -n a7dd13-prod PGUpgrade crunchy-postgres-upgrade
+```

--- a/helm/crunchy-postgres/values-alpha-dev.yaml
+++ b/helm/crunchy-postgres/values-alpha-dev.yaml
@@ -2,7 +2,7 @@ fullnameOverride: crunchy-postgres-alpha
 
 crunchyImage: # it's not necessary to specify an image as the images specified in the Crunchy Postgres Operator will be pulled by default
 #crunchyImage: artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-postgres-gis:ubi8-15.2-3.3-0 # use this image for POSTGIS
-postgresVersion: 15
+postgresVersion: 17
 #postGISVersion: '3.3' # use this version of POSTGIS. both crunchyImage and this property needs to have valid values for POSTGIS to be enabled.
 imagePullPolicy: IfNotPresent
 

--- a/helm/crunchy-postgres/values-alpha-test.yaml
+++ b/helm/crunchy-postgres/values-alpha-test.yaml
@@ -2,7 +2,7 @@ fullnameOverride: crunchy-postgres-alpha
 
 crunchyImage: # it's not necessary to specify an image as the images specified in the Crunchy Postgres Operator will be pulled by default
 #crunchyImage: artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-postgres-gis:ubi8-15.2-3.3-0 # use this image for POSTGIS
-postgresVersion: 15
+postgresVersion: 17
 #postGISVersion: '3.3' # use this version of POSTGIS. both crunchyImage and this property needs to have valid values for POSTGIS to be enabled.
 imagePullPolicy: IfNotPresent
 

--- a/helm/crunchy-postgres/values-dev.yaml
+++ b/helm/crunchy-postgres/values-dev.yaml
@@ -2,7 +2,7 @@ fullnameOverride: crunchy-postgres
 
 crunchyImage: # it's not necessary to specify an image as the images specified in the Crunchy Postgres Operator will be pulled by default
 #crunchyImage: artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-postgres-gis:ubi8-15.2-3.3-0 # use this image for POSTGIS
-postgresVersion: 15
+postgresVersion: 17
 #postGISVersion: '3.3' # use this version of POSTGIS. both crunchyImage and this property needs to have valid values for POSTGIS to be enabled.
 imagePullPolicy: IfNotPresent
 

--- a/helm/crunchy-postgres/values-prod.yaml
+++ b/helm/crunchy-postgres/values-prod.yaml
@@ -2,7 +2,7 @@ fullnameOverride: crunchy-postgres
 
 crunchyImage: # it's not necessary to specify an image as the images specified in the Crunchy Postgres Operator will be pulled by default
 #crunchyImage: artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-postgres-gis:ubi8-15.2-3.3-0 # use this image for POSTGIS
-postgresVersion: 15
+postgresVersion: 17
 #postGISVersion: '3.3' # use this version of POSTGIS. both crunchyImage and this property needs to have valid values for POSTGIS to be enabled.
 imagePullPolicy: IfNotPresent
 

--- a/helm/crunchy-postgres/values-test.yaml
+++ b/helm/crunchy-postgres/values-test.yaml
@@ -2,7 +2,7 @@ fullnameOverride: crunchy-postgres
 
 crunchyImage: # it's not necessary to specify an image as the images specified in the Crunchy Postgres Operator will be pulled by default
 #crunchyImage: artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-postgres-gis:ubi8-15.2-3.3-0 # use this image for POSTGIS
-postgresVersion: 15
+postgresVersion: 17
 #postGISVersion: '3.3' # use this version of POSTGIS. both crunchyImage and this property needs to have valid values for POSTGIS to be enabled.
 imagePullPolicy: IfNotPresent
 

--- a/helm/crunchy-postgres/values-training.yaml
+++ b/helm/crunchy-postgres/values-training.yaml
@@ -2,7 +2,7 @@ fullnameOverride: crunchy-postgres-training
 
 crunchyImage: # it's not necessary to specify an image as the images specified in the Crunchy Postgres Operator will be pulled by default
 #crunchyImage: artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-postgres-gis:ubi8-15.2-3.3-0 # use this image for POSTGIS
-postgresVersion: 15
+postgresVersion: 17
 #postGISVersion: '3.3' # use this version of POSTGIS. both crunchyImage and this property needs to have valid values for POSTGIS to be enabled.
 imagePullPolicy: IfNotPresent
 


### PR DESCRIPTION
### Jira Ticket

CMS-1046

### Description
Updated CrunchyDB to Postgres 17 based on a request from OCIO.  Alpha-dev and Alpha-test are techincally still on 16 because I tried to update them in 2 steps and I was unsuccessful at updating from 16-17. 

