### PR TITLE
CMS-1044: Use prod Keycloak for training environment

### DIFF
--- a/helm/deployment/values-training.yaml
+++ b/helm/deployment/values-training.yaml
@@ -1,5 +1,5 @@
 cluster:
-  ssoAuthUrl: https://test.loginproxy.gov.bc.ca/auth
+  ssoAuthUrl: https://loginproxy.gov.bc.ca/auth
   cmsUrl: https://alpha-test-cms.bcparks.ca
 
 images:


### PR DESCRIPTION
### Jira Ticket

CMS-1044

### Description
Update the training environment to use the prod BCeID & Keycloak.

As part of this change, I also had to add an entry to "Valid redirect URIs" for the `staff-portal` client on Keycloak prod. 
This was the new entry `https://training-staff.bcparks.ca/*`

