### PR TITLE
CMS-000: Split training and test deploy scripts

### DIFF
--- a/.github/workflows/deploy-training.yaml
+++ b/.github/workflows/deploy-training.yaml
@@ -1,15 +1,15 @@
-name: Deploy to Test
+name: Deploy to Training
 
 on:
   workflow_dispatch:
     inputs:
       releaseTag:
-        description: "Tag of version to be deployed to TEST"
+        description: "Tag of version to be deployed to TRAINING"
         required: true
 
 env:
   TOOLS_NAMESPACE: ${{ vars.OPENSHIFT_LICENSE_PLATE }}-tools
-  ENVIRONMENT: test
+  ENVIRONMENT: training
   NAMESPACE: ${{ vars.OPENSHIFT_LICENSE_PLATE }}-test
 
 jobs:
@@ -38,12 +38,12 @@ jobs:
           openshift_server_url: ${{ vars.OPENSHIFT_SERVER_URL }}
           openshift_token: ${{ secrets.OPENSHIFT_SERVICE_TOKEN }}
 
-      - name: Tag Test images
+      - name: Tag Training images
         run: |
           oc -n ${{ env.TOOLS_NAMESPACE }} tag frontend-main:${{ github.event.inputs.releaseTag }} frontend-main:${{ env.ENVIRONMENT }}
           oc -n ${{ env.TOOLS_NAMESPACE }} tag backend-main:${{ github.event.inputs.releaseTag }} backend-main:${{ env.ENVIRONMENT }}
 
-      - name: Trigger new rollout for test
+      - name: Trigger new rollout for training
         run: |
-          oc -n ${{ env.NAMESPACE }} rollout restart deployment main-frontend
-          oc -n ${{ env.NAMESPACE }} rollout restart deployment main-backend
+          oc -n ${{ env.NAMESPACE }} rollout restart deployment training-frontend
+          oc -n ${{ env.NAMESPACE }} rollout restart deployment training-backend

--- a/helm/deployment/values-training.yaml
+++ b/helm/deployment/values-training.yaml
@@ -4,9 +4,9 @@ cluster:
 
 images:
   frontend:
-    tag: test
+    tag: training
   backend:
-    tag: test
+    tag: training
 
 frontend:
   env:


### PR DESCRIPTION
### Jira Ticket

CMS-000 - no ticket

### Description
<!-- What did you change, and why? -->

A single GitHub action deployed to Test and Training at the same time, but we need the ability to deploy separately now that different groups are using both environments. This ticket reverts "Deploy to Test" and creates a separate "Deploy to Training" action. I updated the helm chart for the training environment to use the `training` tag instead of the `test` tag, but I haven't applied it as of yet.