### PR TITLE
CMS-1070: Omit Area-level dates from Area form

### DIFF
--- a/backend/routes/api/seasons.js
+++ b/backend/routes/api/seasons.js
@@ -400,25 +400,18 @@ router.get(
       [Op.or]: [{ parkAreaLevel: true }, { featureLevel: true }],
     });
 
-    // Include all DateTypes for the Park Area level
-    const areaDateTypesArray = await getAllDateTypes({
-      parkAreaLevel: true,
-    });
-
     // Include all DateTypes for the Feature level
     const featureDateTypesArray = await getAllDateTypes({
       featureLevel: true,
     });
 
-    const areaDateTypesByName = _.keyBy(areaDateTypesArray, "name");
     const featureDateTypesByName = _.keyBy(featureDateTypesArray, "name");
 
     // Return the DateTypes in a specific order
-    const orderedAreaDateTypes = [
-      areaDateTypesByName.Operation,
-      areaDateTypesByName.Reservation,
-      areaDateTypesByName["Backcountry registration"],
-    ];
+
+    // Don't include any Area-level dates.
+    // Area forms will only have Feature-level dates.
+    const orderedAreaDateTypes = [];
 
     const orderedFeatureDateTypes = [
       featureDateTypesByName.Operation,
@@ -599,7 +592,7 @@ router.post(
       notes = "",
       deletedDateRangeIds = [],
       dateRangeAnnuals = [],
-      gateDetail = {}
+      gateDetail = {},
     } = req.body;
     let { readyToPublish } = req.body;
 
@@ -649,7 +642,7 @@ router.post(
           transaction,
         },
       );
-      
+
       // gateDetail
       const gateDetailToSave = {
         ...gateDetail,

--- a/backend/routes/api/seasons.js
+++ b/backend/routes/api/seasons.js
@@ -408,11 +408,6 @@ router.get(
     const featureDateTypesByName = _.keyBy(featureDateTypesArray, "name");
 
     // Return the DateTypes in a specific order
-
-    // Don't include any Area-level dates.
-    // Area forms will only have Feature-level dates.
-    const orderedAreaDateTypes = [];
-
     const orderedFeatureDateTypes = [
       featureDateTypesByName.Operation,
       featureDateTypesByName.Reservation,
@@ -446,7 +441,9 @@ router.get(
     const output = {
       current: currentSeason,
       previous: previousSeason,
-      areaDateTypes: orderedAreaDateTypes,
+      // Don't include any Area-level dates.
+      // Area forms will only have Feature-level dates.
+      areaDateTypes: [],
       featureDateTypes: orderedFeatureDateTypes,
       icon,
       featureTypeName,


### PR DESCRIPTION
### Jira Ticket

CMS-1070

### Description
<!-- What did you change, and why? -->

The Area Season form won't show any area-level dates. Every Area has at least one feature (even if it's a fake feature we created called "All sites"). I thought we'd use the area-level to create dates that applied to all the features, but it sounds like we're not doing that at the moment.

The area-level form will still show feature dates, and the gate hours will be the only area-level thing on it. Let me know if my changes will cause problems with the gates section, but I think it won't affect it!