### PR TITLE
CMS-510: Add "completeDateRanges" validation rule

### DIFF
--- a/frontend/src/hooks/useValidation/rules/completeDateRanges.js
+++ b/frontend/src/hooks/useValidation/rules/completeDateRanges.js
@@ -1,0 +1,35 @@
+/**
+ * Validates that the DateRanges with a startDate also have an endDate, and vice versa.
+ * @param {Object} seasonData The season form data to validate
+ * @param {Object} context Validation context with errors array
+ * @returns {void}
+ */
+export default function completeDateRanges(seasonData, context) {
+  const { dateRanges, elements } = context;
+
+  // Only validate after the form is submitted
+  if (!context.submitted) return;
+
+  // Add errors for all invalid dates (dates must be within operatingYear)
+  dateRanges.forEach((dateRange) => {
+    const idOrTempId = dateRange.id || dateRange.tempId;
+
+    // startDate but no endDate
+    if (dateRange.startDate && !dateRange.endDate) {
+      context.addError(
+        // Show the error below the empty end date field
+        elements.dateField(idOrTempId, "endDate"),
+        "Enter an end date",
+      );
+    }
+
+    // endDate but no startDate
+    if (dateRange.endDate && !dateRange.startDate) {
+      context.addError(
+        // Show the error below the empty start date field
+        elements.dateField(idOrTempId, "startDate"),
+        "Enter a start date",
+      );
+    }
+  });
+}

--- a/frontend/src/hooks/useValidation/rules/completeDateRanges.js
+++ b/frontend/src/hooks/useValidation/rules/completeDateRanges.js
@@ -10,7 +10,7 @@ export default function completeDateRanges(seasonData, context) {
   // Only validate after the form is submitted
   if (!context.submitted) return;
 
-  // Add errors for all invalid dates (dates must be within operatingYear)
+  // Add errors for incomplete date ranges (missing startDate or endDate)
   dateRanges.forEach((dateRange) => {
     const idOrTempId = dateRange.id || dateRange.tempId;
 

--- a/frontend/src/hooks/useValidation/useValidation.js
+++ b/frontend/src/hooks/useValidation/useValidation.js
@@ -9,6 +9,7 @@ import noOverlapPrevious from "./rules/noOverlapPrevious.js";
 import changeNoteRequired from "./rules/changeNoteRequired.js";
 import reservationWithinOperating from "./rules/reservationWithinOperating.js";
 import reservationEndsBeforeOperatingEnds from "./rules/reservationEndsBeforeOperatingEnds.js";
+import completeDateRanges from "./rules/completeDateRanges.js";
 
 // Constants for named "validation error slots" in the UI
 const elements = {
@@ -85,6 +86,7 @@ function validate(seasonData, seasonContext) {
   // Call the validation rules on the season data
   validGateTime(seasonData, validationContext);
   hasGateChosen(seasonData, validationContext);
+  completeDateRanges(seasonData, validationContext);
   requiredDateRanges(seasonData, validationContext);
   startDateBeforeEndDate(seasonData, validationContext);
   dateInOperatingYear(seasonData, validationContext);


### PR DESCRIPTION
### Jira Ticket

CMS-510

### Description
<!-- What did you change, and why? -->

The requirements for the basic validation ticket have changed, so I implemented this rule that was not applicable before 👍 
Now, any dateRange with a start date but no end date will show "Enter an end date" when you try to submit.
And likewise, if you have an end date but no start date, you'll see "Enter a start date"