### PR TITLE
CMS-1097: Filter parks by hasGate

### DIFF
--- a/backend/routes/api/parks.js
+++ b/backend/routes/api/parks.js
@@ -333,6 +333,7 @@ router.get(
         publishableId: park.publishableId,
         name: park.name,
         orcs: park.orcs,
+        hasGate: parkHasGate,
         hasTier1Dates: park.hasTier1Dates,
         hasTier2Dates: park.hasTier2Dates,
         hasWinterFeeDates: park.hasWinterFeeDates,

--- a/frontend/src/router/pages/EditAndReview.jsx
+++ b/frontend/src/router/pages/EditAndReview.jsx
@@ -206,6 +206,13 @@ function EditAndReview() {
         if (
           filters.dateTypes.length > 0 &&
           !filters.dateTypes.some((filterDateType) => {
+            // check park.hasGate and dateTypes
+            if (
+              ["Gate", "Operating"].includes(filterDateType.name) &&
+              !park.hasGate
+            ) {
+              return false;
+            }
             // check park.hasTier1Dates, park.hasTier2Dates, park.hasWinterFeeDates, and dateTypes
             if (filterDateType.name === "Tier 1" && !park.hasTier1Dates) {
               return false;


### PR DESCRIPTION
### Jira Ticket

CMS-1097

### Description
<!-- What did you change, and why? -->
- Some gate data on PROD is incorrect and needs to be reviewed by the content team, but given the UAT date is coming, I added a workaround to the park filter
- There is a case where a park has the Operating dates but no gate. 
  - The park filter by date type "Operating (Gate)" should filter based on `hasGate`, not `dateType` "Operating" 