### PR TITLE
CMS-1075: Update park endpoint

### DIFF
--- a/frontend/src/components/EditAndReviewTable.jsx
+++ b/frontend/src/components/EditAndReviewTable.jsx
@@ -183,8 +183,6 @@ function Table({ park, formPanelHandler }) {
   const parkAreas = park.parkAreas || [];
   const features = park.features || [];
 
-  console.log("park:", park);
-
   return (
     <table key={park.id} className="table has-header-row mb-0">
       <thead>


### PR DESCRIPTION
### Jira Ticket

CMS-1075

### Description
<!-- What did you change, and why? -->
- Update the park endpoint
- Remove `description` from `DateType` since it's not necessary for the table
- `Feature` in `ParkArea` didn't have a proper `Season` at the park endpoint since `ParkArea.Feature` is not publishable. When a new date is added to `ParkArea.Feature`, it goes to `ParkArea.Season`, not `ParkArea.Feature.Season`. To fix this, I updated `buildFeatureOutput` to get the related `DateRange` by `dateableId` from `ParkArea.Season` 
