### PR TITLE
CMS-970: Remove early return before creating blank gate dates

### DIFF
--- a/backend/tasks/populate-date-ranges/populate-blank-date-ranges.js
+++ b/backend/tasks/populate-date-ranges/populate-blank-date-ranges.js
@@ -218,10 +218,9 @@ export async function populateBlankDateRangesForYear(
 
     if (keysToCreate.length === 0) {
       console.log("All applicable DateRanges exist - none to create");
-      return [];
+    } else {
+      console.log(`Creating ${keysToCreate.length} missing DateRanges`);
     }
-
-    console.log(`Creating ${keysToCreate.length} missing DateRanges`);
 
     // Bulk insert the new DateRanges
     const createdRecords = await DateRange.bulkCreate(keysToCreate, {


### PR DESCRIPTION
### Jira Ticket

CMS-970

### Description
<!-- What did you change, and why? -->

A quick fix to the script that populates blank date ranges - it was returning early when there were no dates to create, so sometimes the "create blank gate operating dates" section would never be reached. Now it will continue through the process, even if there are 0 dates to create, so the second script will always be called.