### PR TITLE
CMS-970: Bulk create blank dates

### DIFF
--- a/backend/migrations/20250724232555-add-backcountry-permits-feature-col.js
+++ b/backend/migrations/20250724232555-add-backcountry-permits-feature-col.js
@@ -1,0 +1,16 @@
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    // Add hasBackcountryPermits field to Features
+    await queryInterface.addColumn("Features", "hasBackcountryPermits", {
+      type: Sequelize.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    // Remove hasBackcountryPermits field from Features
+    await queryInterface.removeColumn("Features", "hasBackcountryPermits");
+  },
+};

--- a/backend/models/feature.js
+++ b/backend/models/feature.js
@@ -57,6 +57,11 @@ export default (sequelize) => {
         allowNull: false,
         defaultValue: false,
       },
+      hasBackcountryPermits: {
+        type: DataTypes.BOOLEAN,
+        allowNull: false,
+        defaultValue: false,
+      },
     },
     {
       sequelize,

--- a/backend/routes/api/seasons.js
+++ b/backend/routes/api/seasons.js
@@ -4,7 +4,11 @@ import asyncHandler from "express-async-handler";
 import { Op } from "sequelize";
 import sequelize from "../../db/connection.js";
 import * as STATUS from "../../constants/seasonStatus.js";
-import { getAllDateTypes } from "../../utils/dateTypesHelpers.js";
+import {
+  getAllDateTypes,
+  getDateTypesForFeature,
+  getDateTypesForPark,
+} from "../../utils/dateTypesHelpers.js";
 
 import {
   Park,
@@ -309,15 +313,7 @@ router.get(
     const { feature } = seasonModel;
 
     // Return the DateTypes in a specific order
-    const orderedDateTypes = [dateTypesByName.Operation];
-
-    // Add applicable date types for the Feature
-    if (feature.hasReservations) {
-      orderedDateTypes.push(dateTypesByName.Reservation);
-    }
-    if (feature.hasBackcountryPermits) {
-      orderedDateTypes.push(dateTypesByName["Backcountry registration"]);
-    }
+    const orderedDateTypes = getDateTypesForFeature(feature, dateTypesByName);
 
     // Get DateRangeAnnuals and GateDetail
     const dateRangeAnnuals = await getDateRangeAnnuals(
@@ -527,18 +523,7 @@ router.get(
     const dateTypesByName = _.keyBy(dateTypesArray, "name");
 
     // Return the DateTypes in a specific order
-    const orderedDateTypes = [];
-
-    // Add applicable date types for the Park
-    if (park.hasTier1Dates) {
-      orderedDateTypes.push(dateTypesByName["Tier 1"]);
-    }
-    if (park.hasTier2Dates) {
-      orderedDateTypes.push(dateTypesByName["Tier 2"]);
-    }
-    if (park.hasWinterFeeDates) {
-      orderedDateTypes.push(dateTypesByName["Winter fee"]);
-    }
+    const orderedDateTypes = getDateTypesForPark(park, dateTypesByName);
 
     // Add Operating date type
     // @TODO: This should be in its own property

--- a/backend/routes/api/seasons.js
+++ b/backend/routes/api/seasons.js
@@ -4,6 +4,7 @@ import asyncHandler from "express-async-handler";
 import { Op } from "sequelize";
 import sequelize from "../../db/connection.js";
 import * as STATUS from "../../constants/seasonStatus.js";
+import { getAllDateTypes } from "../../utils/dateTypesHelpers.js";
 
 import {
   Park,
@@ -123,19 +124,6 @@ async function getPreviousSeasonDates(currentSeason, dateTypeWhere = {}) {
     console.error("Error fetching previous season:", error);
     throw error;
   }
-}
-
-/**
- * Returns an array of all DateTypes, optionally filtered by a WHERE clause.
- * @param {Object} [where={}] Where clause to filter DateTypes (by level, etc.)
- * @returns {Promise<Array<DateType>>} Array of DateTypes
- */
-async function getAllDateTypes(where = {}) {
-  return DateType.findAll({
-    attributes: ["id", "name", "startDateLabel", "endDateLabel", "description"],
-
-    where,
-  });
 }
 
 /**
@@ -323,7 +311,7 @@ router.get(
     // Return the DateTypes in a specific order
     const orderedDateTypes = [dateTypesByName.Operation];
 
-    // Add applicable date types for the Park
+    // Add applicable date types for the Feature
     if (feature.hasReservations) {
       orderedDateTypes.push(dateTypesByName.Reservation);
     }

--- a/backend/routes/api/seasons.js
+++ b/backend/routes/api/seasons.js
@@ -318,12 +318,18 @@ router.get(
 
     const dateTypesByName = _.keyBy(dateTypesArray, "name");
 
+    const { feature } = seasonModel;
+
     // Return the DateTypes in a specific order
-    const orderedDateTypes = [
-      dateTypesByName.Operation,
-      dateTypesByName.Reservation,
-      dateTypesByName["Backcountry registration"],
-    ];
+    const orderedDateTypes = [dateTypesByName.Operation];
+
+    // Add applicable date types for the Park
+    if (feature.hasReservations) {
+      orderedDateTypes.push(dateTypesByName.Reservation);
+    }
+    if (feature.hasBackcountryPermits) {
+      orderedDateTypes.push(dateTypesByName["Backcountry registration"]);
+    }
 
     // Get DateRangeAnnuals and GateDetail
     const dateRangeAnnuals = await getDateRangeAnnuals(

--- a/backend/strapi-sync/sync.js
+++ b/backend/strapi-sync/sync.js
@@ -345,6 +345,7 @@ export async function createOrUpdateFeature(item) {
     dbItem.hasReservations = item.hasReservations;
     // Update it to false if inReservationSystem from Strapi returns null
     dbItem.inReservationSystem = item.inReservationSystem ?? false;
+    dbItem.hasBackcountryPermits = item.hasBackcountryPermits ?? false;
 
     await dbItem.save();
   } else {
@@ -363,6 +364,7 @@ export async function createOrUpdateFeature(item) {
       dateableId: dateable.id,
       hasReservations: item.hasReservations,
       inReservationSystem: item.inReservationSystem ?? false,
+      hasBackcountryPermits: item.hasBackcountryPermits ?? false,
       active: item.isActive,
       strapiId: item.id,
       strapiFeatureId: item.featureId,

--- a/backend/tasks/create-seasons.js
+++ b/backend/tasks/create-seasons.js
@@ -16,7 +16,7 @@ import {
   Season,
 } from "../models/index.js";
 import * as STATUS from "../constants/seasonStatus.js";
-import { populateDateRangesForYear } from "./populate-date-ranges/populate-date-ranges.js";
+import { populateAnnualDateRangesForYear } from "./populate-date-ranges/populate-annual-date-ranges.js";
 
 // Run all queries in a transaction
 const transaction = await Season.sequelize.transaction();
@@ -399,7 +399,7 @@ console.log(`Added ${dateablesAdded} missing Group Camping Feature Dateables`);
 console.log(`Added ${seasonsAdded} new Group Camping Feature Seasons`);
 
 // Populate DateRanges for the new seasons based on previous year if isDateRangeAnnual is TRUE
-await populateDateRangesForYear(operatingYear, transaction);
+await populateAnnualDateRangesForYear(operatingYear, transaction);
 
 console.log("Committing transaction...");
 

--- a/backend/tasks/create-seasons.js
+++ b/backend/tasks/create-seasons.js
@@ -22,6 +22,14 @@ import { populateBlankDateRangesForYear } from "./populate-date-ranges/populate-
 // Run all queries in a transaction
 const transaction = await Season.sequelize.transaction();
 
+if (process.env.SEQUELIZE_LOGGING === "false") {
+  console.warn(
+    "SEQUELIZE_LOGGING is set to false. No SQL queries will be logged.",
+  );
+
+  Season.sequelize.options.logging = false;
+}
+
 // Print errors and roll back transaction on exceptions
 process.on("uncaughtException", (err) => {
   console.error(`\n${err.message}\n`);

--- a/backend/tasks/create-seasons.js
+++ b/backend/tasks/create-seasons.js
@@ -17,6 +17,7 @@ import {
 } from "../models/index.js";
 import * as STATUS from "../constants/seasonStatus.js";
 import { populateAnnualDateRangesForYear } from "./populate-date-ranges/populate-annual-date-ranges.js";
+import { populateBlankDateRangesForYear } from "./populate-date-ranges/populate-blank-date-ranges.js";
 
 // Run all queries in a transaction
 const transaction = await Season.sequelize.transaction();
@@ -400,6 +401,12 @@ console.log(`Added ${seasonsAdded} new Group Camping Feature Seasons`);
 
 // Populate DateRanges for the new seasons based on previous year if isDateRangeAnnual is TRUE
 await populateAnnualDateRangesForYear(operatingYear, transaction);
+
+// Populate blank DateRanges for the new seasons
+await populateBlankDateRangesForYear(operatingYear, transaction);
+
+// Populate blank DateRanges for the next year (which was just created for Group Camping)
+await populateBlankDateRangesForYear(nextYear, transaction);
 
 console.log("Committing transaction...");
 

--- a/backend/tasks/populate-date-ranges/README.md
+++ b/backend/tasks/populate-date-ranges/README.md
@@ -1,4 +1,4 @@
-# populate-date-ranges.js
+# populate-annual-date-ranges.js
 
 This script populates `DateRange` records for a given target year based on the previous year's `DateRange` entries, but **only if the associated `DateRangeAnnual` is marked as annual** (`isDateRangeAnnual` is `TRUE`). It copies the month and day from the previous year's dates, but updates the year to the target year.
 
@@ -18,7 +18,7 @@ This script populates `DateRange` records for a given target year based on the p
 From your project root, run:
 
 ```sh
-node tasks/populate-date-ranges/populate-date-ranges.js 2026
+node tasks/populate-date-ranges/populate-annual-date-ranges.js 2026
 ```
 
 Replace 2026 with the year you want to populate.

--- a/backend/tasks/populate-date-ranges/README.md
+++ b/backend/tasks/populate-date-ranges/README.md
@@ -1,41 +1,58 @@
-# populate-annual-date-ranges.js
+# Date Range Population Scripts
 
-This script populates `DateRange` records for a given target year based on the previous year's `DateRange` entries, but **only if the associated `DateRangeAnnual` is marked as annual** (`isDateRangeAnnual` is `TRUE`). It copies the month and day from the previous year's dates, but updates the year to the target year.
+This directory contains scripts for populating `DateRange` records for new operating years.
 
-## What does the script do?
+## populate-annual-date-ranges.js
 
-1. **For each DateRangeAnnual marked as annual:**
+Populates `DateRange` records for a given target year based on the previous year's `DateRange` entries, but **only if the associated `DateRangeAnnual` is marked as annual** (`isDateRangeAnnual` is `TRUE`). It copies the month and day from the previous year's dates, but updates the year to the target year.
 
-   - Finds the previous and target `Season` for the same `publishableId`.
-   - If both exist, finds all `DateRange` records for the previous season and the relevant `dateTypeId`.
-   - If the target season does **not** already have `DateRange` records for that `dateTypeId`, it creates new ones for the target year, copying the month and day from the previous year but updating the year.
+**For each DateRangeAnnual marked as annual:**
 
-2. **Transaction Safety:**
-   - All operations are performed inside a transaction. If any error occurs, all changes are rolled back.
+- Finds the previous and target `Season` for the same `publishableId`.
+- If both exist, finds all `DateRange` records for the previous season and the relevant `dateTypeId`.
+- If the target season does **not** already have `DateRange` records for that `dateTypeId`, it creates new ones for the target year, copying the month and day from the previous year but updating the year.
+
+## populate-blank-date-ranges.js
+
+Creates blank `DateRange` records for all applicable seasons, dateables (Parks and Features), and date types for a given year. This script:
+
+- Finds all seasons for the target year
+- Determines applicable date types for each dateable based on their configuration (reservation, winter fee, etc.)
+- Creates blank DateRange records for all missing season+dateable+dateType combinations
+- Excludes existing records and Operating date type (handled by Gate date scripts)
+
+## Transaction Safety
+
+Both scripts perform all operations inside a transaction. If any error occurs, all changes are rolled back.
 
 ## How to run
 
-From your project root, run:
+**Most commonly:** These scripts are called automatically as part of the `create-seasons` script, which creates the new seasons and automatically executes both DateRange creation scripts in the correct order.
+
+**Manual execution:** These scripts can also be run individually. Run the annual date ranges script first to populate dates for annual date types based on the previous year, then run the blank date ranges script to create any remaining necessary DateRange records for the new year.
 
 ```sh
-node tasks/populate-date-ranges/populate-annual-date-ranges.js 2026
+# Copy annual DateRanges from previous year (run first)
+node tasks/populate-date-ranges/populate-annual-date-ranges.js 2075
+
+# Create blank DateRange records for all applicable combinations (run second)
+node tasks/populate-date-ranges/populate-blank-date-ranges.js 2075
 ```
 
-Replace 2026 with the year you want to populate.
+Replace `2075` with the year you want to populate.
 
 ## Output
 
-- The script logs each copied DateRange and a summary message on success.
-- If any error occurs, the transaction is rolled back and an error message is printed.
+Both scripts log their progress and provide summary messages on success. If any error occurs, the transaction is rolled back and an error message is printed.
 
 ## Why is this useful?
 
-- Ensures new seasons have the correct date ranges based on the previous year's configuration for annual date types.
-- Prevents duplicate date ranges for the same season and date type.
-- Keeps your database in sync with annual scheduling logic.
+- **populate-annual-date-ranges.js**: Ensures new seasons have the correct date ranges based on the previous year's configuration for annual date types. This will show pre-populated date input fields in the form on the frontend.
+- **populate-blank-date-ranges.js**: Creates blank DateRange records needed for all applicable seasons and date types for a new operating year. This will show empty date input fields in the form on the frontend.
+- Both scripts prevent duplicate date ranges for the same season and date type
 
 ## Notes
 
-- The script assumes your Sequelize models and associations are set up as in the rest of the BC Parks Staff Portal project.
-- You can safely run this script multiple times; it will not create duplicates and will only add missing date ranges.
-- If you add new annual date types or seasons, re-running this script will add any missing date ranges as needed.
+- Both scripts assume your Sequelize models and associations are set up as in the rest of the BC Parks Staff Portal project
+- You can safely run these scripts multiple times; they will not create duplicates and will only add missing date ranges
+- If you add new annual date types or seasons, re-running these scripts will add any missing date ranges as needed

--- a/backend/tasks/populate-date-ranges/populate-annual-date-ranges.js
+++ b/backend/tasks/populate-date-ranges/populate-annual-date-ranges.js
@@ -24,7 +24,7 @@ export function normalizeToLocalDate(dateObject) {
   );
 }
 
-export async function populateDateRangesForYear(
+export async function populateAnnualDateRangesForYear(
   targetYear,
   transaction = null,
 ) {
@@ -119,7 +119,7 @@ export async function populateDateRangesForYear(
       "DateRanges populated for new Seasons based on previous year's annual DateRanges.",
     );
   } catch (err) {
-    console.error("Error populating DateRanges:", err);
+    console.error("Error populating annual DateRanges:", err);
     throw err;
   }
 }
@@ -137,7 +137,7 @@ if (process.argv[1] === new URL(import.meta.url).pathname) {
   }
 
   try {
-    await populateDateRangesForYear(Number(targetYear), transaction);
+    await populateAnnualDateRangesForYear(Number(targetYear), transaction);
     await transaction.commit();
     console.log("Transaction committed.");
   } catch (err) {

--- a/backend/tasks/populate-date-ranges/populate-annual-date-ranges.js
+++ b/backend/tasks/populate-date-ranges/populate-annual-date-ranges.js
@@ -129,14 +129,14 @@ if (process.argv[1] === new URL(import.meta.url).pathname) {
   const targetYear = process.argv[2];
   const transaction = await DateRange.sequelize.transaction();
 
-  if (!targetYear || isNaN(targetYear)) {
-    console.error(
-      "Please provide a target year. e.g. node populate-annual-date-ranges.js 2026",
-    );
-    throw new Error("Invalid or missing target year argument.");
-  }
-
   try {
+    if (!targetYear || isNaN(targetYear)) {
+      console.error(
+        "Please provide a target year. e.g. node populate-annual-date-ranges.js 2026",
+      );
+      throw new Error("Invalid or missing target year argument.");
+    }
+
     await populateAnnualDateRangesForYear(Number(targetYear), transaction);
     await transaction.commit();
     console.log("Transaction committed.");

--- a/backend/tasks/populate-date-ranges/populate-annual-date-ranges.js
+++ b/backend/tasks/populate-date-ranges/populate-annual-date-ranges.js
@@ -131,7 +131,7 @@ if (process.argv[1] === new URL(import.meta.url).pathname) {
 
   if (!targetYear || isNaN(targetYear)) {
     console.error(
-      "Please provide a target year. e.g. node populate-date-ranges.js 2026",
+      "Please provide a target year. e.g. node populate-annual-date-ranges.js 2026",
     );
     throw new Error("Invalid or missing target year argument.");
   }

--- a/backend/tasks/populate-date-ranges/populate-blank-date-ranges.js
+++ b/backend/tasks/populate-date-ranges/populate-blank-date-ranges.js
@@ -229,9 +229,6 @@ export async function populateBlankDateRangesForYear(
       `Created ${createdRecords.length} blank DateRanges for ${targetYear}`,
     );
 
-    // @TODO: Import and call this function in create-seasons.js
-    // @TODO: then update the Readme
-
     return createdRecords;
   } catch (err) {
     console.error("Error populating blank DateRanges:", err);

--- a/backend/tasks/populate-date-ranges/populate-blank-date-ranges.js
+++ b/backend/tasks/populate-date-ranges/populate-blank-date-ranges.js
@@ -175,15 +175,19 @@ export async function populateBlankDateRangesForYear(
       `${dateRangeKeys.length} applicable DateRanges. Checking if any exist already...`,
     );
 
+    // Exclude the Operating date type, handled by Gate date scripts
+    const dateTypeIdWhere = parkDateTypesByName.Operating
+      ? {
+          [Op.not]: parkDateTypesByName.Operating.id,
+        }
+      : {};
+
     // Query existing DateRanges for these seasons
     const existingDateRanges = await DateRange.findAll({
       where: {
         seasonId: seasons.map((s) => s.id),
 
-        // Exclude the Operating date type, handled by Gate date scripts
-        dateTypeId: {
-          [Op.not]: parkDateTypesByName.Operating?.id ?? null,
-        },
+        dateTypeId: dateTypeIdWhere,
       },
       attributes: ["seasonId", "dateableId", "dateTypeId"],
       transaction,

--- a/backend/tasks/populate-date-ranges/populate-blank-date-ranges.js
+++ b/backend/tasks/populate-date-ranges/populate-blank-date-ranges.js
@@ -242,12 +242,12 @@ if (process.argv[1] === new URL(import.meta.url).pathname) {
   // Run all queries in a transaction
   const transaction = await Season.sequelize.transaction();
 
-  if (!targetYear || isNaN(targetYear)) {
-    console.info("Usage example: node populate-blank-date-ranges.js 2097");
-    throw new Error("Missing year argument");
-  }
-
   try {
+    if (!targetYear || isNaN(targetYear)) {
+      console.info("Usage example: node populate-blank-date-ranges.js 2097");
+      throw new Error("Missing year argument");
+    }
+
     const createdRecords = await populateBlankDateRangesForYear(
       Number(targetYear),
       transaction,

--- a/backend/tasks/populate-date-ranges/populate-blank-date-ranges.js
+++ b/backend/tasks/populate-date-ranges/populate-blank-date-ranges.js
@@ -182,7 +182,7 @@ export async function populateBlankDateRangesForYear(
 
         // Exclude the Operating date type, handled by Gate date scripts
         dateTypeId: {
-          [Op.not]: parkDateTypesByName.Operating.id,
+          [Op.not]: parkDateTypesByName.Operating?.id ?? null,
         },
       },
       attributes: ["seasonId", "dateableId", "dateTypeId"],

--- a/backend/tasks/populate-date-ranges/populate-blank-date-ranges.js
+++ b/backend/tasks/populate-date-ranges/populate-blank-date-ranges.js
@@ -18,6 +18,15 @@ import {
   getDateTypesForPark,
 } from "../../utils/dateTypesHelpers.js";
 
+// Select the relevant attributes for Feature records
+const FEATURE_ATTRIBUTES = [
+  "id",
+  "dateableId",
+  "publishableId",
+  "hasReservations",
+  "hasBackcountryPermits",
+];
+
 /**
  * Returns a comparison key for a DateRange based on its season, dateable, and date type IDs.
  * @param {number} seasonId season ID from the DB
@@ -70,13 +79,7 @@ export async function populateBlankDateRangesForYear(
             {
               model: Feature,
               as: "features",
-              attributes: [
-                "id",
-                "dateableId",
-                "publishableId",
-                "hasReservations",
-                "hasBackcountryPermits",
-              ],
+              attributes: FEATURE_ATTRIBUTES,
             },
           ],
         },
@@ -84,13 +87,7 @@ export async function populateBlankDateRangesForYear(
         {
           model: Feature,
           as: "feature",
-          attributes: [
-            "id",
-            "dateableId",
-            "publishableId",
-            "hasReservations",
-            "hasBackcountryPermits",
-          ],
+          attributes: FEATURE_ATTRIBUTES,
         },
       ],
 

--- a/backend/tasks/populate-date-ranges/populate-blank-date-ranges.js
+++ b/backend/tasks/populate-date-ranges/populate-blank-date-ranges.js
@@ -1,0 +1,267 @@
+// This script populates DateRanges for a given target year
+// based on previous year's DateRanges if isDateRangeAnnual is TRUE.
+import "../../env.js";
+
+import _ from "lodash";
+import { Op } from "sequelize";
+
+import {
+  DateRange,
+  Feature,
+  Park,
+  ParkArea,
+  Season,
+} from "../../models/index.js";
+import {
+  getAllDateTypes,
+  getDateTypesForFeature,
+  getDateTypesForPark,
+} from "../../utils/dateTypesHelpers.js";
+
+/**
+ * Returns a comparison key for a DateRange based on its season, dateable, and date type IDs.
+ * @param {number} seasonId season ID from the DB
+ * @param {number} dateableId dateable ID from the DB
+ * @param {number} dateTypeId date type ID from the DB
+ * @returns {string} Unique key for the DateRange
+ */
+function getDateRangeKey(seasonId, dateableId, dateTypeId) {
+  return `${seasonId}-${dateableId}-${dateTypeId}`;
+}
+
+/**
+ * Populates blank DateRanges for a given year by creating DateRanges for all Seasons
+ * and their associated Dateable Parks and Features, and applicable DateTypes.
+ * @param {number} targetYear The year for which to populate blank DateRanges
+ * @param {Transaction} [transaction] Optional Sequelize transaction
+ * @returns {Promise<Array>} Array of created DateRange records
+ */
+export async function populateBlankDateRangesForYear(
+  targetYear,
+  transaction = null,
+) {
+  try {
+    console.log(`Creating blank DateRanges for ${targetYear}`);
+
+    // Find all Seasons for the target year
+    const seasons = await Season.findAll({
+      where: { operatingYear: targetYear },
+
+      include: [
+        {
+          model: Park,
+          as: "park",
+          attributes: [
+            "id",
+            "dateableId",
+            "publishableId",
+            "hasTier1Dates",
+            "hasTier2Dates",
+            "hasWinterFeeDates",
+          ],
+        },
+
+        {
+          model: ParkArea,
+          as: "parkArea",
+          attributes: ["id", "dateableId", "publishableId"],
+
+          include: [
+            {
+              model: Feature,
+              as: "features",
+              attributes: [
+                "id",
+                "dateableId",
+                "publishableId",
+                "hasReservations",
+                "hasBackcountryPermits",
+              ],
+            },
+          ],
+        },
+
+        {
+          model: Feature,
+          as: "feature",
+          attributes: [
+            "id",
+            "dateableId",
+            "publishableId",
+            "hasReservations",
+            "hasBackcountryPermits",
+          ],
+        },
+      ],
+
+      transaction,
+    });
+
+    console.log(`Found ${seasons.length} Seasons for ${targetYear}`);
+
+    // Get all date types for all levels of dateables
+    const allDateTypes = await getAllDateTypes({}, transaction);
+
+    // Group date types by their applicable levels
+    // (Dates aren't collected for ParkArea Dateables: only Parks and Features)
+    const parkDateTypes = [];
+    const featureDateTypes = [];
+
+    allDateTypes.forEach((dateType) => {
+      // If the date type is applicable to Parks, add it to parkDateTypes
+      if (dateType.parkLevel) {
+        parkDateTypes.push({ id: dateType.id, name: dateType.name });
+      }
+
+      // If the date type is applicable to Features, add it to featureDateTypes
+      if (dateType.featureLevel) {
+        featureDateTypes.push({ id: dateType.id, name: dateType.name });
+      }
+    });
+
+    const parkDateTypesByName = _.keyBy(parkDateTypes, "name");
+    const featureDateTypesByName = _.keyBy(featureDateTypes, "name");
+
+    // Create a list of seasonId+dateableId+dateTypeId combinations
+    // for the DateRanges to be created
+    const dateRangeKeys = seasons.flatMap((season) => {
+      // If the season is for a Park, add its ID for all applicable date types
+      if (season.park) {
+        const dateTypes = getDateTypesForPark(season.park, parkDateTypesByName);
+
+        return dateTypes.map((dateType) => ({
+          seasonId: season.id,
+          dateableId: season.park.dateableId,
+          dateTypeId: dateType.id,
+        }));
+      }
+
+      // If the season is for a ParkArea, add IDs for all of its features
+      // and applicable date types
+      if (season.parkArea) {
+        return season.parkArea.features.flatMap((feature) => {
+          const dateTypes = getDateTypesForFeature(
+            feature,
+            featureDateTypesByName,
+          );
+
+          return dateTypes.map((dateType) => ({
+            seasonId: season.id,
+            dateableId: feature.dateableId,
+            dateTypeId: dateType.id,
+          }));
+        });
+      }
+
+      // If the season is for a Feature, add its ID for all applicable date types
+      if (season.feature) {
+        const feature = season.feature;
+        const dateTypes = getDateTypesForFeature(
+          feature,
+          featureDateTypesByName,
+        );
+
+        return dateTypes.map((dateType) => ({
+          seasonId: season.id,
+          dateableId: feature.dateableId,
+          dateTypeId: dateType.id,
+        }));
+      }
+
+      return [];
+    });
+
+    console.log(
+      `${dateRangeKeys.length} applicable DateRanges. Checking if any exist already...`,
+    );
+
+    // Query existing DateRanges for these seasons
+    const existingDateRanges = await DateRange.findAll({
+      where: {
+        seasonId: seasons.map((s) => s.id),
+
+        // Exclude the Operating date type, handled by Gate date scripts
+        dateTypeId: {
+          [Op.not]: parkDateTypesByName.Operating.id,
+        },
+      },
+      attributes: ["seasonId", "dateableId", "dateTypeId"],
+      transaction,
+    });
+
+    console.log(
+      `${existingDateRanges.length} applicable DateRanges already exist.`,
+    );
+
+    // Create a Set of existing DateRange keys to avoid creating duplicates
+    const existingKeys = new Set(
+      existingDateRanges.map((dateRange) =>
+        getDateRangeKey(
+          dateRange.seasonId,
+          dateRange.dateableId,
+          dateRange.dateTypeId,
+        ),
+      ),
+    );
+
+    // Get all the keys that need to be created:
+    // dateRangeKeys that are not in existingKeys
+    const keysToCreate = dateRangeKeys.filter(
+      (key) =>
+        !existingKeys.has(
+          getDateRangeKey(key.seasonId, key.dateableId, key.dateTypeId),
+        ),
+    );
+
+    if (keysToCreate.length === 0) {
+      console.log("All applicable DateRanges exist - none to create");
+      return [];
+    }
+
+    console.log(`Creating ${keysToCreate.length} missing DateRanges`);
+
+    // Bulk insert the new DateRanges
+    const createdRecords = await DateRange.bulkCreate(keysToCreate, {
+      transaction,
+    });
+
+    console.log(
+      `Created ${createdRecords.length} blank DateRanges for ${targetYear}`,
+    );
+
+    // @TODO: Import and call this function in create-seasons.js
+    // @TODO: then update the Readme
+
+    return createdRecords;
+  } catch (err) {
+    console.error("Error populating blank DateRanges:", err);
+    throw err;
+  }
+}
+
+// run directly:
+if (process.argv[1] === new URL(import.meta.url).pathname) {
+  const targetYear = process.argv[2];
+  // Run all queries in a transaction
+  const transaction = await Season.sequelize.transaction();
+
+  if (!targetYear || isNaN(targetYear)) {
+    console.info("Usage example: node populate-blank-date-ranges.js 2097");
+    throw new Error("Missing year argument");
+  }
+
+  try {
+    const createdRecords = await populateBlankDateRangesForYear(
+      Number(targetYear),
+      transaction,
+    );
+
+    await transaction.commit();
+    console.log("Done creating blank DateRanges for year", targetYear);
+    console.log(`Created ${createdRecords.length} records`);
+  } catch (err) {
+    await transaction.rollback();
+    console.error("Transaction rolled back due to error:", err);
+    throw err;
+  }
+}

--- a/backend/tasks/populate-date-ranges/populate-blank-date-ranges.js
+++ b/backend/tasks/populate-date-ranges/populate-blank-date-ranges.js
@@ -1,5 +1,5 @@
-// This script populates DateRanges for a given target year
-// based on previous year's DateRanges if isDateRangeAnnual is TRUE.
+// This script populates blank DateRanges for a given target year
+// in order to show blank date picker inputs on the frontend
 import "../../env.js";
 
 import _ from "lodash";

--- a/backend/utils/dateTypesHelpers.js
+++ b/backend/utils/dateTypesHelpers.js
@@ -1,0 +1,72 @@
+import { DateType } from "../models/index.js";
+
+/**
+ * Returns an array of all DateTypes, optionally filtered by a WHERE clause.
+ * @param {Object} [where={}] Where clause to filter DateTypes (by level, etc.)
+ * @param {Transaction} [transaction] Optional Sequelize transaction
+ * @returns {Promise<Array<DateType>>} Array of DateTypes
+ */
+export async function getAllDateTypes(where = {}, transaction = null) {
+  return DateType.findAll({
+    attributes: [
+      "id",
+      "name",
+      "startDateLabel",
+      "endDateLabel",
+      "description",
+      "parkLevel",
+      "parkAreaLevel",
+      "featureLevel",
+    ],
+
+    where,
+
+    transaction,
+  });
+}
+
+/**
+ * Returns the DateTypes applicable to a Park or Feature in a specific order.
+ * @param {Object} park Park object
+ * @param {Object} dateTypesByName Object mapping date type name to objects with ids
+ * @returns {Array} Applicable DateType objects for the Park, in order
+ */
+export function getDateTypesForPark(park, dateTypesByName) {
+  // Return the DateTypes in a specific order
+  const orderedDateTypes = [];
+
+  // Add applicable date types for the Park
+  if (park.hasTier1Dates) {
+    orderedDateTypes.push(dateTypesByName["Tier 1"]);
+  }
+  if (park.hasTier2Dates) {
+    orderedDateTypes.push(dateTypesByName["Tier 2"]);
+  }
+  if (park.hasWinterFeeDates) {
+    orderedDateTypes.push(dateTypesByName["Winter fee"]);
+  }
+
+  return orderedDateTypes;
+}
+
+/**
+ * Returns the DateTypes applicable to a Feature in a specific order.
+ * For Features, it includes Operation, Reservation, and Backcountry registration dates if applicable.
+ * @param {Object} feature Feature object
+ * @param {Object} dateTypesByName Object mapping date type name to objects with ids
+ * @returns {Array} An array of DateType objects in the specified order.
+ */
+export function getDateTypesForFeature(feature, dateTypesByName) {
+  // Return the DateTypes in a specific order
+  const orderedDateTypes = [dateTypesByName.Operation];
+
+  // Add applicable date types for the Feature
+  if (feature.hasReservations) {
+    orderedDateTypes.push(dateTypesByName.Reservation);
+  }
+  if (feature.hasBackcountryPermits) {
+    orderedDateTypes.push(dateTypesByName["Backcountry registration"]);
+  }
+
+  return orderedDateTypes;
+}


### PR DESCRIPTION
### Jira Ticket

CMS-970

### Description
<!-- What did you change, and why? -->

A bunch of related changes in this ticket:

1. created a "dateTypeHelpers" file and moved some shared/repeated code in there: get all dateTypes, and get the ordered list of dateTypes for the given Park/Feature
2. Added `hasBackcountryPermits` to the Feature model to conditionally show the Backcountry registration date type.
3. Updated the sync script to pull in the hasBackcountryPermits value
4. renamed populate-date-ranges to populate-**annual**-date-ranges
5. Created a new script to go with it called populate-**blank**-date-ranges and updated the Readme file in that folder
6. updated `create-seasons` to call both scripts in order

# create-blank-date-ranges
This script finds all of the seasons for the given operatingYear (so they have to exist already, from create-seasons) and then looks at all of the **dateables** for those seasons, and all of the **date ranges** that apply to those dateables.

It builds a list of season+dateable+dateRange IDs and checks if any DateRanges already exist for those ID combinations.
(create-seasons creates stuff for future years so there might already be group camping/winter dates for the year that were entered previously). For any DateRanges that **don't** exist yet, it bulk-inserts blank DateRange records in the db.

The result is the frontend season edit form will have empty dateRange inputs for every dateable & date type so the user won't have to click "+ Add more Reservation dates" etc.

<img width="534" height="190" alt="image" src="https://github.com/user-attachments/assets/0b115ebd-2e38-49c9-8023-2d8ec05dbed6" />

Hopefully the script makes sense! It's a big file, but half of it is taken up by the query :P
