### PR TITLE
CMS-1014: Implement approve button on table rows

### DIFF
--- a/frontend/src/contexts/RefreshTableContext.js
+++ b/frontend/src/contexts/RefreshTableContext.js
@@ -1,0 +1,7 @@
+import { createContext } from "react";
+
+// Context to provide functions for refreshing main table data
+// when changes are saved to the DB
+export default createContext({
+  refreshTable() {},
+});

--- a/frontend/src/router/pages/EditAndReview.jsx
+++ b/frontend/src/router/pages/EditAndReview.jsx
@@ -277,7 +277,7 @@ function EditAndReview() {
 
         return true;
       }),
-    [parks, filters],
+    [parks, filters, userData],
   );
 
   function updateFilter(key, value) {

--- a/frontend/src/router/pages/EditAndReview.jsx
+++ b/frontend/src/router/pages/EditAndReview.jsx
@@ -299,7 +299,7 @@ function EditAndReview() {
   }, [filteredParks, page, pageSize]);
 
   // components
-  function renderTable() {
+  function ParksTableWrapper() {
     if (loading) {
       return <LoadingBar />;
     }
@@ -412,7 +412,7 @@ function EditAndReview() {
           </div>
         </div>
 
-        {renderTable()}
+        <ParksTableWrapper />
 
         <ConfirmationDialog {...modal.props} />
 

--- a/frontend/src/router/pages/EditAndReview.jsx
+++ b/frontend/src/router/pages/EditAndReview.jsx
@@ -10,6 +10,7 @@ import PaginationBar from "@/components/PaginationBar";
 import FilterPanel from "@/components/FilterPanel";
 import FormPanel from "@/components/FormPanel";
 import ConfirmationDialog from "@/components/ConfirmationDialog";
+import RefreshTableContext from "@/contexts/RefreshTableContext";
 import UserContext from "@/contexts/UserContext";
 
 function EditAndReview() {
@@ -286,6 +287,14 @@ function EditAndReview() {
     }));
   }
 
+  /**
+   * Fetches all the data from the API when something changes.
+   * @returns {void}
+   */
+  function refreshTable() {
+    fetchData();
+  }
+
   // Slice the list of parks for pagination
   const totalPages = useMemo(
     () => Math.ceil(filteredParks.length / pageSize),
@@ -311,11 +320,13 @@ function EditAndReview() {
     return (
       <div className="paginated-table">
         <div className="mb-3">
-          <EditAndReviewTable
-            data={pageData}
-            onResetFilters={resetFilters}
-            formPanelHandler={formPanelHandler}
-          />
+          <RefreshTableContext.Provider value={{ refreshTable }}>
+            <EditAndReviewTable
+              data={pageData}
+              onResetFilters={resetFilters}
+              formPanelHandler={formPanelHandler}
+            />
+          </RefreshTableContext.Provider>
         </div>
 
         <div className="d-flex justify-content-center">
@@ -357,11 +368,6 @@ function EditAndReview() {
         Clear filters
       </button>
     );
-  }
-
-  // Fetch all the data from the API when something changes
-  function refreshData() {
-    fetchData();
   }
 
   return (
@@ -420,7 +426,7 @@ function EditAndReview() {
           show={showFormPanel}
           setShow={setShowFormPanel}
           formData={formData}
-          onDataUpdate={refreshData}
+          onDataUpdate={refreshTable}
         />
 
         <FilterPanel


### PR DESCRIPTION
### Jira Ticket

CMS-1014

### Description
<!-- What did you change, and why? -->

This hooks up the "Approve" button on the homepage table. It does the same thing as if you opened the form and clicked "Mark approved" in there:
- Update the status to "Approved"
- Reload the data in the table to show the changes
- Show a success flash message

I added yet another context to provide the main table's refreshTable function down to the ApproveButton, rather than passing it down 5 or 6 levels. 

I also renamed the "renderTable" functional component to ParksTableWrapper and used a proper tag for it in the JSX. I think that was left over from v1 when it was some of the first React code I ever wrote 🙈 

This branch is pretty quick and basic; I put in a TODO comment about handling API errors and I'll be sure to add something to the backlog for that. I also had the idea to return some season details from the API when we save/approve/submit so we will have all the info we need to show in he flash message, rather than having to gather it from the frontend. That hasn't really been a problem yet but it could be. I'll put that as an optimization/refactoring task in the backlog too.
