### PR TITLE
CMS-1097: Update filter by date type

### DIFF
--- a/backend/routes/api/parks.js
+++ b/backend/routes/api/parks.js
@@ -65,6 +65,7 @@ function featureModel(minYear, where = {}) {
       "publishableId",
       "parkAreaId",
       "name",
+      "hasBackcountryPermits",
       "inReservationSystem",
     ],
     include: [
@@ -183,6 +184,7 @@ function buildFeatureOutput(feature, seasons, includeCurrentSeason = true) {
     publishableId: feature.publishableId,
     parkAreaId: feature.parkAreaId,
     name: feature.name,
+    hasBackcountryPermits: feature.hasBackcountryPermits,
     inReservationSystem: feature.inReservationSystem,
     featureType: {
       id: feature.featureType.id,

--- a/frontend/src/router/pages/EditAndReview.jsx
+++ b/frontend/src/router/pages/EditAndReview.jsx
@@ -206,6 +206,27 @@ function EditAndReview() {
         if (
           filters.dateTypes.length > 0 &&
           !filters.dateTypes.some((filterDateType) => {
+            // check park.hasTier1Dates, park.hasTier2Dates, park.hasWinterFeeDates, and dateTypes
+            if (filterDateType.name === "Tier 1" && !park.hasTier1Dates) {
+              return false;
+            }
+            if (filterDateType.name === "Tier 2" && !park.hasTier2Dates) {
+              return false;
+            }
+            if (
+              filterDateType.name === "Winter fee" &&
+              !park.hasWinterFeeDates
+            ) {
+              return false;
+            }
+            // check feature.hasBackcountryPermits and dateTypes
+            if (
+              filterDateType.name === "Backcountry registration" &&
+              !park.features?.some((feature) => feature.hasBackcountryPermits)
+            ) {
+              return false;
+            }
+
             // check park.seasons and dateTypes
             const hasParkDateType = park.seasons?.some((season) =>
               season.dateRanges?.some(


### PR DESCRIPTION
### Jira Ticket

CMS-1097

### Description
<!-- What did you change, and why? -->

- Filter parks by date types, including not only parks/parkAreas/features that have dates with the specific date type, but also those without dates if the following properties are applicable: `park.hasTier1Dates`, `park.hasTier2Dates`, `park.hasWinterFeeDates`, and `feature.hasBackcountryPermits`