### PR TITLE
CMS-996: Fix crash when opening month dropdown

### DIFF
--- a/frontend/src/components/DatePicker.jsx
+++ b/frontend/src/components/DatePicker.jsx
@@ -1,0 +1,94 @@
+import { useState, useMemo, memo } from "react";
+import PropTypes from "prop-types";
+import classNames from "classnames";
+import DatePicker from "react-datepicker";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faCalendarCheck } from "@fa-kit/icons/classic/regular";
+import { normalizeToUTCDate, normalizeToLocalDate } from "@/lib/utils";
+
+function DootDatePickerComponent({
+  id,
+  dateField,
+  minDate,
+  maxDate,
+  disabled = false,
+  date,
+  onSelect,
+}) {
+  // Clone the date prop and store it in local state
+  // This is so we can control the DatePicker without modifying the parent data
+  // until the field is blurred or Enter is pressed
+  const [localDate, setLocalDate] = useState(date && new Date(date));
+
+  const adjustedLocalDate = useMemo(
+    () => normalizeToLocalDate(localDate),
+    [localDate],
+  );
+
+  // Updates the local date to control the DatePicker
+  function onDateChange(dateObj) {
+    // Store as UTC time
+    const utcDateObj = normalizeToUTCDate(dateObj);
+
+    setLocalDate(utcDateObj ?? null);
+  }
+
+  return (
+    <>
+      <DatePicker
+        id={`date-range-${id}-${dateField}`}
+        portalId={`date-picker-portal-${dateField}`}
+        minDate={minDate}
+        maxDate={maxDate}
+        className={classNames("form-control", dateField)}
+        selected={adjustedLocalDate}
+        onChange={(newDate) => onDateChange(newDate)}
+        onBlur={() => {
+          // Update the `dates` object on blur
+          onSelect(dateField, adjustedLocalDate);
+        }}
+        onKeyDown={(event) => {
+          // Update the `dates` object on Enter
+          if (event.key === "Enter" && event.target.tagName === "INPUT") {
+            onSelect(dateField, adjustedLocalDate);
+          }
+        }}
+        dateFormat="EEE, MMM d, yyyy"
+        showMonthYearDropdown
+        disabled={disabled}
+      />
+
+      <FontAwesomeIcon className="append-content" icon={faCalendarCheck} />
+    </>
+  );
+}
+
+// Memoize the component to prevent re-renders unless the dates change
+export default memo(DootDatePickerComponent, (prevProps, nextProps) => {
+  // Custom comparison: only re-render if the dates actually changed
+  // Compare dates by timestamp
+  const prevDate = prevProps.date?.getTime() || null;
+  const nextDate = nextProps.date?.getTime() || null;
+
+  // Also check other props that might affect rendering
+  // (Don't check onSelect, since it won't change)
+  return (
+    prevDate === nextDate &&
+    prevProps.id === nextProps.id &&
+    prevProps.dateField === nextProps.dateField &&
+    prevProps.disabled === nextProps.disabled &&
+    prevProps.minDate?.getTime() === nextProps.minDate?.getTime() &&
+    prevProps.maxDate?.getTime() === nextProps.maxDate?.getTime()
+  );
+});
+
+DootDatePickerComponent.propTypes = {
+  // id (number) or tempId (string) for new date ranges
+  id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
+  dateField: PropTypes.string.isRequired,
+  minDate: PropTypes.instanceOf(Date),
+  maxDate: PropTypes.instanceOf(Date),
+  disabled: PropTypes.bool,
+  date: PropTypes.instanceOf(Date),
+  onSelect: PropTypes.func.isRequired,
+};

