### PR TITLE
CMS-1002: Hide form sections with showDateFormSections

### DIFF
--- a/frontend/src/components/SeasonForms/AreaSeasonForm.jsx
+++ b/frontend/src/components/SeasonForms/AreaSeasonForm.jsx
@@ -287,6 +287,18 @@ export default function AreaSeasonForm({
     [features],
   );
 
+  // Show the BC Parks Reservations section if there are any area date types,
+  //  or any features with inReservationSystem
+  const showBcpResSection = useMemo(
+    () => areaDateTypes.length > 0 || bcpResFeatures.length > 0,
+    [areaDateTypes.length, bcpResFeatures.length],
+  );
+
+  const showNonBcpResSection = useMemo(
+    () => nonBcpResFeatures.length > 0,
+    [nonBcpResFeatures.length],
+  );
+
   const featureDatesByType = useMemo(() => {
     // Create objects with IDs as keys to loop over
     const featuresByDateableId = keyBy(features, "dateableId");
@@ -436,40 +448,66 @@ export default function AreaSeasonForm({
 
   return (
     <>
-      <FormContainer>
-        <div className="row">
-          {/* Area-level dates */}
-          {areaDateTypes.map((dateType) => (
-            <div key={dateType.name} className="col-lg-6 mb-4">
-              <h6 className="fw-normal">
-                {dateType.name}{" "}
-                <TooltipWrapper placement="top" content={dateType.description}>
-                  <FontAwesomeIcon icon={faCircleInfo} />
-                </TooltipWrapper>
-              </h6>
+      {showBcpResSection && (
+        <FormContainer>
+          <div className="row">
+            {/* Area-level dates */}
+            {areaDateTypes.map((dateType) => (
+              <div key={dateType.name} className="col-lg-6 mb-4">
+                <h6 className="fw-normal">
+                  {dateType.name}{" "}
+                  <TooltipWrapper
+                    placement="top"
+                    content={dateType.description}
+                  >
+                    <FontAwesomeIcon icon={faCircleInfo} />
+                  </TooltipWrapper>
+                </h6>
 
-              <PreviousDates
-                dateRanges={previousAreaDatesByType?.[dateType.name]}
-              />
+                <PreviousDates
+                  dateRanges={previousAreaDatesByType?.[dateType.name]}
+                />
 
-              <DateRangeFields
-                dateableId={parkArea.dateableId}
-                dateType={dateType}
-                dateRanges={areaDatesByType[dateType.name] ?? []}
-                updateDateRange={updateAreaDateRange}
-                addDateRange={addAreaDateRange}
-                removeDateRange={removeAreaDateRange}
-                dateRangeAnnuals={dateRangeAnnuals}
-                updateDateRangeAnnual={updateDateRangeAnnual}
-              />
-            </div>
-          ))}
+                <DateRangeFields
+                  dateableId={parkArea.dateableId}
+                  dateType={dateType}
+                  dateRanges={areaDatesByType[dateType.name] ?? []}
+                  updateDateRange={updateAreaDateRange}
+                  addDateRange={addAreaDateRange}
+                  removeDateRange={removeAreaDateRange}
+                  dateRangeAnnuals={dateRangeAnnuals}
+                  updateDateRangeAnnual={updateDateRangeAnnual}
+                />
+              </div>
+            ))}
 
-          {/*
+            {/*
             Feature-level dates within this Area with inReservationSystem=true
             (Features have their own add/update/delete functions)
-          */}
-          {bcpResFeatures.map((feature) => (
+            */}
+            {bcpResFeatures.map((feature) => (
+              <FeatureFormSection
+                feature={feature}
+                featureDateTypes={featureDateTypes}
+                previousFeatureDatesByType={previousFeatureDatesByType}
+                featureDatesByType={featureDatesByType}
+                updateFeatureDateRange={updateFeatureDateRange}
+                addFeatureDateRange={addFeatureDateRange}
+                removeFeatureDateRange={removeFeatureDateRange}
+                key={feature.id}
+              />
+            ))}
+          </div>
+        </FormContainer>
+      )}
+
+      {showNonBcpResSection && (
+        <div className="non-bcp-reservations">
+          {/*
+          Feature-level dates within this Area with inReservationSystem=false
+          (Features have their own add/update/delete functions)
+        */}
+          {nonBcpResFeatures.map((feature) => (
             <FeatureFormSection
               feature={feature}
               featureDateTypes={featureDateTypes}
@@ -482,26 +520,7 @@ export default function AreaSeasonForm({
             />
           ))}
         </div>
-      </FormContainer>
-
-      <div className="non-bcp-reservations">
-        {/*
-          Feature-level dates within this Area with inReservationSystem=false
-          (Features have their own add/update/delete functions)
-        */}
-        {nonBcpResFeatures.map((feature) => (
-          <FeatureFormSection
-            feature={feature}
-            featureDateTypes={featureDateTypes}
-            previousFeatureDatesByType={previousFeatureDatesByType}
-            featureDatesByType={featureDatesByType}
-            updateFeatureDateRange={updateFeatureDateRange}
-            addFeatureDateRange={addFeatureDateRange}
-            removeFeatureDateRange={removeFeatureDateRange}
-            key={feature.id}
-          />
-        ))}
-      </div>
+      )}
 
       <GateForm
         gateTitle={`${parkArea.name} gate`}

--- a/frontend/src/components/SeasonForms/FeatureSeasonForm.jsx
+++ b/frontend/src/components/SeasonForms/FeatureSeasonForm.jsx
@@ -25,6 +25,13 @@ export default function FeatureSeasonForm({
   const dateRangeAnnuals = season.dateRangeAnnuals || [];
   const gateDetail = season.gateDetail || {};
 
+  // Show the date form sections only if there are applicable date types for this feature.
+  // If there are no date types to show, the section would be empty, so we won't render it.
+  const showDateFormSections = useMemo(
+    () => dateTypes.length > 0,
+    [dateTypes.length],
+  );
+
   const datesByType = useMemo(
     () => groupBy(feature.dateable.dateRanges, "dateType.name"),
     [feature.dateable.dateRanges],
@@ -199,15 +206,16 @@ export default function FeatureSeasonForm({
 
   return (
     <>
-      {feature.inReservationSystem ? (
-        <FormContainer>
-          <FormSection />
-        </FormContainer>
-      ) : (
-        <div className="non-bcp-reservations">
-          <FormSection />
-        </div>
-      )}
+      {showDateFormSections &&
+        (feature.inReservationSystem ? (
+          <FormContainer>
+            <FormSection />
+          </FormContainer>
+        ) : (
+          <div className="non-bcp-reservations">
+            <FormSection />
+          </div>
+        ))}
 
       <GateForm
         gateTitle={`${feature.name} gate`}

--- a/frontend/src/components/SeasonForms/ParkSeasonForm.jsx
+++ b/frontend/src/components/SeasonForms/ParkSeasonForm.jsx
@@ -37,6 +37,13 @@ export default function ParkSeasonForm({
     return [operating, nonOperating];
   }, [allDateTypes]);
 
+  // Show the date form sections only if there are applicable date types for this park.
+  // If there are no date types to show, the section would be empty, so we won't render it.
+  const showDateFormSections = useMemo(
+    () => dateTypes.length > 0,
+    [dateTypes.length],
+  );
+
   const datesByType = useMemo(
     () => groupBy(park.dateable.dateRanges, "dateType.name"),
     [park.dateable.dateRanges],
@@ -211,15 +218,16 @@ export default function ParkSeasonForm({
 
   return (
     <>
-      {park.inReservationSystem ? (
-        <FormContainer>
-          <FormSection />
-        </FormContainer>
-      ) : (
-        <div className="non-bcp-reservations">
-          <FormSection />
-        </div>
-      )}
+      {showDateFormSections &&
+        (park.inReservationSystem ? (
+          <FormContainer>
+            <FormSection />
+          </FormContainer>
+        ) : (
+          <div className="non-bcp-reservations">
+            <FormSection />
+          </div>
+        ))}
 
       <GateForm
         gateTitle="Park gate"


### PR DESCRIPTION
### Jira Ticket

CMS-1002

### Description
<!-- What did you change, and why? -->

When there are no applicable date types to collect, the "BC Parks Reservations" box can sometimes be empty, and in that case we don't want to show it. This ticket adds some "show ___ section" variables and wraps the template sections to prevent them from rendering if they'll be empty. This is somewhat related to the other 4 or 5 branches we just merged involving this BC Parks Reservations box. This scenario is getting increasingly unlikely as the other fixes have been merged, but it's still possible with certain conditions, so this branch prevents empty form sections from rendering.

In the Park and Feature forms, it's just one item, so the dates will either be all in the box, or all outside of the box. Just one variable `showDateFormSections` decides whether to show or hide everything.

In the Area form, you could theoretically have some features in the BCP Res. section and some that aren't, so this form uses two variables: `showBcpResSection` and `showNonBcpResSection` to show or hide the two sections individually, but the pattern is pretty much the same.