### PR TITLE
CMS-1043: Populate date ranges if dates are the same every year

### DIFF
--- a/backend/tasks/create-date-range-annual/README.md
+++ b/backend/tasks/create-date-range-annual/README.md
@@ -2,37 +2,35 @@
 
 This script creates and updates `DateRangeAnnual` entries in the database based on existing `Publishable`, `Season`, `DateRange`, `DateType`, `Park`, and Strapi `park-operation` data. It ensures that each valid combination of `publishableId` and `dateTypeId` has a corresponding `DateRangeAnnual` entry, and that the `isDateRangeAnnual` field is kept in sync with Strapi.
 
-
 ## What does the script do?
 
 1. **Creates `DateRangeAnnual` entries for all valid date ranges:**
+
    - For each `Publishable`, it finds all related `Season` records.
    - For each `Season`, it finds all associated `DateRange` records (and their `DateType`).
    - For each `DateRange`, it creates a `DateRangeAnnual` entry for the combination of `publishableId` and `dateTypeId`, **unless** the `DateType` name is `"Tier 1"`, `"Tier 2"`, or `"Operating"`.
    - If an entry already exists, it is not duplicated.
 
 2. **Creates or updates `DateRangeAnnual` entries for all Parks with a `publishableId` and the `"Operating"` date type:**
+
    - For each `Park` with a non-null `publishableId`, it finds the corresponding Strapi `park-operation` by matching the `orcs` code.
    - It uses the `isDateRangeAnnual` value from Strapi `park-operation` data and sets it on the `DateRangeAnnual` entry for that park and the `"Operating"` `dateType`.
    - If the entry already exists and the value differs, it updates `isDateRangeAnnual` to match Strapi.
 
 3. **All operations are performed inside a transaction** for safety and atomicity.
 
-
 ## How does it get Strapi data?
 
 - The script fetches Strapi data using the `/park-operations` endpoint, requesting the `orcs` field of the related `protectedArea`.
 - It builds a lookup of `orcs` to `isDateRangeAnnual` from the Strapi response, ensuring accurate mapping to each Park.
-
 
 ## How to run
 
 From your project root, run:
 
 ```sh
-node backend/tasks/create-date-range-annual/create-date-range-annual.js
+node tasks/create-date-range-annual/create-date-range-annual.js
 ```
-
 
 ## Output
 
@@ -40,14 +38,12 @@ node backend/tasks/create-date-range-annual/create-date-range-annual.js
 - At the end, it logs `"DateRangeAnnual creation complete."`
 - If any error occurs, the transaction is rolled back and an error message is printed.
 
-
 ## Why is this useful?
 
 - Ensures your `DateRangeAnnual` table is up-to-date with all valid combinations from your business logic and Strapi data.
 - Prevents duplicate entries.
 - Keeps the `isDateRangeAnnual` field in sync with the source of truth (Strapi).
 - Handles both general date ranges and the special `"Operating"` type for parks.
-
 
 ## Notes
 

--- a/backend/tasks/create-gate-details/README.md
+++ b/backend/tasks/create-gate-details/README.md
@@ -2,10 +2,10 @@
 
 This script creates or updates `GateDetail` entries for all Parks, ParkAreas, and Features with a `publishableId` in your database, and imports gate-related data from Strapi’s `park-operation` and `park-operation-sub-area` models.
 
-
 ## What does the script do?
 
 1. **For Parks:**
+
    - Finds all Parks with a non-null `publishableId`.
    - For each Park, creates or updates a `GateDetail` entry linked by `publishableId`.
    - If the Park’s `orcs` matches a Strapi `park-operation`’s `protectedArea.orcs`, it imports the following fields from Strapi and sets them on the `GateDetail`:
@@ -16,14 +16,14 @@ This script creates or updates `GateDetail` entries for all Parks, ParkAreas, an
      - `gateClosesAtDusk`
      - `gateOpen24Hours`
 
-
 2. **For ParkAreas:**
+
    - Finds all ParkAreas with a non-null `publishableId`.
    - For each ParkArea, creates a `GateDetail` entry linked by `publishableId` if one does not exist.
    - (No Strapi import for ParkArea at this time.)
 
-
 3. **For Features:**
+
    - Finds all Features with a non-null `publishableId`.
    - For each Feature, creates or updates a `GateDetail` entry linked by `publishableId`.
    - If the Feature’s `strapiId` matches a Strapi `park-operation-sub-area`’s `id`, it imports the following fields from Strapi and sets them on the `GateDetail`:
@@ -37,28 +37,24 @@ This script creates or updates `GateDetail` entries for all Parks, ParkAreas, an
 4. **Transaction Safety:**
    - All operations are performed inside a transaction. If any error occurs, all changes are rolled back.
 
