### PR TITLE
CMS-947: Update filter for bcp reservations

### DIFF
--- a/backend/migrations/20250818235750-add-in-reservation-system-field-to-parkarea.js
+++ b/backend/migrations/20250818235750-add-in-reservation-system-field-to-parkarea.js
@@ -1,0 +1,16 @@
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    // Add inReservationSystem field to ParkAreas
+    await queryInterface.addColumn("ParkAreas", "inReservationSystem", {
+      type: Sequelize.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    // Remove inReservationSystem field from ParkAreas
+    await queryInterface.removeColumn("ParkAreas", "inReservationSystem");
+  },
+};

--- a/backend/models/parkarea.js
+++ b/backend/models/parkarea.js
@@ -40,6 +40,12 @@ export default (sequelize) => {
       name: DataTypes.STRING,
       parkId: DataTypes.INTEGER,
       dateableId: DataTypes.INTEGER,
+      
+      inReservationSystem: {
+        type: DataTypes.BOOLEAN,
+        allowNull: false,
+        defaultValue: false,
+      },
     },
     {
       sequelize,

--- a/backend/routes/api/parks.js
+++ b/backend/routes/api/parks.js
@@ -232,6 +232,7 @@ function buildParkAreaOutput(parkArea) {
     dateableId: parkArea.dateableId,
     publishableId: parkArea.publishableId,
     name: parkArea.name,
+    inReservationSystem: parkArea.inReservationSystem,
     features: parkArea.features.map((feature) =>
       buildFeatureOutput(feature, parkArea.seasons, false),
     ),
@@ -269,7 +270,13 @@ router.get(
         {
           model: ParkArea,
           as: "parkAreas",
-          attributes: ["id", "dateableId", "publishableId", "name"],
+          attributes: [
+            "id",
+            "dateableId",
+            "publishableId",
+            "name",
+            "inReservationSystem",
+          ],
           include: [
             // Features that are part of the ParkArea
             featureModel(currentYear),

--- a/backend/tasks/populate-in-reservation-system/README.md
+++ b/backend/tasks/populate-in-reservation-system/README.md
@@ -13,7 +13,6 @@ This script populates the `inReservationSystem` field on each `ParkArea` based o
    - If **any** child `Feature` has `inReservationSystem === true`, sets the parent `ParkArea.inReservationSystem` to `true`.
    - If **all** child `Feature` records have `inReservationSystem === false`, sets the parent to `false`.
    - If there are **no child features**, the script skips that `ParkArea`.
-   - If all child features are `null`/`undefined`, the script skips updating that `ParkArea`.
 
 3. **Transaction Safety:**
    - All operations are performed inside a transaction. If any error occurs, all changes are rolled back.

--- a/backend/tasks/populate-in-reservation-system/README.md
+++ b/backend/tasks/populate-in-reservation-system/README.md
@@ -1,0 +1,50 @@
+# populate-in-reservation-system.js
+
+This script populates the `inReservationSystem` field on each `ParkArea` based on the values of its child `Feature` records.
+
+## What does the script do?
+
+1. **For each ParkArea:**
+
+   - Fetches all child `Feature` records.
+
+2. **Logic for setting `inReservationSystem`:**
+
+   - If **any** child `Feature` has `inReservationSystem === true`, sets the parent `ParkArea.inReservationSystem` to `true`.
+   - If **all** child `Feature` records have `inReservationSystem === false`, sets the parent to `false`.
+   - If there are **no child features**, the script skips that `ParkArea`.
+   - If all child features are `null`/`undefined`, the script skips updating that `ParkArea`.
+
+3. **Transaction Safety:**
+   - All operations are performed inside a transaction. If any error occurs, all changes are rolled back.
+
+## How to run
+
+From your project root, run:
+
+```sh
+node tasks/populate-in-reservation-system/populate-in-reservation-system.js
+```
+
+## Output
+
+- The script logs each `ParkArea` that was updated, e.g.:
+  ```
+  Updated ParkArea id=123 inReservationSystem=true
+  ```
+- On success, logs:
+  ```
+  Finished. Updated X ParkAreas.
+  ```
+- If any error occurs, the transaction is rolled back and an error message is printed.
+
+## Why is this useful?
+
+- Ensures every `ParkArea`'s `inReservationSystem` field accurately reflects the reservation status of its child features.
+- Keeps your database consistent and up-to-date with the actual reservation system status of features.
+
+## Notes
+
+- The script assumes your Sequelize models and associations are set up as in the rest of the BC Parks Staff Portal project.
+- You can safely run this script multiple times; it will only update `ParkArea` records where the value needs to change.
+- If you add new Features or update their `inReservationSystem` status, re-running this script will update the parent `ParkArea` as needed.

--- a/backend/tasks/populate-in-reservation-system/populate-in-reservation-system.js
+++ b/backend/tasks/populate-in-reservation-system/populate-in-reservation-system.js
@@ -20,22 +20,13 @@ export async function populateParkAreaInReservationSystem(transaction = null) {
     });
 
     for (const parkArea of parkAreas) {
-      let newValue;
       const features = parkArea.features || [];
 
       if (features.length === 0) continue;
 
-      // set it true if any feature has inReservationSystem = true,
-      if (features.some((feature) => feature.inReservationSystem === true)) {
-        newValue = true;
-      } else if (
-        features.every((feature) => feature.inReservationSystem === false)
-      ) {
-        newValue = false;
-      } else {
-        // skip if all features have null or undefined inReservationSystem values
-        continue;
-      }
+      const newValue = features.some(
+        (feature) => feature.inReservationSystem === true,
+      );
 
       if (parkArea.inReservationSystem !== newValue) {
         parkArea.inReservationSystem = newValue;

--- a/backend/tasks/populate-in-reservation-system/populate-in-reservation-system.js
+++ b/backend/tasks/populate-in-reservation-system/populate-in-reservation-system.js
@@ -33,7 +33,7 @@ export async function populateParkAreaInReservationSystem(transaction = null) {
       ) {
         newValue = false;
       } else {
-        // skip if there are no features
+        // skip if all features have null or undefined inReservationSystem values
         continue;
       }
 
@@ -48,10 +48,8 @@ export async function populateParkAreaInReservationSystem(transaction = null) {
       }
     }
 
-    await transaction.commit();
     console.log(`Finished. Updated ${updatedCount} ParkAreas.`);
   } catch (error) {
-    await transaction.rollback();
     console.error("Error populating ParkArea.inReservationSystem:", error);
     throw error;
   }
@@ -61,8 +59,12 @@ export async function populateParkAreaInReservationSystem(transaction = null) {
 if (process.argv[1] === new URL(import.meta.url).pathname) {
   const transaction = await ParkArea.sequelize.transaction();
 
-  populateParkAreaInReservationSystem(transaction).catch((err) => {
+  try {
+    await populateParkAreaInReservationSystem(transaction);
+    await transaction.commit();
+  } catch (err) {
+    await transaction.rollback();
     console.error("Error populating ParkArea.inReservationSystem:", err);
     throw err;
-  });
+  }
 }

--- a/backend/tasks/populate-in-reservation-system/populate-in-reservation-system.js
+++ b/backend/tasks/populate-in-reservation-system/populate-in-reservation-system.js
@@ -1,0 +1,68 @@
+// This script populates ParkArea.inReservationSystem based on its child Features' inReservationSystem values.
+
+import "../../env.js";
+import { ParkArea, Feature } from "../../models/index.js";
+
+export async function populateParkAreaInReservationSystem(transaction = null) {
+  let updatedCount = 0;
+
+  try {
+    // find all ParkAreas with their Features
+    const parkAreas = await ParkArea.findAll({
+      include: [
+        {
+          model: Feature,
+          as: "features",
+          attributes: ["id", "inReservationSystem"],
+        },
+      ],
+      transaction,
+    });
+
+    for (const parkArea of parkAreas) {
+      let newValue;
+      const features = parkArea.features || [];
+
+      if (features.length === 0) continue;
+
+      // set it true if any feature has inReservationSystem = true,
+      if (features.some((feature) => feature.inReservationSystem === true)) {
+        newValue = true;
+      } else if (
+        features.every((feature) => feature.inReservationSystem === false)
+      ) {
+        newValue = false;
+      } else {
+        // skip if there are no features
+        continue;
+      }
+
+      if (parkArea.inReservationSystem !== newValue) {
+        parkArea.inReservationSystem = newValue;
+        await parkArea.save({ transaction });
+        updatedCount++;
+
+        console.log(
+          `Updated ParkArea id=${parkArea.id} inReservationSystem=${newValue}`,
+        );
+      }
+    }
+
+    await transaction.commit();
+    console.log(`Finished. Updated ${updatedCount} ParkAreas.`);
+  } catch (error) {
+    await transaction.rollback();
+    console.error("Error populating ParkArea.inReservationSystem:", error);
+    throw error;
+  }
+}
+
+// run directly
+if (process.argv[1] === new URL(import.meta.url).pathname) {
+  const transaction = await ParkArea.sequelize.transaction();
+
+  populateParkAreaInReservationSystem(transaction).catch((err) => {
+    console.error("Error populating ParkArea.inReservationSystem:", err);
+    throw err;
+  });
+}

--- a/frontend/src/components/FilterPanel.jsx
+++ b/frontend/src/components/FilterPanel.jsx
@@ -95,10 +95,9 @@ function FilterPanel({
                 </div>
               </div>
               <div className="mt-4">
-                {/* TODO: CMS-787 */}
                 <SwitchToggle
                   id="is-in-reservation-system"
-                  label="In BC Parks reservation system"
+                  label="BCP reservations only"
                   checked={filters.isInReservationSystem}
                   onChange={(e) =>
                     updateFilter("isInReservationSystem", e.target.checked)

--- a/frontend/src/router/pages/EditAndReview.jsx
+++ b/frontend/src/router/pages/EditAndReview.jsx
@@ -307,10 +307,15 @@ function EditAndReview() {
         }
 
         // filter by isInReservationSystem
+        // park level - check if it has hasTier1Dates, hasTier2Dates, or hasWinterFeeDates
+        // area and feature level - check it it has inReservationSystem
         if (
           filters.isInReservationSystem &&
           !(
-            park.inReservationSystem ||
+            park.hasTier1Dates ||
+            park.hasTier2Dates ||
+            park.hasWinterFeeDates ||
+            park.parkAreas.some((parkArea) => parkArea.inReservationSystem) ||
             park.features.some((feature) => feature.inReservationSystem)
           )
         ) {


### PR DESCRIPTION
### Jira Ticket

CMS-947

### Description
- Added a new field `inReservationSystem` to `ParkArea`
- Created a script to populate `inReservationSystem` at the `ParkArea` level from `inReservationSystem` at the `Feature` level 
- ^ For testing, run `node tasks/populate-in-reservation-system/populate-in-reservation-system.js`
- Updated the filter text to "BCP reservations only"
- Updated the filter logic
  - `Park` level dates only appear if they contain Tier 1, Tier 2, or Winter fee dates
  - `ParkArea` level dates appear if they are `inReservationSystem`
  - `Feature` level dates appear if they are `inReservationSystem`
