### PR TITLE
CMS-1075: Filter seasons for features at park area level

### DIFF
--- a/backend/routes/api/parks.js
+++ b/backend/routes/api/parks.js
@@ -153,6 +153,16 @@ function buildFeatureOutput(
 ) {
   // filter seasons if dateRange's dateableId matches feature's dateableId
   const filteredSeasons = (seasons || [])
+    // first, filter seasons that have at least one matching dateRange
+    .filter((season) => {
+      // convert to plain object if it's a Sequelize instance
+      const plainSeason =
+        typeof season.toJSON === "function" ? season.toJSON() : season;
+
+      return (plainSeason.dateRanges || []).some(
+        (dateRange) => dateRange.dateableId === feature.dateableId,
+      );
+    })
     .map((season) => {
       // convert to plain object if it's a Sequelize instance
       const plainSeason =
@@ -164,8 +174,7 @@ function buildFeatureOutput(
           (dateRange) => dateRange.dateableId === feature.dateableId,
         ),
       };
-    })
-    .filter((season) => season.dateRanges.length > 0);
+    });
 
   // get date ranges for park.feature
   const featureDateRanges = getAllDateRanges(filteredSeasons)


### PR DESCRIPTION
### Jira Ticket

CMS-1075

### Description
<!-- What did you change, and why? -->
- After the last change https://github.com/bcgov/bcparks-staff-portal/commit/2f53681cec8a6e546797bb471e032a97e9e89277, I noticed the seasons at `parkArea.feature` weren't fully filtered by `feature.dateableId`. It got all items in the array, if one of the items matched with `feature.dateableId`.
- Filter `dateRange` only if its `dateableId` matches `feature.dateableId`
- Remove `featureType.icon` since it's no longer needed for the park table
