### PR TITLE
CMS-898: Fix return value for getSeasonPark

### DIFF
--- a/backend/utils/propagateWinterFeeDates.js
+++ b/backend/utils/propagateWinterFeeDates.js
@@ -49,9 +49,9 @@ function frontcountryFeaturesQueryPart(featureTypeId) {
  * @returns {Promise<Park>} Park record for the Season
  */
 async function getSeasonPark(season, transaction = null) {
-  // If the season is a Park season, return it directly
+  // If the season is a Park season, return the Park directly
   if (season.park) {
-    return season;
+    return season.park;
   }
 
   // If the season is an Area season, get the Park details


### PR DESCRIPTION
### Jira Ticket

CMS-898

### Description
<!-- What did you change, and why? -->

I noticed a bug with the process that propagates Winter fee dates from the Park down to the Features/Areas:

If you approve the Park-level season last (and the Park season is the season that triggers this function), the `getSeasonPark` function returns the Season instead of the Park, then the check for `hasWinterFeeDates` will always be false and it will return without doing anything.

This branch is a quick fix for that. The other season types should work either way.