### PR TITLE
CMS-1020: Use park area publishable id for group camping feature seasons

### DIFF
--- a/backend/routes/api/parks.js
+++ b/backend/routes/api/parks.js
@@ -84,9 +84,7 @@ function featureModel(minYear, where = {}) {
 // e.g. {Operation: {2024: [...], 2025: [...]}, Winter: {2024: [...], 2025: [...]}, ...}
 function groupDateRangesByTypeAndYear(dateRanges, hasGate = null) {
   // filter out invalid dateRanges
-  let validRanges = dateRanges.filter(
-    (dateRange) => dateRange.dateType && dateRange.startDate,
-  );
+  let validRanges = dateRanges.filter((dateRange) => dateRange.dateType);
 
   // filter out "Operating" dateType if hasGate is explicitly false at the park level
   if (hasGate === false) {

--- a/backend/tasks/create-seasons.js
+++ b/backend/tasks/create-seasons.js
@@ -307,6 +307,12 @@ const parkAreasWithFeatures = Array.from(parkAreasMap.values());
 
 console.log(`Found ${parkAreasWithFeatures.length} ParkAreas with Features`);
 
+/**
+ * Creates new Seasons for each ParkArea in the provided array for the given year.
+ * @param {Array<ParkArea>} parkAreas Array of ParkArea records to process.
+ * @param {number} year The operating year for which to create seasons.
+ * @returns {Promise<void>}
+ */
 async function createSeasonsForParkAreas(parkAreas, year) {
   for (const parkArea of parkAreas) {
     // If the parkArea doesn't have a publishableId, add one and associate it
@@ -346,6 +352,12 @@ console.log(
   `Found ${featuresWithoutParkArea.length} Features with no ParkArea`,
 );
 
+/**
+ * Creates new Seasons for each Feature in the provided array for the given year.
+ * @param {Array<Feature>} features Array of Feature records to process.
+ * @param {number} year The operating year for which to create seasons.
+ * @returns {Promise<void>}
+ */
 async function createSeasonsForFeatures(features, year) {
   for (const feature of features) {
     // If the feature doesn't have a publishableId, add one and associate it

--- a/backend/tasks/create-seasons.js
+++ b/backend/tasks/create-seasons.js
@@ -389,6 +389,22 @@ const groupCampingFeatures = await Feature.findAll({
 console.log(`Found ${groupCampingFeatures.length} Group Camping Features`);
 
 const groupCampingQueries = groupCampingFeatures.map(async (feature) => {
+  // If the feature belongs to a ParkArea, use the ParkArea's publishableId
+  if (feature.parkAreaId) {
+    let parkArea = feature.parkArea;
+
+    if (!parkArea) {
+      parkArea = await ParkArea.findByPk(feature.parkAreaId, { transaction });
+    }
+
+    if (parkArea) {
+      await createPublishable(parkArea);
+      await createDateable(parkArea);
+      await createSeason(parkArea.publishableId, nextYear);
+      return;
+    }
+  }
+
   // If the feature doesn't have a publishableId, add one and associate it
   await createPublishable(feature);
 

--- a/backend/tasks/create-seasons.js
+++ b/backend/tasks/create-seasons.js
@@ -303,22 +303,24 @@ const parkAreaFeatures = await Feature.findAll({
 const parkAreasMap = new Map(
   parkAreaFeatures.map((feature) => [feature.parkArea.id, feature.parkArea]),
 );
-const parkAreas = Array.from(parkAreasMap.values());
+const parkAreasWithFeatures = Array.from(parkAreasMap.values());
 
-console.log(`Found ${parkAreas.length} ParkAreas with Features`);
+console.log(`Found ${parkAreasWithFeatures.length} ParkAreas with Features`);
 
-const parkAreasQueries = parkAreas.map(async (parkArea) => {
-  // If the parkArea doesn't have a publishableId, add one and associate it
-  await createPublishable(parkArea);
+async function createSeasonsForParkAreas(parkAreas, year) {
+  for (const parkArea of parkAreas) {
+    // If the parkArea doesn't have a publishableId, add one and associate it
+    await createPublishable(parkArea);
 
-  // If the parkArea doesn't have a dateableId, add one and associate it
-  await createDateable(parkArea);
+    // If the parkArea doesn't have a dateableId, add one and associate it
+    await createDateable(parkArea);
 
-  // Create a season for this parkArea's Publishable ID and Operating Year, if it doesn't exist
-  await createSeason(parkArea.publishableId, operatingYear);
-});
+    // Create a season for this parkArea's Publishable ID and Operating Year, if it doesn't exist
+    await createSeason(parkArea.publishableId, year);
+  }
+}
 
-await Promise.all(parkAreasQueries);
+await createSeasonsForParkAreas(parkAreasWithFeatures, operatingYear);
 
 console.log(`Added ${publishablesAdded} missing ParkArea Publishables`);
 console.log(`Added ${dateablesAdded} missing ParkArea Dateables`);
@@ -330,7 +332,7 @@ publishablesAdded = 0;
 dateablesAdded = 0;
 seasonsAdded = 0;
 
-const features = await Feature.findAll({
+const featuresWithoutParkArea = await Feature.findAll({
   where: {
     active: true,
     // Find Features with null parkAreaId
@@ -340,20 +342,24 @@ const features = await Feature.findAll({
   transaction,
 });
 
-console.log(`Found ${features.length} Features with no ParkArea`);
+console.log(
+  `Found ${featuresWithoutParkArea.length} Features with no ParkArea`,
+);
 
-const featuresQueries = features.map(async (feature) => {
-  // If the feature doesn't have a publishableId, add one and associate it
-  await createPublishable(feature);
+async function createSeasonsForFeatures(features, year) {
+  for (const feature of features) {
+    // If the feature doesn't have a publishableId, add one and associate it
+    await createPublishable(feature);
 
-  // If the feature doesn't have a dateableId, add one and associate it
-  await createDateable(feature);
+    // If the feature doesn't have a dateableId, add one and associate it
+    await createDateable(feature);
 
-  // Create a season for this feature's Publishable ID and Operating Year, if it doesn't exist
-  await createSeason(feature.publishableId, operatingYear);
-});
+    // Create a season for this feature's Publishable ID and Operating Year, if it doesn't exist
+    await createSeason(feature.publishableId, year);
+  }
+}
 
-await Promise.all(featuresQueries);
+await createSeasonsForFeatures(featuresWithoutParkArea, operatingYear);
 
 console.log(`Added ${publishablesAdded} missing Feature Publishables`);
 console.log(`Added ${dateablesAdded} missing Feature Dateables`);
@@ -388,34 +394,29 @@ const groupCampingFeatures = await Feature.findAll({
 
 console.log(`Found ${groupCampingFeatures.length} Group Camping Features`);
 
-const groupCampingQueries = groupCampingFeatures.map(async (feature) => {
-  // If the feature belongs to a ParkArea, use the ParkArea's publishableId
-  if (feature.parkAreaId) {
-    let parkArea = feature.parkArea;
+// Collect unique parkAreaIds from group camping features that belong to a ParkArea
+const uniqueParkAreaIds = [
+  ...new Set(
+    groupCampingFeatures
+      .filter((feature) => feature.parkAreaId)
+      .map((feature) => feature.parkAreaId),
+  ),
+];
 
-    if (!parkArea) {
-      parkArea = await ParkArea.findByPk(feature.parkAreaId, { transaction });
-    }
-
-    if (parkArea) {
-      await createPublishable(parkArea);
-      await createDateable(parkArea);
-      await createSeason(parkArea.publishableId, nextYear);
-      return;
-    }
-  }
-
-  // If the feature doesn't have a publishableId, add one and associate it
-  await createPublishable(feature);
-
-  // If the feature doesn't have a dateableId, add one and associate it
-  await createDateable(feature);
-
-  // Create a season for this Feature's Publishable ID and next Operating Year, if it doesn't exist
-  await createSeason(feature.publishableId, nextYear);
+const groupCampingParkAreas = await ParkArea.findAll({
+  where: { id: uniqueParkAreaIds },
+  transaction,
 });
 
-await Promise.all(groupCampingQueries);
+// Create seasons for each unique ParkArea
+await createSeasonsForParkAreas(groupCampingParkAreas, nextYear);
+
+// For group camping features that do NOT belong to a ParkArea, create seasons for the feature itself
+const independentFeatures = groupCampingFeatures.filter(
+  (feature) => !feature.parkAreaId,
+);
+
+await createSeasonsForFeatures(independentFeatures, nextYear);
 
 console.log(
   `Added ${publishablesAdded} missing Group Camping Feature Publishables`,


### PR DESCRIPTION
### Jira Ticket

CMS-1020

### Description
<!-- What did you change, and why? -->

- When next year's seasons are created (e.g. 2026), the year after the next seasons will be created for the group campsites (e.g. 2027), but these seasons weren't displayed in the table and the form because the season used `feature.publishableId`, not `parkArea.publishableId`
- Updated `create-season` script to create seasons for the group campsites based on `parkArea.publishableId` if its `feature` belongs to `parkArea`
  - If not, create seasons based on `feature.publishableId`
 - Updated the `/park` endpoint to display empty date ranges as "Not provided" for the last year's season in the table
 - For testing, run `node tasks/re-sync-seasons-and-dates/re-sync-season-and-dates.js`