### PR TITLE
CMS-898: Temporarily disable winter fee propagation to features

### DIFF
--- a/backend/routes/api/parks.js
+++ b/backend/routes/api/parks.js
@@ -158,7 +158,10 @@ function buildFeatureOutput(
     ),
   );
   // get date ranges for park.feature
-  const featureDateRanges = getAllDateRanges(filteredSeasons);
+  const featureDateRanges = getAllDateRanges(filteredSeasons)
+    // Temporarily disabling display of Winter Fees
+    // @TODO: Remove this filter when Winter fee logic is revised (CMS-898)
+    .filter((dateRange) => dateRange.dateType?.name !== "Winter fee");
 
   const output = {
     id: feature.id,
@@ -190,7 +193,10 @@ function buildFeatureOutput(
 // build park area output object
 function buildParkAreaOutput(parkArea, currentYear) {
   // get date ranges for parkArea
-  const parkAreaDateRanges = getAllDateRanges(parkArea.seasons);
+  const parkAreaDateRanges = getAllDateRanges(parkArea.seasons)
+    // Temporarily disabling display of Winter Fees
+    // @TODO: Remove this filter when Winter fee logic is revised (CMS-898)
+    .filter((dateRange) => dateRange.dateType?.name !== "Winter fee");
 
   // add featureType to parkArea if all features have the same featureType
   let featureType = null;

--- a/backend/routes/api/seasons.js
+++ b/backend/routes/api/seasons.js
@@ -28,7 +28,7 @@ import {
 } from "../../middleware/permissions.js";
 
 // import { createFirstComeFirstServedDateRange } from "../../utils/firstComeFirstServedHelper.js";
-import propagateWinterFeeDates from "../../utils/propagateWinterFeeDates.js";
+// import propagateWinterFeeDates from "../../utils/propagateWinterFeeDates.js";
 import checkUserRoles from "../../utils/checkUserRoles.js";
 
 const router = Router();
@@ -767,7 +767,8 @@ router.post(
       // await createFirstComeFirstServedDateRange(season, transaction);
 
       // Copy Winter fee dates from the Park level to Features and Park Areas
-      await propagateWinterFeeDates(seasonId, transaction);
+      // @TODO: Uncomment after revising the logic for Winter fees
+      // await propagateWinterFeeDates(seasonId, transaction);
 
       await transaction.commit();
       res.sendStatus(200);


### PR DESCRIPTION
### Jira Ticket

CMS-898

### Description
<!-- What did you change, and why? -->

After discussing this feature with UX and QA today, we realized it's not needed until later on, and the logic may change. Amanda asked to simply disable it for now, and hide Winter fees at the feature/area level on the homepage, and we'll revisit it in a future sprint.

(We're not collecting winter fees at those levels, they'd be generated by the `propagateWinterFeeDates` script which is being commented out here, but the temporary `filter` lines will hide any that exist in the DB for any other reason)