### PR TITLE
CMS-970: Fix season/dateRange filter in create-blank-gate-dates

### DIFF
--- a/backend/tasks/populate-date-ranges/populate-blank-gate-dates.js
+++ b/backend/tasks/populate-date-ranges/populate-blank-gate-dates.js
@@ -39,7 +39,7 @@ export default async function populateBlankGateOperatingDates(
       {
         model: Park,
         as: "park",
-        attributes: ["id", "name", "publishableId"],
+        attributes: ["id", "name"],
         required: true,
 
         include: [

--- a/backend/tasks/populate-date-ranges/populate-blank-gate-dates.js
+++ b/backend/tasks/populate-date-ranges/populate-blank-gate-dates.js
@@ -1,6 +1,5 @@
 import "../../env.js";
 
-import { Sequelize } from "sequelize";
 import {
   DateType,
   DateRange,
@@ -63,11 +62,6 @@ export default async function populateBlankGateOperatingDates(
                 model: DateRange,
                 as: "dateRanges",
                 required: false,
-                where: {
-                  seasonId: {
-                    [Sequelize.Op.col]: "Season.id",
-                  },
-                },
               },
             ],
           },
@@ -82,10 +76,12 @@ export default async function populateBlankGateOperatingDates(
     `\nFound ${parkSeasons.length} park seasons with gates for year ${targetYear}`,
   );
 
-  // Filter for seasons that have no Operating DateRanges
+  // Filter for seasons that have no Operating DateRanges for this specific season
   const seasonsWithoutOperatingDates = parkSeasons.filter((season) => {
     const operatingDateRanges = season.park.dateable.dateRanges.filter(
-      (dateRange) => dateRange.dateTypeId === operatingDateType.id,
+      (dateRange) =>
+        dateRange.dateTypeId === operatingDateType.id &&
+        dateRange.seasonId === season.id,
     );
 
     return operatingDateRanges.length === 0;

--- a/backend/tasks/populate-date-ranges/populate-blank-gate-dates.js
+++ b/backend/tasks/populate-date-ranges/populate-blank-gate-dates.js
@@ -32,50 +32,49 @@ export default async function populateBlankGateOperatingDates(
   });
 
   // Get all Park Seasons with "HasGate = true"
-  const parkSeasons = await Season.findAll(
-    {
-      where: { operatingYear: targetYear },
+  const parkSeasons = await Season.findAll({
+    where: { operatingYear: targetYear },
 
-      include: [
-        {
-          model: Park,
-          as: "park",
-          attributes: ["id", "name"],
-          required: true,
+    include: [
+      {
+        model: Park,
+        as: "park",
+        attributes: ["id", "name"],
+        required: true,
 
-          include: [
-            {
-              model: GateDetail,
-              as: "gateDetails",
-              required: true,
-              where: {
-                hasGate: true,
-              },
+        include: [
+          {
+            model: GateDetail,
+            as: "gateDetails",
+            required: true,
+            where: {
+              hasGate: true,
             },
+          },
 
-            {
-              model: Dateable,
-              as: "dateable",
-              required: true,
+          {
+            model: Dateable,
+            as: "dateable",
+            required: true,
 
-              include: [
-                {
-                  model: DateRange,
-                  as: "dateRanges",
-                  required: false,
+            include: [
+              {
+                model: DateRange,
+                as: "dateRanges",
+                required: false,
 
-                  where: {
-                    dateTypeId: operatingDateType.id,
-                  },
+                where: {
+                  dateTypeId: operatingDateType.id,
                 },
-              ],
-            },
-          ],
-        },
-      ],
-    },
-    { transaction },
-  );
+              },
+            ],
+          },
+        ],
+      },
+    ],
+
+    transaction,
+  });
 
   // Filter a list of Park Seasons that have no Operating date ranges yet
   const seasonsWithoutDates = parkSeasons.filter(


### PR DESCRIPTION
### Jira Ticket

CMS-970

### Description
<!-- What did you change, and why? -->

Another fix to the script that creates blank Operating gate dates:
- The query wasn't using the transaction because it wasn't passed correctly
- The query wasn't properly filtering the seasons and date types.
This commit should fix both of those issues.

I already copied the file up to the alpha-test environment and ran it there, and it seemed to work 🙈 