### PR TITLE
CMS-1176: Allow save draft if there are validation errors

### DIFF
--- a/frontend/src/hooks/useValidation/useValidation.js
+++ b/frontend/src/hooks/useValidation/useValidation.js
@@ -112,7 +112,7 @@ function validate(seasonData, seasonContext) {
  * - {Object} groupedErrors Errors grouped by element for display
  * - {Array} errors Array of validation error objects
  * - {Object} elements Constants for named validation error slots in the UI
- * - {Function} validateForm Function to manually validate the form and throw if errors exist
+ * - {Function} validateForm Function to manually validate the form and return any errors found
  */
 export default function useValidation(seasonData, context) {
   // Re-validate when any form value changes, and update the errors array
@@ -123,9 +123,10 @@ export default function useValidation(seasonData, context) {
   );
 
   /**
-   * Validates the form data and throws an error if there are validation errors.
+   * Validates the form data and returns any validation errors.
    * This is used in the onSave function to ensure the form is valid before saving.
    * @param {boolean} [submitted=true] Whether the form has been submitted.
+   * @returns {Array} Array of validation error objects
    */
   const validateForm = useCallback(
     (submitted = true) => {
@@ -134,9 +135,8 @@ export default function useValidation(seasonData, context) {
 
       const errorResults = validate(seasonData, validationContext);
 
-      if (errorResults.length) {
-        throw new Error(`Validation failed with ${errorResults.length} errors`);
-      }
+      // Return the errors. Any length > 0 means the form is invalid.
+      return errorResults;
     },
     [seasonData, context],
   );


### PR DESCRIPTION
### Jira Ticket

CMS-1176

### Description
<!-- What did you change, and why? -->

A small change to allow "Save Draft" even if there are validation errors. I added a second parameter to the onSave function to "allow invalid" and now I'm returning the errors as an array, and then throwing an exception if there's anything in the array.

I think we will need this later on if Approvers need the ability to bypass validation errors for unusual park rules.

Approving and Submitting are still not allowed but Saving drafts will be allowed with errors. 

I'll mention in the ticket, the error where you have to provide a note if you're editing previously approved/published dates can be bypassed now... but we can add an exception or something for that in another ticket. This ticket is just to allow saving with errors.