-
 ## How to run
 
 From your project root, run:
 
 ```sh
-node backend/tasks/create-gate-details/create-gate-details.js
+node tasks/create-gate-details/create-gate-details.js
 ```
-
 
 ## Output
 
 - The script logs `"GateDetail creation and import complete."` on success.
 - If any error occurs, the transaction is rolled back and an error message is printed.
 
-
 ## Why is this useful?
 
 - Ensures every Park, ParkArea, and Feature with a `publishableId` has a corresponding `GateDetail` entry.
 - Keeps gate-related fields in sync with Strapi data for Parks and Features.
 - Prevents duplicate entries and ensures data consistency.
-
 
 ## Notes
 

--- a/backend/tasks/create-seasons.js
+++ b/backend/tasks/create-seasons.js
@@ -16,6 +16,7 @@ import {
   Season,
 } from "../models/index.js";
 import * as STATUS from "../constants/seasonStatus.js";
+import { populateDateRangesForYear } from "./populate-date-ranges/populate-date-ranges.js";
 
 // Run all queries in a transaction
 const transaction = await Season.sequelize.transaction();
@@ -398,6 +399,9 @@ console.log(`Added ${dateablesAdded} missing Group Camping Feature Dateables`);
 console.log(`Added ${seasonsAdded} new Group Camping Feature Seasons`);
 
 console.log("Committing transaction...");
+
+// Populate DateRanges for the new seasons based on previous year if isDateRangeAnnual is TRUE
+await populateDateRangesForYear(operatingYear);
 
 await transaction?.commit();
 

--- a/backend/tasks/create-seasons.js
+++ b/backend/tasks/create-seasons.js
@@ -400,9 +400,9 @@ console.log(`Added ${seasonsAdded} new Group Camping Feature Seasons`);
 
 console.log("Committing transaction...");
 
+await transaction?.commit();
+
 // Populate DateRanges for the new seasons based on previous year if isDateRangeAnnual is TRUE
 await populateDateRangesForYear(operatingYear);
-
-await transaction?.commit();
 
 console.log("Done");

--- a/backend/tasks/create-seasons.js
+++ b/backend/tasks/create-seasons.js
@@ -398,11 +398,11 @@ console.log(
 console.log(`Added ${dateablesAdded} missing Group Camping Feature Dateables`);
 console.log(`Added ${seasonsAdded} new Group Camping Feature Seasons`);
 
+// Populate DateRanges for the new seasons based on previous year if isDateRangeAnnual is TRUE
+await populateDateRangesForYear(operatingYear, transaction);
+
 console.log("Committing transaction...");
 
 await transaction?.commit();
-
-// Populate DateRanges for the new seasons based on previous year if isDateRangeAnnual is TRUE
-await populateDateRangesForYear(operatingYear);
 
 console.log("Done");

--- a/backend/tasks/populate-date-ranges/README.md
+++ b/backend/tasks/populate-date-ranges/README.md
@@ -18,7 +18,7 @@ This script populates `DateRange` records for a given target year based on the p
 From your project root, run:
 
 ```sh
-node backend/tasks/populate-date-ranges/populate-date-ranges.js 2026
+node tasks/populate-date-ranges/populate-date-ranges.js 2026
 ```
 
 Replace 2026 with the year you want to populate.

--- a/backend/tasks/populate-date-ranges/README.md
+++ b/backend/tasks/populate-date-ranges/README.md
@@ -1,0 +1,41 @@
+# populate-date-ranges.js
+
+This script populates `DateRange` records for a given target year based on the previous year's `DateRange` entries, but **only if the associated `DateRangeAnnual` is marked as annual** (`isDateRangeAnnual` is `TRUE`). It copies the month and day from the previous year's dates, but updates the year to the target year.
+
+## What does the script do?
+
+1. **For each DateRangeAnnual marked as annual:**
+
+   - Finds the previous and target `Season` for the same `publishableId`.
+   - If both exist, finds all `DateRange` records for the previous season and the relevant `dateTypeId`.
+   - If the target season does **not** already have `DateRange` records for that `dateTypeId`, it creates new ones for the target year, copying the month and day from the previous year but updating the year.
+
+2. **Transaction Safety:**
+   - All operations are performed inside a transaction. If any error occurs, all changes are rolled back.
+
+## How to run
+
+From your project root, run:
+
+```sh
+node backend/tasks/populate-date-ranges/populate-date-ranges.js 2026
+```
+
+Replace 2026 with the year you want to populate.
+
+## Output
+
+- The script logs each copied DateRange and a summary message on success.
+- If any error occurs, the transaction is rolled back and an error message is printed.
+
+## Why is this useful?
+
+- Ensures new seasons have the correct date ranges based on the previous year's configuration for annual date types.
+- Prevents duplicate date ranges for the same season and date type.
+- Keeps your database in sync with annual scheduling logic.
+
+## Notes
+
+- The script assumes your Sequelize models and associations are set up as in the rest of the BC Parks Staff Portal project.
+- You can safely run this script multiple times; it will not create duplicates and will only add missing date ranges.
+- If you add new annual date types or seasons, re-running this script will add any missing date ranges as needed.

--- a/backend/tasks/populate-date-ranges/populate-date-ranges.js
+++ b/backend/tasks/populate-date-ranges/populate-date-ranges.js
@@ -56,7 +56,7 @@ export async function populateDateRangesForYear(targetYear) {
       });
 
       // check if target season already has DateRanges for this dateType
