### PR TITLE
CMS-1082: Add "Optional" labels, disable "X" for single dates

### DIFF
--- a/frontend/src/components/DateRangeFields.jsx
+++ b/frontend/src/components/DateRangeFields.jsx
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import PropTypes from "prop-types";
+import classNames from "classnames";
 import { faPlus, faXmark } from "@fa-kit/icons/classic/regular";
 import { startOfYear, endOfYear, addYears } from "date-fns";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -12,6 +13,7 @@ function DateRange({
   dateRange,
   updateDateRange,
   removeDateRange,
+  removable = true,
   isDateRangeAnnual,
 }) {
   // A unique ID for template loops and selectors
@@ -72,7 +74,11 @@ function DateRange({
       </div>
 
       <button
-        className="btn btn-text text-link align-self-end"
+        // Disable and hide the remove button if this is the first/only date range
+        className={classNames("btn btn-text text-link align-self-end", {
+          invisible: !removable,
+        })}
+        disabled={!removable}
         onClick={() => removeDateRange(dateRange)}
       >
         <FontAwesomeIcon icon={faXmark} />
@@ -94,6 +100,8 @@ DateRange.propTypes = {
   }).isRequired,
   updateDateRange: PropTypes.func.isRequired,
   removeDateRange: PropTypes.func.isRequired,
+  // Allow removal only if it's not the first date range
+  removable: PropTypes.bool,
   isDateRangeAnnual: PropTypes.bool.isRequired,
 };
 
@@ -106,6 +114,7 @@ export default function DateRangeFields({
   dateType,
   dateRangeAnnuals,
   updateDateRangeAnnual,
+  optional = false,
 }) {
   // Constants
   // Tier 1 only allows 1 date range
@@ -148,12 +157,13 @@ export default function DateRangeFields({
 
   return (
     <>
-      {dateRanges.map((dateRange) => (
+      {dateRanges.map((dateRange, index) => (
         <DateRange
           key={dateRange.id || dateRange.tempId}
           dateRange={dateRange}
           updateDateRange={updateDateRange}
           removeDateRange={removeDateRange}
+          removable={optional || index > 0}
           isDateRangeAnnual={isDateRangeAnnual}
         />
       ))}
@@ -211,4 +221,5 @@ DateRangeFields.propTypes = {
   }).isRequired,
   dateRangeAnnuals: PropTypes.arrayOf(PropTypes.object).isRequired,
   updateDateRangeAnnual: PropTypes.func.isRequired,
+  optional: PropTypes.bool,
 };

--- a/frontend/src/components/GateForm.jsx
+++ b/frontend/src/components/GateForm.jsx
@@ -9,6 +9,8 @@ import RadioButtonGroup from "@/components/RadioButtonGroup";
 import TimeRangeForm from "@/components/TimeRangeForm";
 import TooltipWrapper from "@/components/TooltipWrapper";
 
+import isDateTypeOptional from "@/lib/isDateTypeOptional";
+
 export default function GateForm({
   gateTitle,
   gateDescription,
@@ -73,6 +75,10 @@ export default function GateForm({
                   </TooltipWrapper>
                 </h6>
 
+                {isDateTypeOptional(dateType.name, level) && (
+                  <div className="my-2 text-secondary-grey">(Optional)</div>
+                )}
+
                 <PreviousDates dateRanges={previousDateRanges} />
 
                 <DateRangeFields
@@ -84,6 +90,7 @@ export default function GateForm({
                   removeDateRange={removeDateRange}
                   dateRangeAnnuals={dateRangeAnnuals}
                   updateDateRangeAnnual={updateDateRangeAnnual}
+                  optional={isDateTypeOptional(dateType.name, level)}
                 />
               </div>
             )}
@@ -99,8 +106,10 @@ export default function GateForm({
               >
                 <FontAwesomeIcon icon={faCircleInfo} />
               </TooltipWrapper>{" "}
-              (Optional)
             </h6>
+
+            <div className="my-2 text-secondary-grey">(Optional)</div>
+
             <p>Hours remain the same every year unless updated.</p>
             <Form>
               <Form.Check

--- a/frontend/src/components/SeasonForms/AreaSeasonForm.jsx
+++ b/frontend/src/components/SeasonForms/AreaSeasonForm.jsx
@@ -20,6 +20,7 @@ import PreviousDates from "@/components/SeasonForms/PreviousDates";
 
 import DataContext from "@/contexts/DataContext";
 import { updateDateRangeAnnualsArray } from "@/lib/utils";
+import isDateTypeOptional from "@/lib/isDateTypeOptional";
 
 // Individual Area-Feature form section
 function FeatureFormSectionComponent({
@@ -45,6 +46,10 @@ function FeatureFormSectionComponent({
               <FontAwesomeIcon icon={faCircleInfo} />
             </TooltipWrapper>
           </h6>
+
+          {isDateTypeOptional(dateType.name, "feature") && (
+            <div className="my-2 text-secondary-grey">(Optional)</div>
+          )}
 
           {/* Show previous dates for this featureId/dateableId */}
           <PreviousDates
@@ -72,6 +77,7 @@ function FeatureFormSectionComponent({
             }
             dateRangeAnnuals={dateRangeAnnuals}
             updateDateRangeAnnual={updateDateRangeAnnual}
+            optional={isDateTypeOptional(dateType.name, "feature")}
           />
         </div>
       ))}
@@ -468,6 +474,10 @@ export default function AreaSeasonForm({
                   </TooltipWrapper>
                 </h6>
 
+                {isDateTypeOptional(dateType.name, "parkArea") && (
+                  <div className="my-2 text-secondary-grey">(Optional)</div>
+                )}
+
                 <PreviousDates
                   dateRanges={previousAreaDatesByType?.[dateType.name]}
                 />
@@ -481,6 +491,7 @@ export default function AreaSeasonForm({
                   removeDateRange={removeAreaDateRange}
                   dateRangeAnnuals={dateRangeAnnuals}
                   updateDateRangeAnnual={updateDateRangeAnnual}
+                  optional={isDateTypeOptional(dateType.name, "parkArea")}
                 />
               </div>
             ))}

--- a/frontend/src/components/SeasonForms/FeatureSeasonForm.jsx
+++ b/frontend/src/components/SeasonForms/FeatureSeasonForm.jsx
@@ -13,6 +13,7 @@ import PreviousDates from "@/components/SeasonForms/PreviousDates";
 
 import DataContext from "@/contexts/DataContext";
 import { updateDateRangeAnnualsArray } from "@/lib/utils";
+import isDateTypeOptional from "@/lib/isDateTypeOptional";
 
 export default function FeatureSeasonForm({
   season,
@@ -184,6 +185,10 @@ export default function FeatureSeasonForm({
               </TooltipWrapper>
             </h6>
 
+            {isDateTypeOptional(dateType.name, "feature") && (
+              <div className="my-2 text-secondary-grey">(Optional)</div>
+            )}
+
             <PreviousDates dateRanges={previousDatesByType?.[dateType.name]} />
 
             <DateRangeFields
@@ -195,6 +200,7 @@ export default function FeatureSeasonForm({
               removeDateRange={removeDateRange}
               dateRangeAnnuals={dateRangeAnnuals}
               updateDateRangeAnnual={updateDateRangeAnnual}
+              optional={isDateTypeOptional(dateType.name, "feature")}
             />
           </div>
         ))}

--- a/frontend/src/components/SeasonForms/ParkSeasonForm.jsx
+++ b/frontend/src/components/SeasonForms/ParkSeasonForm.jsx
@@ -13,6 +13,7 @@ import PreviousDates from "@/components/SeasonForms/PreviousDates";
 
 import DataContext from "@/contexts/DataContext";
 import { updateDateRangeAnnualsArray } from "@/lib/utils";
+import isDateTypeOptional from "@/lib/isDateTypeOptional";
 
 export default function ParkSeasonForm({
   season,
@@ -215,6 +216,10 @@ export default function ParkSeasonForm({
               </TooltipWrapper>
             </h6>
 
+            {isDateTypeOptional(dateType.name, "park") && (
+              <div className="my-2 text-secondary-grey">(Optional)</div>
+            )}
+
             <PreviousDates dateRanges={previousDatesByType?.[dateType.name]} />
 
             <DateRangeFields
@@ -226,6 +231,7 @@ export default function ParkSeasonForm({
               removeDateRange={removeDateRange}
               dateRangeAnnuals={dateRangeAnnuals}
               updateDateRangeAnnual={updateDateRangeAnnual}
+              optional={isDateTypeOptional(dateType.name, "park")}
             />
           </div>
         ))}

--- a/frontend/src/lib/isDateTypeOptional.js
+++ b/frontend/src/lib/isDateTypeOptional.js
@@ -1,0 +1,16 @@
+export const optionalTypes = {
+  // @TODO: use a list of constants for date types
+  park: ["Operating", "Tier 2"],
+  parkArea: [],
+  feature: [],
+};
+
+/**
+ * Returns true if the date type is optional for the given level.
+ * @param {string} dateTypeName the date type to check
+ * @param {string} level the level to check against ("park", "parkArea", "feature")
+ * @returns {boolean} true if the date type is optional for the level, false otherwise
+ */
+export default function isDateTypeOptional(dateTypeName, level) {
+  return optionalTypes[level]?.includes(dateTypeName) ?? false;
+}

--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -104,6 +104,13 @@ a:not(.btn):focus {
   }
 }
 
+// custom bootstrap text color: "secondary-grey"
+// (The Bootstrap theme's "secondary" color is blue.
+// This uses the dark grey color from the design tokens.)
+.text-secondary-grey {
+  color: var(--typography-color-secondary) !important;
+}
+
 // override bootstrap button disabled styles
 .btn:disabled,
 .btn.disabled {


### PR DESCRIPTION
### Jira Ticket

CMS-1082

### Description
<!-- What did you change, and why? -->

Added a new function to return true if a date type is "optional" at the given level. If it's optional, we show a label under the date type header. 

Also added some logic to hide and disable the "X" button to remove dates:
- If a date is not optional, you won't be able to remove them all; there must always be one left.
- If a date is optional, you can still remove them all.
- Instead of removing the button entirely, I made it disabled and invisible so the flex box elements stay the same size. We can update this with a CSS grid later on...

Added a CSS class for the "secondary' color, which is very close to black. Some things in Figma are colored in this dark grey shade so we can use this class for that. The "secondary" color in the Bootstrap is blue 🙃 so I called it "secondary-grey"