### PR TITLE
CMS-324: Always reset AccessGroups tables when populating new bundles

### DIFF
--- a/backend/tasks/populate-access-groups/populate-access-groups.js
+++ b/backend/tasks/populate-access-groups/populate-access-groups.js
@@ -42,8 +42,7 @@ export async function populateAccessGroups() {
   const transaction = await AccessGroup.sequelize.transaction();
 
   try {
-    // turn it on if you want to clean up existing data before populating
-    // await cleanupAccessGroupData(transaction);
+    await cleanupAccessGroupData(transaction);
 
     for (const agreement of agreements) {
       const accessGroupId = agreement.id;


### PR DESCRIPTION
### Jira Ticket

CMS-324

### Description
<!-- What did you change, and why? -->

A small update for the AccessGroups changes from CMS-324, this just makes the default behavior to clear the database tables every time. I don't think there's any drawback to doing this every time. The benefit is, if anybody is removed from an AccessGroup, this will update that without us having to manually delete the record.