### PR TITLE
CMS-1075: Remove dates row at park area level from table

### DIFF
--- a/frontend/src/components/EditAndReviewTable.jsx
+++ b/frontend/src/components/EditAndReviewTable.jsx
@@ -214,8 +214,6 @@ function Table({ park, formPanelHandler }) {
                 formPanelHandler({ ...parkArea, level: "park-area" })
               }
             />
-            <DateTypeTableRow groupedDateRanges={parkArea.groupedDateRanges} />
-            <DateTableRow groupedDateRanges={parkArea.groupedDateRanges} />
 
             {/* features that belong to park area */}
             {/* these features might not be publishable */}


### PR DESCRIPTION
### Jira Ticket

CMS-1075

### Description
<!-- What did you change, and why? -->
- Remove the dates row at the park area level from the table
- `ParkArea` doesn't have dates anymore