--- a/frontend/src/components/DateRangeFields.jsx
+++ b/frontend/src/components/DateRangeFields.jsx
@@ -47,8 +47,8 @@ function DateRange({
 
   // Min and max dates: Jan 1 of this year and Dec 31 of next year
   // @TODO: Update this when validation is implemented
-  const minDate = startOfYear(new Date());
-  const maxDate = endOfYear(addYears(new Date(), 1));
+  const minDate = useMemo(() => startOfYear(new Date()), []);
+  const maxDate = useMemo(() => endOfYear(addYears(new Date(), 1)), []);
 
   // Convert to UTC if necessary, and call the update method from the parent
   function onSelect(dateField, dateObj) {

--- a/frontend/src/components/DateRangeFields.jsx
+++ b/frontend/src/components/DateRangeFields.jsx
@@ -10,6 +10,7 @@ import Form from "react-bootstrap/Form";
 import PropTypes from "prop-types";
 
 import { normalizeToUTCDate, normalizeToLocalDate } from "@/lib/utils";
+import { startOfYear, endOfYear, addYears } from "date-fns";
 
 function DateRange({
   dateRange,
@@ -44,6 +45,11 @@ function DateRange({
     setLocalDateRange(updatedRange);
   }
 
+  // Min and max dates: Jan 1 of this year and Dec 31 of next year
+  // @TODO: Update this when validation is implemented
+  const minDate = startOfYear(new Date());
+  const maxDate = endOfYear(addYears(new Date(), 1));
+
   // Convert to UTC if necessary, and call the update method from the parent
   function onSelect(dateField, dateObj) {
     const newValue = normalizeToUTCDate(dateObj);
@@ -64,6 +70,9 @@ function DateRange({
         <div className="input-with-append">
           <DatePicker
             id={`date-range-${idOrTempId}-start`}
+            portalId="date-picker-portal-start"
+            minDate={minDate}
+            maxDate={maxDate}
             className="form-control start-date"
             selected={adjustedLocalStartDate}
             onChange={(date) => onDateChange("startDate", date)}
@@ -78,7 +87,6 @@ function DateRange({
               }
             }}
             dateFormat="EEE, MMM d, yyyy"
-            // @TODO: the dropdown makes chrome hang??
             showMonthYearDropdown
             disabled={isDateRangeAnnual}
           />
@@ -96,6 +104,9 @@ function DateRange({
         <div className="input-with-append">
           <DatePicker
             id={`date-range-${idOrTempId}-end`}
+            portalId="date-picker-portal-end"
+            minDate={minDate}
+            maxDate={maxDate}
             className="form-control end-date"
             selected={adjustedLocalEndDate}
             onChange={(date) => onDateChange("endDate", date)}
@@ -110,7 +121,6 @@ function DateRange({
               }
             }}
             dateFormat="EEE, MMM d, yyyy"
-            // @TODO: the dropdown makes chrome hang??
             showMonthYearDropdown
             disabled={isDateRangeAnnual}
           />

--- a/frontend/src/components/DateRangeFields.jsx
+++ b/frontend/src/components/DateRangeFields.jsx
@@ -1,16 +1,12 @@
-import { useMemo, useState } from "react";
-import {
-  faPlus,
-  faXmark,
-  faCalendarCheck,
-} from "@fa-kit/icons/classic/regular";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import DatePicker from "react-datepicker";
-import Form from "react-bootstrap/Form";
+import { useMemo } from "react";
 import PropTypes from "prop-types";
-
-import { normalizeToUTCDate, normalizeToLocalDate } from "@/lib/utils";
+import { faPlus, faXmark } from "@fa-kit/icons/classic/regular";
 import { startOfYear, endOfYear, addYears } from "date-fns";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import Form from "react-bootstrap/Form";
+
+import DootDatePicker from "@/components/DatePicker";
+import { normalizeToUTCDate } from "@/lib/utils";
 
 function DateRange({
   dateRange,
@@ -20,30 +16,6 @@ function DateRange({
 }) {
   // A unique ID for template loops and selectors
   const idOrTempId = dateRange.id || dateRange.tempId;
-
-  // Keep local state until the field is blurred or Enter is pressed
-  const [localDateRange, setLocalDateRange] = useState({ ...dateRange });
-  const adjustedLocalStartDate = useMemo(
-    () => normalizeToLocalDate(localDateRange.startDate),
-    [localDateRange.startDate],
-  );
-  const adjustedLocalEndDate = useMemo(
-    () => normalizeToLocalDate(localDateRange.endDate),
-    [localDateRange.endDate],
-  );
-
-  // Updates the local date ranges to control the DatePickers
-  function onDateChange(dateField, dateObj) {
-    // Store as UTC time
-    const utcDateObj = normalizeToUTCDate(dateObj);
-
-    const updatedRange = {
-      ...localDateRange,
-      [dateField]: utcDateObj ?? null,
-    };
-
-    setLocalDateRange(updatedRange);
-  }
 
   // Min and max dates: Jan 1 of this year and Dec 31 of next year
   // @TODO: Update this when validation is implemented
@@ -68,30 +40,15 @@ function DateRange({
       <div className="form-group">
         <label className="form-label d-lg-none">Start date</label>
         <div className="input-with-append">
-          <DatePicker
-            id={`date-range-${idOrTempId}-start`}
-            portalId="date-picker-portal-start"
+          <DootDatePicker
+            id={idOrTempId}
+            dateField="startDate"
             minDate={minDate}
             maxDate={maxDate}
-            className="form-control start-date"
-            selected={adjustedLocalStartDate}
-            onChange={(date) => onDateChange("startDate", date)}
-            onBlur={() => {
-              // Update the `dates` object on blur
-              onSelect("startDate", adjustedLocalStartDate);
-            }}
-            onKeyDown={(event) => {
-              // Update the `dates` object on Enter
-              if (event.key === "Enter" && event.target.tagName === "INPUT") {
-                onSelect("startDate", adjustedLocalStartDate);
-              }
-            }}
-            dateFormat="EEE, MMM d, yyyy"
-            showMonthYearDropdown
             disabled={isDateRangeAnnual}
+            date={dateRange.startDate}
+            onSelect={onSelect}
           />
-
-          <FontAwesomeIcon className="append-content" icon={faCalendarCheck} />
         </div>
       </div>
 
@@ -102,30 +59,15 @@ function DateRange({
       <div className="form-group">
         <label className="form-label d-lg-none">End date</label>
         <div className="input-with-append">
-          <DatePicker
-            id={`date-range-${idOrTempId}-end`}
-            portalId="date-picker-portal-end"
+          <DootDatePicker
+            id={idOrTempId}
+            dateField="endDate"
             minDate={minDate}
             maxDate={maxDate}
-            className="form-control end-date"
-            selected={adjustedLocalEndDate}
-            onChange={(date) => onDateChange("endDate", date)}
-            onBlur={() => {
-              // Update the `dates` object on blur
-              onSelect("endDate", adjustedLocalEndDate);
-            }}
-            onKeyDown={(event) => {
-              // Update the `dates` object on Enter
-              if (event.key === "Enter" && event.target.tagName === "INPUT") {
-                onSelect("endDate", adjustedLocalEndDate);
-              }
-            }}
-            dateFormat="EEE, MMM d, yyyy"
-            showMonthYearDropdown
             disabled={isDateRangeAnnual}
+            date={dateRange.endDate}
+            onSelect={onSelect}
           />
-
-          <FontAwesomeIcon className="append-content" icon={faCalendarCheck} />
         </div>
       </div>
 

--- a/frontend/src/styles/_datepicker.scss
+++ b/frontend/src/styles/_datepicker.scss
@@ -1,6 +1,11 @@
 // Import the library styles
 @use "react-datepicker/dist/react-datepicker.css";
 
+// Display the datepicker in a portal, above the Offcanvas panel (z-index 1045 + 1)
+.react-datepicker-popper {
+  z-index: 1046;
+}
+
 // Overrides for the react-datepicker component package
 .react-datepicker {
   // Prevent the bootstrap theme from making the month name huge


### PR DESCRIPTION
### Jira Ticket

CMS-996

### Description
<!-- What did you change, and why? -->

This fixes the bug that caused the tab to freeze and crash when opening the month dropdown, now that we moved the datepicker to the Offcanvas panel. I implemented the fix you found on the library's github page, so thank you for finding that!

I also added another commit to move the component into its own file. I refactored it a bit and made a DatePicker component that wraps the third party one. I called it `<DootDatePicker>` on the page to avoid confusion.