-      const targetDateRanges = await DateRange.findAll({
+      const targetDateRangeCount = await DateRange.count({
         where: {
           seasonId: targetSeason.id,
           dateTypeId: annual.dateTypeId,
@@ -65,7 +65,7 @@ export async function populateDateRangesForYear(targetYear) {
       });
 
       // skip if target season already has DateRanges
-      if (targetDateRanges.length > 0) continue;
+      if (targetDateRangeCount > 0) continue;
 
       // copy each previous DateRange to current season
       for (const prevRange of prevDateRanges) {
@@ -112,6 +112,7 @@ if (process.argv[1] === new URL(import.meta.url).pathname) {
     console.error(
       "Please provide a target year, e.g. node populate-date-ranges.js 2026",
     );
+    throw new Error("Invalid or missing target year argument.");
   }
 
   populateDateRangesForYear(Number(targetYear)).catch((err) => {

--- a/backend/tasks/populate-date-ranges/populate-date-ranges.js
+++ b/backend/tasks/populate-date-ranges/populate-date-ranges.js
@@ -108,14 +108,12 @@ export async function populateDateRangesForYear(
     } else {
       console.log("No new DateRanges to create.");
     }
-
-    await transaction.commit();
     console.log(
       "DateRanges populated for new Seasons based on previous year's annual DateRanges.",
     );
   } catch (err) {
-    await transaction.rollback();
-    console.error("Error populating DateRanges from annual:", err);
+    console.error("Error populating DateRanges:", err);
+    throw err;
   }
 }
 
@@ -126,13 +124,18 @@ if (process.argv[1] === new URL(import.meta.url).pathname) {
 
   if (!targetYear || isNaN(targetYear)) {
     console.error(
-      "Please provide a target year, e.g. node populate-date-ranges.js 2026",
+      "Please provide a target year. e.g. node populate-date-ranges.js 2026",
     );
     throw new Error("Invalid or missing target year argument.");
   }
 
-  populateDateRangesForYear(Number(targetYear), transaction).catch((err) => {
-    console.error("Unhandled error in  populateDateRangesFromAnnual:", err);
+  try {
+    await populateDateRangesForYear(Number(targetYear), transaction);
+    await transaction.commit();
+    console.log("Transaction committed.");
+  } catch (err) {
+    await transaction.rollback();
+    console.error("Transaction rolled back due to error:", err);
     throw err;
-  });
+  }
 }

--- a/backend/tasks/populate-date-ranges/populate-date-ranges.js
+++ b/backend/tasks/populate-date-ranges/populate-date-ranges.js
@@ -1,0 +1,121 @@
+// This script populates DateRanges for a given target year
+// based on previous year's DateRanges if isDateRangeAnnual is TRUE.
+
+import "../../env.js";
+
+import { Season, DateRange, DateRangeAnnual } from "../../models/index.js";
+
+// Function
+function normalizeToLocalDate(dateObject) {
+  if (!dateObject) return null;
+
+  return new Date(
+    dateObject.getUTCFullYear(),
+    dateObject.getUTCMonth(),
+    dateObject.getUTCDate(),
+  );
+}
+
+export async function populateDateRangesForYear(targetYear) {
+  const transaction = await DateRange.sequelize.transaction();
+
+  try {
+    // find all DateRangeAnnuals where isDateRangeAnnual is TRUE
+    const annuals = await DateRangeAnnual.findAll({
+      where: { isDateRangeAnnual: true },
+      transaction,
+    });
+
+    for (const annual of annuals) {
+      // find previous and target seasons for this publishable
+      const prevSeason = await Season.findOne({
+        where: {
+          publishableId: annual.publishableId,
+          operatingYear: targetYear - 1,
+        },
+        transaction,
+      });
+      const targetSeason = await Season.findOne({
+        where: {
+          publishableId: annual.publishableId,
+          operatingYear: targetYear,
+        },
+        transaction,
+      });
+
+      // skip if no previous or target season found
+      if (!prevSeason || !targetSeason) continue;
+
+      // find DateRanges for previous season and this dateType
+      const prevDateRanges = await DateRange.findAll({
+        where: {
+          seasonId: prevSeason.id,
+          dateTypeId: annual.dateTypeId,
+        },
+        transaction,
+      });
+
+      // check if target season already has DateRanges for this dateType
+      const targetDateRanges = await DateRange.findAll({
+        where: {
+          seasonId: targetSeason.id,
+          dateTypeId: annual.dateTypeId,
+        },
+        transaction,
+      });
+
+      // skip if target season already has DateRanges
+      if (targetDateRanges.length > 0) continue;
+
+      // copy each previous DateRange to current season
+      for (const prevRange of prevDateRanges) {
+        const currentYear = targetSeason.operatingYear;
+        const prevStartDate = normalizeToLocalDate(prevRange.startDate);
+        const prevEndDate = normalizeToLocalDate(prevRange.endDate);
+
+        const newStartDate = new Date(prevStartDate);
+        const newEndDate = new Date(prevEndDate);
+
+        newStartDate.setFullYear(currentYear);
+        newEndDate.setFullYear(currentYear);
+
+        await DateRange.create(
+          {
+            seasonId: targetSeason.id,
+            dateTypeId: annual.dateTypeId,
+            startDate: newStartDate,
+            endDate: newEndDate,
+          },
+          { transaction },
+        );
+        console.log(
+          `Copied DateRange from season ${prevSeason.operatingYear} to ${targetSeason.operatingYear} for publishableId=${annual.publishableId}`,
+        );
+      }
+    }
+
+    await transaction.commit();
+    console.log(
+      "DateRanges populated for new Seasons based on previous year's annual DateRanges.",
+    );
+  } catch (err) {
+    await transaction.rollback();
+    console.error("Error populating DateRanges from annual:", err);
+  }
+}
+
+// run directly:
+if (process.argv[1] === new URL(import.meta.url).pathname) {
+  const targetYear = process.argv[2];
+
+  if (!targetYear || isNaN(targetYear)) {
+    console.error(
+      "Please provide a target year, e.g. node populate-date-ranges.js 2026",
+    );
+  }
+
+  populateDateRangesForYear(Number(targetYear)).catch((err) => {
+    console.error("Unhandled error in  populateDateRangesFromAnnual:", err);
+    throw err;
+  });
+}

--- a/backend/tasks/populate-park-gate-dates/README.md
+++ b/backend/tasks/populate-park-gate-dates/README.md
@@ -2,7 +2,6 @@
 
 This script populates the `Season` and `DateRange` tables in your database based on Strapi `park-operation-date` data and existing Parks.
 
-
 ## What does the script do?
 
 1. **For each Park with a `publishableId`:**
@@ -26,28 +25,24 @@ This script populates the `Season` and `DateRange` tables in your database based
 4. **Transaction Safety:**
    - All operations are performed inside a transaction. If any error occurs, all changes are rolled back.
 
-
 ## How to run
 
 From your project root, run:
 
 ```sh
-node backend/tasks/populate-park-gate-dates/populate-park-gate-dates.js
+node tasks/populate-park-gate-dates/populate-park-gate-dates.js
 ```
-
 
 ## Output
 
 - The script logs `"Season and DateRange population complete."` on success.
 - If any error occurs, the transaction is rolled back and an error message is printed.
 
-
 ## Why is this useful?
 
 - Ensures every Park with a `publishableId` has a `Season` for each operating year found in Strapi.
 - Ensures each Season has a corresponding `DateRange` for the `"Operating"` date type, with dates matching Strapi.
 - Keeps your database in sync with Strapi's park operation date data.
-
 
 ## Notes
 


### PR DESCRIPTION
### Jira Ticket

CMS-1043

### Description
<!-- What did you change, and why? -->
- Create this PR to try a different approach for CMS-1043, based on our conversation in https://github.com/bcgov/bcparks-staff-portal/pull/236
- Populate date ranges based on the previous year's dates if `isDateRangeAnnual` is TRUE
- Case 1: Populate dates when Seasons are newly created 
  - e.g. Run `create-season 2026`
  - If the date type has `isDateRangeAnnual` is TRUE, 2026 dates will be populated based on 2025 dates
 - Case 2: Populate dates when the current Seasons do not have dates
   - e.g. Run `populate-date-ranges 2025`
   - If the date type has `isDateRangeAnnual` is TRUE and no DateRange of the year, 2025 dates will be populated based on 2024 dates
