### PR TITLE
CMS-1043: Add dateable id to date range

### DIFF
--- a/backend/tasks/populate-date-ranges/populate-date-ranges.js
+++ b/backend/tasks/populate-date-ranges/populate-date-ranges.js
@@ -4,6 +4,7 @@
 import "../../env.js";
 
 import { Season, DateRange, DateRangeAnnual } from "../../models/index.js";
+import { findDateableIdByPublishableId } from "../../utils/findDateableIdByPublishableId.js";
 
 // Functions
 /**
@@ -53,6 +54,11 @@ export async function populateDateRangesForYear(
         transaction,
       });
 
+      // find dateableId for targetSeason's publishableId
+      const dateableId = await findDateableIdByPublishableId(
+        targetSeason.publishableId,
+      );
+
       // skip if no previous or target season found
       if (!prevSeason || !targetSeason) continue;
 
@@ -90,6 +96,7 @@ export async function populateDateRangesForYear(
         newEndDate.setFullYear(currentYear);
 
         dateRangesToCreate.push({
+          dateableId,
           seasonId: targetSeason.id,
           dateTypeId: annual.dateTypeId,
           startDate: newStartDate,

--- a/backend/tasks/populate-missing-dateable-id/README.md
+++ b/backend/tasks/populate-missing-dateable-id/README.md
@@ -1,0 +1,38 @@
+# populate-missing-dateable-id.js
+
+This script populates missing `dateableId` fields in existing `DateRange` records in your database.
+It does **not** create new `DateRange` records—only updates those where `dateableId` is currently `null`.
+
+## What does the script do?
+
+1. **For each `DateRange` with a missing `dateableId`:**
+   - Looks up the associated `Season` using `seasonId`.
+   - Uses the `publishableId` from the `Season` to find the corresponding `dateableId` from the `Park`, `ParkArea`, or `Feature` tables.
+   - Updates the `DateRange` with the found `dateableId`.
+
+2. **Transaction Safety:**
+   - All operations are performed inside a transaction. If any error occurs, all changes are rolled back.
+
+## How to run
+
+From your project root, run:
+
+```sh
+node tasks/populate-missing-dateable-id/populate-missing-dateable-id.js
+```
+
+## Output
+
+- The script logs each update and a summary of how many `DateRange` records were updated.
+- If any error occurs, the transaction is rolled back and an error message is printed.
+
+## Why is this useful?
+
+- Ensures every `DateRange` record has the correct `dateableId` based on its associated `Season`.
+- Keeps your database consistent and ready for queries that rely on `dateableId`.
+
+## Notes
+
+- The script assumes your Sequelize models and associations are set up as in the rest of the BC Parks Staff Portal project.
+- You can safely run this script multiple times; it will only update records where `dateableId` is missing.
+- If a `dateableId` cannot be found for a `DateRange`, the script will log a warning and

--- a/backend/tasks/populate-missing-dateable-id/populate-missing-dateable-id.js
+++ b/backend/tasks/populate-missing-dateable-id/populate-missing-dateable-id.js
@@ -1,0 +1,66 @@
+// This script populates missing dateableId in existing DateRanges
+// by looking up the publishableId from the associated Season.
+
+import "../../env.js";
+import { Season, DateRange } from "../../models/index.js";
+import { findDateableIdByPublishableId } from "../../utils/findDateableIdByPublishableId.js";
+
+export async function populateMissingDateableIdInDateRanges() {
+  const transaction = await DateRange.sequelize.transaction();
+  let updatedCount = 0;
+
+  try {
+    // find all DateRanges with missing dateableId
+    const dateRanges = await DateRange.findAll({
+      where: { dateableId: null },
+      include: [{ model: Season, as: "season" }],
+      transaction,
+    });
+
+    for (const dateRange of dateRanges) {
+      // get associated Season
+      const season =
+        dateRange.season ||
+        (await Season.findByPk(dateRange.seasonId, { transaction }));
+
+      if (!season) {
+        console.warn(`No season found for DateRange id=${dateRange.id}`);
+        continue;
+      }
+
+      // find correct dateableId
+      const dateableId = await findDateableIdByPublishableId(
+        season.publishableId,
+      );
+
+      if (!dateableId) {
+        console.warn(
+          `No dateableId found for publishableId=${season.publishableId} (DateRange id=${dateRange.id})`,
+        );
+        continue;
+      }
+
+      // update DateRange
+      await dateRange.update({ dateableId }, { transaction });
+      updatedCount++;
+      console.log(
+        `Updated DateRange id=${dateRange.id} with dateableId=${dateableId}`,
+      );
+    }
+
+    await transaction.commit();
+    console.log(`Finished. Updated ${updatedCount} DateRanges.`);
+  } catch (error) {
+    await transaction.rollback();
+    console.error("Error populating missing dateableId:", error);
+    throw error;
+  }
+}
+
+// Run directly
+if (process.argv[1] === new URL(import.meta.url).pathname) {
+  populateMissingDateableIdInDateRanges().catch((err) => {
+    console.error("Error populating missing dateableId:", err);
+    throw err;
+  });
+}

--- a/backend/tasks/populate-park-gate-dates/populate-park-gate-dates.js
+++ b/backend/tasks/populate-park-gate-dates/populate-park-gate-dates.js
@@ -75,6 +75,7 @@ export async function populateParkGateDates() {
           dateTypeId: operatingDateType.id,
         },
         defaults: {
+          dateableId: park.dateableId,
           seasonId: season.id,
           dateTypeId: operatingDateType.id,
           startDate,
@@ -86,10 +87,12 @@ export async function populateParkGateDates() {
       // if dateRange exists but dates differ, update them
       if (
         dateRange.startDate.getTime() !== new Date(startDate).getTime() ||
-        dateRange.endDate.getTime() !== new Date(endDate).getTime()
+        dateRange.endDate.getTime() !== new Date(endDate).getTime() ||
+        dateRange.dateableId !== park.dateableId
       ) {
         dateRange.startDate = new Date(startDate);
         dateRange.endDate = new Date(endDate);
+        dateRange.dateableId = park.dateableId;
         await dateRange.save({ transaction });
       }
     }

--- a/backend/utils/findDateableIdByPublishableId.js
+++ b/backend/utils/findDateableIdByPublishableId.js
@@ -1,0 +1,26 @@
+import { Park, ParkArea, Feature } from "../models/index.js";
+
+/**
+ * Finds the dateableId for a given publishableId by searching Park, ParkArea, and Feature.
+ * @param {number} publishableId The publishableId to search for
+ * @returns {Promise<number|null>} The dateableId or null if not found
+ */
+export async function findDateableIdByPublishableId(publishableId) {
+  // try Park
+  const park = await Park.findOne({ where: { publishableId } });
+
+  if (park) return park.dateableId;
+
+  // try ParkArea
+  const parkArea = await ParkArea.findOne({ where: { publishableId } });
+
+  if (parkArea) return parkArea.dateableId;
+
+  // try Feature
+  const feature = await Feature.findOne({ where: { publishableId } });
+
+  if (feature) return feature.dateableId;
+
+  // not found
+  return null;
+}


### PR DESCRIPTION
### Jira Ticket

CMS-1043

### Description
<!-- What did you change, and why? -->
- Additional change on top of https://github.com/bcgov/bcparks-staff-portal/pull/239
- Some dates are displayed in the table but not in the form, because some `DateRanges` were missing `dateableId` 
- Update scripts to add `dateableId` when `DateRanges` are created
  - populate-date-ranges.js: When `Seasons` are created, `DateRanges` will be created if `dateRangeAnnual` is TRUE
  - populate-park-gate-dates.js: When the operating dates are imported from Strapi, `DateRanges` will be created
 - Add a new script to add `dateableId` to `DateRanges` if it is missing
   - For testing: 
     - Check `DateRange` on AdminJS, see the entries without `dateableId`
     - Run `node tasks/populate-missing-dateable-id/populate-missing-dateable-id.js`
     - Check `DateRange` again to see if `dateableId` is added