### PR TITLE
CMS-929: Fix "Move back to draft?" prompt check

### DIFF
--- a/frontend/src/components/FormPanel.jsx
+++ b/frontend/src/components/FormPanel.jsx
@@ -261,8 +261,10 @@ function SeasonForm({
     }
   }
 
+  // If the season is not "requested" (eg it is submitted, approved, or published),
+  // prompt the user to confirm moving back to draft.
   async function promptAndSave(close = true) {
-    if (dataChanged) {
+    if (season.status !== "requested") {
       const proceed = await openModal(
         "Move back to draft?",
         `The dates will be moved back to draft and need to be submitted again to be reviewed.

--- a/frontend/src/components/FormPanel.jsx
+++ b/frontend/src/components/FormPanel.jsx
@@ -261,7 +261,7 @@ function SeasonForm({
     }
   }
 
-  // If the season is not "requested" (eg it is submitted, approved, or published),
+  // If the season is not "requested" (e.g. it is submitted, approved, or published),
   // prompt the user to confirm moving back to draft.
   async function promptAndSave(close = true) {
     if (season.status !== "requested") {


### PR DESCRIPTION
### Jira Ticket

CMS-929

### Description
<!-- What did you change, and why? -->

Noticed a bug with my original branch - the "Move back to draft?" modal was coming up all the time because I had the wrong check. It should only come up if the season is already approved/submitted/requested. This branch is a quick fix for that.