### PR TITLE
CMS-1106: Fix intermittent false 401 errors

### DIFF
--- a/backend/middleware/checkJwt.js
+++ b/backend/middleware/checkJwt.js
@@ -1,14 +1,50 @@
 import { expressjwt } from "express-jwt";
 import jwksRsa from "jwks-rsa";
 
-export default expressjwt({
+const jwtMiddleware = expressjwt({
   secret: jwksRsa.expressJwtSecret({
     cache: true,
     rateLimit: true,
-    jwksRequestsPerMinute: 5,
+    jwksRequestsPerMinute: 10,
     jwksUri: process.env.JWKS_URI,
+
+    // Log JWKS fetching errors for debugging
+    handleSigningKeyError(err, cb) {
+      console.error("JWKS signing key error:", err);
+      cb(err);
+    },
   }),
 
   algorithms: ["RS256", "ES256"],
   issuer: process.env.JWT_ISSUER,
+
+  // Log expired token errors
+  onExpired(req, err) {
+    console.error("JWT expired:", err.message);
+    return err;
+  },
 });
+
+// Wrapper to handle JWT validation errors and return 401 status
+export default function checkJwt(req, res, next) {
+  jwtMiddleware(req, res, (err) => {
+    if (err) {
+      console.error("JWT validation error:", {
+        message: err.message,
+        name: err.name,
+        status: err.status,
+        url: req.url,
+        method: req.method,
+      });
+
+      // Set status to 401 if not already set and pass to global error handler
+      if (!err.status) {
+        err.status = 401;
+      }
+      return next(err);
+    }
+
+    // Only continue if JWT validation succeeded
+    return next();
+  });
+}

--- a/backend/middleware/checkJwt.js
+++ b/backend/middleware/checkJwt.js
@@ -21,7 +21,6 @@ const jwtMiddleware = expressjwt({
   // Log expired token errors
   onExpired(req, err) {
     console.error("JWT expired:", err.message);
-    return err;
   },
 });
 


### PR DESCRIPTION
### Jira Ticket

CMS-1106

### Description
<!-- What did you change, and why? -->

This branch makes some changes to the JWT token checking middleware we're using. It was fine for months and then it started occasionally throwing false 401 errors with no indication of why. And when these 401 errors happened, it would continue along the middleware chain (and still save data, even though it was responding with a 401)

- Wrap the JWT middleware to handle errors and print them out so we can debug if anything weird happens
- The wrapper will also make sure to cancel the middleware chain if there's an error by passing any errors to the global error handler in index.js
- Increase the JWKS Requests Per Minute to 10. I don't think this is the cause of the problem, but it could help 🤷 