### PR TITLE
CMS-1185: Add a filter to previous dates at feature in park area level

### DIFF
--- a/frontend/src/components/SeasonForms/AreaSeasonForm.jsx
+++ b/frontend/src/components/SeasonForms/AreaSeasonForm.jsx
@@ -57,7 +57,9 @@ function FeatureFormSectionComponent({
 
           {/* Show previous dates for this featureId/dateableId */}
           <PreviousDates
-            dateRanges={previousFeatureDatesByType?.[dateType.name]}
+            dateRanges={previousFeatureDatesByType?.[dateType.name]?.filter(
+              (dateRange) => dateRange.dateableId === feature.dateableId,
+            )}
           />
 
           <DateRangeFields


### PR DESCRIPTION
### Jira Ticket

CMS-1185

### Description
<!-- What did you change, and why? -->

- Add a `dateableId` filter to previous dates at the feature in the park area level