### PR TITLE
CMS-1087: Fall back to checking T1/T2/Winter if BCP Res. check is false

### DIFF
--- a/frontend/src/components/SeasonForms/ParkSeasonForm.jsx
+++ b/frontend/src/components/SeasonForms/ParkSeasonForm.jsx
@@ -44,6 +44,25 @@ export default function ParkSeasonForm({
     [dateTypes.length],
   );
 
+  // If this park is in the BCParks Reservations system,
+  // wrap the date inputs with FormContainer.
+  const useBcpReservationsSection = useMemo(() => {
+    if (park.inReservationSystem) return true;
+
+    // If inReservationSystem is false in the database,
+    // fall back to checking for Winter/T1/T2 dates as a workaround for incomplete data.
+    if (park.hasTier1Dates || park.hasTier2Dates || park.hasWinterFeeDates) {
+      return true;
+    }
+
+    return false;
+  }, [
+    park.inReservationSystem,
+    park.hasTier1Dates,
+    park.hasTier2Dates,
+    park.hasWinterFeeDates,
+  ]);
+
   const datesByType = useMemo(
     () => groupBy(park.dateable.dateRanges, "dateType.name"),
     [park.dateable.dateRanges],
@@ -219,7 +238,7 @@ export default function ParkSeasonForm({
   return (
     <>
       {showDateFormSections &&
-        (park.inReservationSystem ? (
+        (useBcpReservationsSection ? (
           <FormContainer>
             <FormSection />
           </FormContainer>


### PR DESCRIPTION
### Jira Ticket

CMS-1087

### Description
<!-- What did you change, and why? -->

The data is currently incomplete, so many Parks in the BCParks Reservation System have the `inReservationSystem` value false. As a workaround until the data is updated, we've tweaked the logic in the Parks form:

If inReservationSystem is false, then fall back and check the Tier 1, Tier 2, and Winter dates columns. If any of them are true, then consider `inReservationSystem` to be true as well.

If all of them are false, that means there will be no date types to collect besides the Gate Operating dates at the Park level, so the top section of the form won't show anyway. Some of the other checks we added today are now going to be redundant... but at least it will support it if we ever add more date types at the Park level. 

More stuff we can refactor in the future 🫠 