### PR TITLE
CMS-1078: Add Tier 1 & 2 validation rules

### DIFF
--- a/backend/routes/api/seasons.js
+++ b/backend/routes/api/seasons.js
@@ -315,6 +315,50 @@ async function getFeatureReservationDates(park, operatingYear) {
   return reservationDateRanges;
 }
 
+/**
+ * Returns the Tier 1 and Tier 2 dates for a Park Season.
+ * @param {Object} park Park model with hasTier1Dates, hasTier2Dates, and publishableId
+ * @param {number} operatingYear Operating year for the Seasons
+ * @returns {Promise<Object>} - Object with parkTier1Dates and parkTier2Dates arrays
+ */
+async function getParkTier1And2Dates(park, operatingYear) {
+  // Don't fetch other dates if the park doesn't have both Tier 1 and Tier 2 dates
+  if (!(park.hasTier1Dates && park.hasTier2Dates)) {
+    return {
+      parkTier1Dates: [],
+      parkTier2Dates: [],
+    };
+  }
+
+  // Get the Park Season for the operating year
+  const parkSeason = await Season.findOne({
+    where: {
+      publishableId: park.publishableId,
+      operatingYear,
+    },
+
+    include: [
+      {
+        model: DateRange,
+        as: "dateRanges",
+        required: false,
+
+        include: [
+          { model: DateType, as: "dateType", attributes: ["id", "name"] },
+        ],
+      },
+    ],
+  });
+
+  // Group DateRanges by Type and get the Tier 1 and Tier 2 dates, if any
+  const datesByType = _.groupBy(parkSeason.dateRanges, "dateType.name");
+
+  return {
+    parkTier1Dates: datesByType["Tier 1"] ?? [],
+    parkTier2Dates: datesByType["Tier 2"] ?? [],
+  };
+}
+
 // Get all form data and DateRanges for a Feature Season
 router.get(
   "/feature/:seasonId",
@@ -370,6 +414,13 @@ router.get(
 
     const { feature } = seasonModel;
 
+    // Add the park-level Tier 1 and Tier 2 dates to the payload
+    // (for Tier 1 and Tier 2 / Reservation validation rules)
+    const parkTier1And2Dates = getParkTier1And2Dates(
+      feature.park,
+      seasonModel.operatingYear,
+    );
+
     // Return the DateTypes in a specific order
     const orderedDateTypes = getDateTypesForFeature(feature, dateTypesByName);
 
@@ -386,6 +437,8 @@ router.get(
       gateDetail,
     };
 
+    const { parkTier1Dates, parkTier2Dates } = await parkTier1And2Dates;
+
     const output = {
       current: currentSeason,
       previous: previousSeason,
@@ -394,6 +447,8 @@ router.get(
       featureTypeName: seasonModel.feature.featureType.name,
       name: seasonModel.feature.name,
       parkName: seasonModel.feature.park.name,
+      parkTier1Dates,
+      parkTier2Dates,
     };
 
     res.json(output);
@@ -453,6 +508,13 @@ router.get(
 
     const featureDateTypesByName = _.keyBy(featureDateTypesArray, "name");
 
+    // Add the park-level Tier 1 and Tier 2 dates to the payload
+    // (for Tier 1 and Tier 2 / Reservation validation rules)
+    const parkTier1And2Dates = getParkTier1And2Dates(
+      seasonModel.parkArea.park,
+      seasonModel.operatingYear,
+    );
+
     // Return the DateTypes in a specific order for each feature, keyed by ID
     const orderedFeatureDateTypesEntries = seasonModel.parkArea.features.map(
       (feature) => [
@@ -489,6 +551,8 @@ router.get(
       gateDetail,
     };
 
+    const { parkTier1Dates, parkTier2Dates } = await parkTier1And2Dates;
+
     const output = {
       current: currentSeason,
       previous: previousSeason,
@@ -500,6 +564,8 @@ router.get(
       featureTypeName,
       name: seasonModel.parkArea.name,
       parkName: seasonModel.parkArea.park.name,
+      parkTier1Dates,
+      parkTier2Dates,
     };
 
     res.json(output);
@@ -612,13 +678,6 @@ router.get(
       dateRangeAnnuals,
       gateDetail,
     };
-
-    console.log(
-      "\n\n\n\npark",
-      park.hasTier1Dates,
-      park.hasTier2Dates,
-      "\n\n\n\n",
-    );
 
     const output = {
       current: currentSeason,

--- a/frontend/src/components/DateRangeFields.jsx
+++ b/frontend/src/components/DateRangeFields.jsx
@@ -76,16 +76,23 @@ function DateRange({
           />
         </div>
 
-        <button
-          // Disable and hide the remove button if this is the first/only date range
-          className={classNames("btn btn-text text-link align-self-start", {
-            invisible: !removable,
-          })}
-          disabled={!removable}
-          onClick={() => removeDateRange(dateRange)}
-        >
-          <FontAwesomeIcon icon={faXmark} />
-        </button>
+        <div className="align-self-start">
+          <div className="form-label d-lg-none">
+            &nbsp;
+            <span className="visually-hidden">Remove this date range</span>
+          </div>
+
+          <button
+            // Disable and hide the remove button if this is the first/only date range
+            className={classNames("btn btn-text text-link", {
+              invisible: !removable,
+            })}
+            disabled={!removable}
+            onClick={() => removeDateRange(dateRange)}
+          >
+            <FontAwesomeIcon icon={faXmark} />
+          </button>
+        </div>
       </div>
 
       <ErrorSlot element={elements.dateRange(idOrTempId)} />

--- a/frontend/src/components/DateRangeFields.jsx
+++ b/frontend/src/components/DateRangeFields.jsx
@@ -122,6 +122,7 @@ export default function DateRangeFields({
   updateDateRangeAnnual,
   optional = false,
 }) {
+  const { elements } = useValidationContext();
   // Constants
   // Tier 1 only allows 1 date range
   const hasMultipleDates = dateType.name !== "Tier 1";
@@ -199,6 +200,10 @@ export default function DateRangeFields({
           className="mt-2 mb-0"
         />
       )}
+
+      <ErrorSlot
+        element={elements.dateableDateType(dateableId, dateType.name)}
+      />
     </>
   );
 }

--- a/frontend/src/components/SeasonForms/FeatureSeasonForm.jsx
+++ b/frontend/src/components/SeasonForms/FeatureSeasonForm.jsx
@@ -10,10 +10,12 @@ import GateForm from "@/components/GateForm";
 import ReadyToPublishBox from "@/components/ReadyToPublishBox";
 import TooltipWrapper from "@/components/TooltipWrapper";
 import PreviousDates from "@/components/SeasonForms/PreviousDates";
+import ErrorSlot from "@/components/ValidationErrorSlot";
 
 import DataContext from "@/contexts/DataContext";
 import { updateDateRangeAnnualsArray } from "@/lib/utils";
 import isDateTypeOptional from "@/lib/isDateTypeOptional";
+import { useValidationContext } from "@/hooks/useValidation/useValidation";
 
 export default function FeatureSeasonForm({
   season,
@@ -174,6 +176,8 @@ export default function FeatureSeasonForm({
 
   // Individual Feature form section
   function FormSection() {
+    const { elements } = useValidationContext();
+
     return (
       <div className="row">
         {dateTypes.map((dateType) => (
@@ -202,6 +206,8 @@ export default function FeatureSeasonForm({
               updateDateRangeAnnual={updateDateRangeAnnual}
               optional={isDateTypeOptional(dateType.name, "feature")}
             />
+
+            <ErrorSlot element={elements.dateableSection(feature.dateableId)} />
           </div>
         ))}
       </div>

--- a/frontend/src/hooks/useValidation/rules/reservationSameAsTier1And2.js
+++ b/frontend/src/hooks/useValidation/rules/reservationSameAsTier1And2.js
@@ -1,16 +1,17 @@
 import { isEqual } from "date-fns";
+import { groupBy } from "lodash-es";
 
 import consolidateRanges from "@/lib/consolidateDateRanges";
 
 /**
  * Validates that the Feature/Area-level reservation dates match the Park-level Tier 1 and 2 dates.
+ * Each feature's dates must be the same as the Park's combined Tier 1 and Tier 2 dates.
  * @param {Object} seasonData The season form data to validate
  * @param {Object} context Validation context with errors array
  * @returns {void}
  */
 export default function reservationSameAsTier1And2(seasonData, context) {
   const { dateRanges, elements, parkTier1Dates, parkTier2Dates } = context;
-  const { current } = seasonData;
 
   // This rule applies to the Feature and ParkArea level. Skip for Parks
   if (context.level === "park") return;
@@ -19,12 +20,15 @@ export default function reservationSameAsTier1And2(seasonData, context) {
   if (parkTier1Dates.length === 0 && parkTier2Dates.length === 0) return;
 
   // Get a list of the populated Reservation dates on this form
-  const reservationDates = dateRanges.filter(
+  const allReservationDates = dateRanges.filter(
     (dateRange) =>
       dateRange.dateType.name === "Reservation" &&
       dateRange.startDate &&
       dateRange.endDate,
   );
+
+  // Group reservation dates by dateableId
+  const reservationDatesByFeature = groupBy(allReservationDates, "dateableId");
 
   // Consolidate Tier 1 + 2 ranges for comparison
   const consolidatedTierDates = consolidateRanges([
@@ -32,41 +36,35 @@ export default function reservationSameAsTier1And2(seasonData, context) {
     ...parkTier2Dates,
   ]);
 
-  // Consolidate Reservation dates for comparison
-  const consolidatedReservationDates = consolidateRanges(reservationDates);
+  // Compare each dateable Feature's reservation dates to the Park's Tier 1 and 2 dates
+  Object.entries(reservationDatesByFeature).forEach(
+    ([dateableId, reservationDates]) => {
+      // Consolidate Reservation dates for comparison
+      const consolidatedReservationDates = consolidateRanges(reservationDates);
 
-  // Compare consolidated date arrays
-  const sameDates =
-    consolidatedTierDates.length === consolidatedReservationDates.length &&
-    consolidatedTierDates.every((dateRangeA, index) => {
-      const dateRangeB = consolidatedReservationDates[index];
+      // Compare consolidated date arrays
+      const sameDates =
+        consolidatedTierDates.length === consolidatedReservationDates.length &&
+        consolidatedTierDates.every((dateRangeA, index) => {
+          const dateRangeB = consolidatedReservationDates[index];
 
-      // Return true if the date range covers the same dates
-      return (
-        isEqual(dateRangeA.startDate, dateRangeB.startDate) &&
-        isEqual(dateRangeA.endDate, dateRangeB.endDate)
-      );
-    });
+          // Return true if the date range covers the same dates
+          return (
+            isEqual(dateRangeA.startDate, dateRangeB.startDate) &&
+            isEqual(dateRangeA.endDate, dateRangeB.endDate)
+          );
+        });
 
-  if (!sameDates) {
-    const errorText =
-      "The reservation dates must include all tier 1 and tier 2 dates. (To change tier 1 and tier 2 dates, edit the park)";
+      if (!sameDates) {
+        const errorText =
+          "The reservation dates must include all tier 1 and tier 2 dates. (To change tier 1 and tier 2 dates, edit the park)";
 
-    // Show the error below the Reservation dates section
-    if (context.level === "feature") {
-      // For an individual feature, show the error below its Reservation dates section
-      context.addError(
-        elements.dateableDateType(current.feature.dateableId, "Reservation"),
-        errorText,
-      );
-    } else {
-      // For a ParkArea, show the error below every Feature's Reservation dates section
-      current.parkArea.features.forEach((feature) => {
+        // Show the error below the Reservation dates section
         context.addError(
-          elements.dateableDateType(feature.dateableId, "Reservation"),
+          elements.dateableDateType(dateableId, "Reservation"),
           errorText,
         );
-      });
-    }
-  }
+      }
+    },
+  );
 }

--- a/frontend/src/hooks/useValidation/rules/reservationSameAsTier1And2.js
+++ b/frontend/src/hooks/useValidation/rules/reservationSameAsTier1And2.js
@@ -1,0 +1,72 @@
+import { isEqual } from "date-fns";
+
+import consolidateRanges from "@/lib/consolidateDateRanges";
+
+/**
+ * Validates that the Feature/Area-level reservation dates match the Park-level Tier 1 and 2 dates.
+ * @param {Object} seasonData The season form data to validate
+ * @param {Object} context Validation context with errors array
+ * @returns {void}
+ */
+export default function reservationSameAsTier1And2(seasonData, context) {
+  const { dateRanges, elements, parkTier1Dates, parkTier2Dates } = context;
+  const { current } = seasonData;
+
+  // This rule applies to the Feature and ParkArea level. Skip for Parks
+  if (context.level === "park") return;
+
+  // Skip if the Park doesn't have Tier 1 & Tier 2 dates
+  if (parkTier1Dates.length === 0 && parkTier2Dates.length === 0) return;
+
+  // Get a list of the populated Reservation dates on this form
+  const reservationDates = dateRanges.filter(
+    (dateRange) =>
+      dateRange.dateType.name === "Reservation" &&
+      dateRange.startDate &&
+      dateRange.endDate,
+  );
+
+  // Consolidate Tier 1 + 2 ranges for comparison
+  const consolidatedTierDates = consolidateRanges([
+    ...parkTier1Dates,
+    ...parkTier2Dates,
+  ]);
+
+  // Consolidate Reservation dates for comparison
+  const consolidatedReservationDates = consolidateRanges(reservationDates);
+
+  // Compare consolidated date arrays
+  const sameDates =
+    consolidatedTierDates.length === consolidatedReservationDates.length &&
+    consolidatedTierDates.every((dateRangeA, index) => {
+      const dateRangeB = consolidatedReservationDates[index];
+
+      // Return true if the date range covers the same dates
+      return (
+        isEqual(dateRangeA.startDate, dateRangeB.startDate) &&
+        isEqual(dateRangeA.endDate, dateRangeB.endDate)
+      );
+    });
+
+  if (!sameDates) {
+    const errorText =
+      "The reservation dates must include all reservation dates. (To change tier 1 and tier 2 dates, edit the park)";
+
+    // Show the error below the Reservation dates section
+    if (context.level === "feature") {
+      // For an individual feature, show the error below its Reservation dates section
+      context.addError(
+        elements.dateableDateType(current.feature.dateableId, "Reservation"),
+        errorText,
+      );
+    } else {
+      // For a ParkArea, show the error below every Feature's Reservation dates section
+      current.parkArea.features.forEach((feature) => {
+        context.addError(
+          elements.dateableDateType(feature.dateableId, "Reservation"),
+          errorText,
+        );
+      });
+    }
+  }
+}

--- a/frontend/src/hooks/useValidation/rules/reservationSameAsTier1And2.js
+++ b/frontend/src/hooks/useValidation/rules/reservationSameAsTier1And2.js
@@ -50,7 +50,7 @@ export default function reservationSameAsTier1And2(seasonData, context) {
 
   if (!sameDates) {
     const errorText =
-      "The reservation dates must include all reservation dates. (To change tier 1 and tier 2 dates, edit the park)";
+      "The reservation dates must include all tier 1 and tier 2 dates. (To change tier 1 and tier 2 dates, edit the park)";
 
     // Show the error below the Reservation dates section
     if (context.level === "feature") {

--- a/frontend/src/hooks/useValidation/rules/tier1and2NoOverlap.js
+++ b/frontend/src/hooks/useValidation/rules/tier1and2NoOverlap.js
@@ -1,0 +1,69 @@
+import { areIntervalsOverlapping } from "date-fns";
+
+import consolidateRanges from "@/lib/consolidateDateRanges";
+
+/**
+ * Validates that Tier 1 dates do not overlap with Tier 2 dates.
+ * @param {Object} seasonData The season form data to validate
+ * @param {Object} context Validation context with errors array
+ * @returns {void}
+ */
+export default function tier1and2NoOverlap(seasonData, context) {
+  const { dateRanges, elements } = context;
+  const { current } = seasonData;
+
+  // This rule applies to the Park level. Skip for other levels
+  if (context.level !== "park") return;
+
+  // Skip if the Park doesn't have Tier 1 & Tier 2 dates
+  if (!(current.park.hasTier1Dates && current.park.hasTier2Dates)) return;
+
+  // Skip if Tier 1 and Reservation dates are not provided
+  const tier1Dates = dateRanges.filter(
+    (dateRange) =>
+      dateRange.dateType.name === "Tier 1" &&
+      dateRange.startDate &&
+      dateRange.endDate,
+  );
+  const tier2Dates = dateRanges.filter(
+    (dateRange) => dateRange.dateType.name === "Tier 2",
+  );
+
+  // Skip if Tier 1 and 2 dates aren't entered yet
+  if (tier1Dates.length === 0 || tier2Dates.length === 0) return;
+
+  // Consolidate the Tier 2 dates for comparison. Tier 1 dates will only have one date range.
+  const consolidatedTier2Dates = consolidateRanges(tier2Dates);
+  const consolidatedTier1Dates = tier1Dates[0];
+
+  // Check if the single Tier 1 date range overlaps with any of the consolidated Tier 2 date ranges
+  const hasOverlaps = consolidatedTier2Dates.some((tier2DateRange) =>
+    areIntervalsOverlapping(
+      {
+        start: consolidatedTier1Dates.startDate,
+        end: consolidatedTier1Dates.endDate,
+      },
+      {
+        start: tier2DateRange.startDate,
+        end: tier2DateRange.endDate,
+      },
+      // Include cases where the end of one range is the start of the other
+      { inclusive: true },
+    ),
+  );
+
+  if (hasOverlaps) {
+    const errorText = "The tier 1 and tier 2 dates must not overlap.";
+
+    // Show the error below the Tier 1 and Tier 2 date range sections
+    context.addError(
+      elements.dateableDateType(current.park.dateableId, "Tier 1"),
+      errorText,
+    );
+
+    context.addError(
+      elements.dateableDateType(current.park.dateableId, "Tier 2"),
+      errorText,
+    );
+  }
+}

--- a/frontend/src/hooks/useValidation/rules/tier1and2NoOverlap.js
+++ b/frontend/src/hooks/useValidation/rules/tier1and2NoOverlap.js
@@ -18,7 +18,7 @@ export default function tier1And2NoOverlap(seasonData, context) {
   // Skip if the Park doesn't have Tier 1 & Tier 2 dates
   if (!(current.park.hasTier1Dates && current.park.hasTier2Dates)) return;
 
-  // Skip if Tier 1 and Reservation dates are not provided
+  // Get separate lists of Tier 1 and 2 dates
   const tier1Dates = dateRanges.filter(
     (dateRange) =>
       dateRange.dateType.name === "Tier 1" &&

--- a/frontend/src/hooks/useValidation/rules/tier1and2NoOverlap.js
+++ b/frontend/src/hooks/useValidation/rules/tier1and2NoOverlap.js
@@ -8,7 +8,7 @@ import consolidateRanges from "@/lib/consolidateDateRanges";
  * @param {Object} context Validation context with errors array
  * @returns {void}
  */
-export default function tier1and2NoOverlap(seasonData, context) {
+export default function tier1And2NoOverlap(seasonData, context) {
   const { dateRanges, elements } = context;
   const { current } = seasonData;
 

--- a/frontend/src/hooks/useValidation/rules/tier1and2SameAsReservation.js
+++ b/frontend/src/hooks/useValidation/rules/tier1and2SameAsReservation.js
@@ -1,0 +1,73 @@
+import { isEqual } from "date-fns";
+
+import consolidateRanges from "@/lib/consolidateDateRanges";
+
+/**
+ * Validates that the Park-level Tier 1 and 2 dates match the reservation dates.
+ * @param {Object} seasonData The season form data to validate
+ * @param {Object} context Validation context with errors array
+ * @returns {void}
+ */
+export default function tier1and2SameAsReservation(seasonData, context) {
+  const { dateRanges, elements, featureReservationDates } = context;
+  const { current } = seasonData;
+
+  // This rule applies to the Park level. Skip for other levels
+  if (context.level !== "park") return;
+
+  // Skip if the Park doesn't have Tier 1 & Tier 2 dates
+  if (!(current.park.hasTier1Dates && current.park.hasTier2Dates)) return;
+
+  // Skip if Tier 1 and Reservation dates are not provided
+  const tier1Dates = dateRanges.filter(
+    (dateRange) =>
+      dateRange.dateType.name === "Tier 1" &&
+      dateRange.startDate &&
+      dateRange.endDate,
+  );
+  const tier2Dates = dateRanges.filter(
+    (dateRange) => dateRange.dateType.name === "Tier 2",
+  );
+
+  if (featureReservationDates.length === 0 || tier1Dates.length === 0) return;
+
+  // Consolidate Tier 1 + 2 ranges for comparison
+  const consolidatedTierDates = consolidateRanges([
+    ...tier1Dates,
+    ...tier2Dates,
+  ]);
+
+  // Consolidate Reservation dates for comparison
+  const consolidatedReservationDates = consolidateRanges(
+    featureReservationDates,
+  );
+
+  // Compare consolidated date arrays
+  const sameDates =
+    consolidatedTierDates.length === consolidatedReservationDates.length &&
+    consolidatedTierDates.every((dateRangeA, index) => {
+      const dateRangeB = consolidatedReservationDates[index];
+
+      // Return true if the date range covers the same dates
+      return (
+        isEqual(dateRangeA.startDate, dateRangeB.startDate) &&
+        isEqual(dateRangeA.endDate, dateRangeB.endDate)
+      );
+    });
+
+  if (!sameDates) {
+    const errorText =
+      "The tier 1 and tier 2 dates must include all reservation dates. (To change reservation dates, edit the park’s reservable features)";
+
+    // Show the error below the Tier 1 and Tier 2 date range sections
+    context.addError(
+      elements.dateableDateType(current.park.dateableId, "Tier 1"),
+      errorText,
+    );
+
+    context.addError(
+      elements.dateableDateType(current.park.dateableId, "Tier 2"),
+      errorText,
+    );
+  }
+}

--- a/frontend/src/hooks/useValidation/rules/tier1and2SameAsReservation.js
+++ b/frontend/src/hooks/useValidation/rules/tier1and2SameAsReservation.js
@@ -8,7 +8,7 @@ import consolidateRanges from "@/lib/consolidateDateRanges";
  * @param {Object} context Validation context with errors array
  * @returns {void}
  */
-export default function tier1and2SameAsReservation(seasonData, context) {
+export default function tier1And2SameAsReservation(seasonData, context) {
   const { dateRanges, elements, featureReservationDates } = context;
   const { current } = seasonData;
 

--- a/frontend/src/hooks/useValidation/useValidation.js
+++ b/frontend/src/hooks/useValidation/useValidation.js
@@ -11,6 +11,7 @@ import reservationWithinOperating from "./rules/reservationWithinOperating.js";
 import reservationEndsBeforeOperatingEnds from "./rules/reservationEndsBeforeOperatingEnds.js";
 import completeDateRanges from "./rules/completeDateRanges.js";
 import tier1and2SameAsReservation from "./rules/tier1and2SameAsReservation.js";
+import tier1and2NoOverlap from "./rules/tier1and2NoOverlap.js";
 
 // Constants for named "validation error slots" in the UI
 const elements = {
@@ -104,6 +105,7 @@ function validate(seasonData, seasonContext) {
   reservationWithinOperating(seasonData, validationContext);
   reservationEndsBeforeOperatingEnds(seasonData, validationContext);
   tier1and2SameAsReservation(seasonData, validationContext);
+  tier1and2NoOverlap(seasonData, validationContext);
 
   return errors;
 }

--- a/frontend/src/hooks/useValidation/useValidation.js
+++ b/frontend/src/hooks/useValidation/useValidation.js
@@ -12,6 +12,7 @@ import reservationEndsBeforeOperatingEnds from "./rules/reservationEndsBeforeOpe
 import completeDateRanges from "./rules/completeDateRanges.js";
 import tier1And2SameAsReservation from "./rules/tier1And2SameAsReservation.js";
 import tier1And2NoOverlap from "./rules/tier1And2NoOverlap.js";
+import reservationSameAsTier1And2 from "./rules/reservationSameAsTier1And2.js";
 
 // Constants for named "validation error slots" in the UI
 const elements = {
@@ -71,6 +72,10 @@ function validate(seasonData, seasonContext) {
   validationContext.featureReservationDates =
     seasonData.featureReservationDates ?? [];
 
+  // Provide flat arrays of Tier 1 and 2 dates in the context, for Feature/Area Reservation validation
+  validationContext.parkTier1Dates = seasonData.parkTier1Dates ?? [];
+  validationContext.parkTier2Dates = seasonData.parkTier2Dates ?? [];
+
   // Flatten the date ranges for looping in validation
   const dateRanges = [];
 
@@ -106,6 +111,7 @@ function validate(seasonData, seasonContext) {
   reservationEndsBeforeOperatingEnds(seasonData, validationContext);
   tier1And2SameAsReservation(seasonData, validationContext);
   tier1And2NoOverlap(seasonData, validationContext);
+  reservationSameAsTier1And2(seasonData, validationContext);
 
   return errors;
 }

--- a/frontend/src/hooks/useValidation/useValidation.js
+++ b/frontend/src/hooks/useValidation/useValidation.js
@@ -10,6 +10,7 @@ import changeNoteRequired from "./rules/changeNoteRequired.js";
 import reservationWithinOperating from "./rules/reservationWithinOperating.js";
 import reservationEndsBeforeOperatingEnds from "./rules/reservationEndsBeforeOperatingEnds.js";
 import completeDateRanges from "./rules/completeDateRanges.js";
+import tier1and2SameAsReservation from "./rules/tier1and2SameAsReservation.js";
 
 // Constants for named "validation error slots" in the UI
 const elements = {
@@ -27,6 +28,10 @@ const elements = {
 
   // Under an individual date input field by its dateRange ID and its field name
   dateField: (idOrTempId, fieldName) => `dateField-${idOrTempId}-${fieldName}`,
+
+  // Under all the date ranges for a dateable feature, by date type
+  dateableDateType: (dateableId, dateTypeName) =>
+    `dateableDateType-${dateableId}-${dateTypeName}`,
 
   // Under a form section for a dateable entity, such as a Feature, by its dateableId
   dateableSection: (dateableId) => `formSection-${dateableId}`,
@@ -98,6 +103,7 @@ function validate(seasonData, seasonContext) {
   changeNoteRequired(seasonData, validationContext);
   reservationWithinOperating(seasonData, validationContext);
   reservationEndsBeforeOperatingEnds(seasonData, validationContext);
+  tier1and2SameAsReservation(seasonData, validationContext);
 
   return errors;
 }

--- a/frontend/src/hooks/useValidation/useValidation.js
+++ b/frontend/src/hooks/useValidation/useValidation.js
@@ -61,6 +61,10 @@ function validate(seasonData, seasonContext) {
     errors.push({ element, message });
   };
 
+  // Provide the flat array of Feature Reservation dates in the context, for Park-level validation
+  validationContext.featureReservationDates =
+    seasonData.featureReservationDates ?? [];
+
   // Flatten the date ranges for looping in validation
   const dateRanges = [];
 

--- a/frontend/src/hooks/useValidation/useValidation.js
+++ b/frontend/src/hooks/useValidation/useValidation.js
@@ -10,8 +10,8 @@ import changeNoteRequired from "./rules/changeNoteRequired.js";
 import reservationWithinOperating from "./rules/reservationWithinOperating.js";
 import reservationEndsBeforeOperatingEnds from "./rules/reservationEndsBeforeOperatingEnds.js";
 import completeDateRanges from "./rules/completeDateRanges.js";
-import tier1and2SameAsReservation from "./rules/tier1and2SameAsReservation.js";
-import tier1and2NoOverlap from "./rules/tier1and2NoOverlap.js";
+import tier1And2SameAsReservation from "./rules/tier1And2SameAsReservation.js";
+import tier1And2NoOverlap from "./rules/tier1And2NoOverlap.js";
 
 // Constants for named "validation error slots" in the UI
 const elements = {
@@ -104,8 +104,8 @@ function validate(seasonData, seasonContext) {
   changeNoteRequired(seasonData, validationContext);
   reservationWithinOperating(seasonData, validationContext);
   reservationEndsBeforeOperatingEnds(seasonData, validationContext);
-  tier1and2SameAsReservation(seasonData, validationContext);
-  tier1and2NoOverlap(seasonData, validationContext);
+  tier1And2SameAsReservation(seasonData, validationContext);
+  tier1And2NoOverlap(seasonData, validationContext);
 
   return errors;
 }

--- a/frontend/src/lib/consolidateDateRanges.js
+++ b/frontend/src/lib/consolidateDateRanges.js
@@ -1,12 +1,13 @@
-import { isAfter, max } from "date-fns";
+import { addDays, isAfter, max } from "date-fns";
 import { cloneDeep, orderBy } from "lodash-es";
 
 /**
  * Returns a chronological list of date ranges with overlapping ranges combined
  * @param {Array} ranges An array of objects with startDate and endDate properties
+ * @param {boolean} [combineAdjacent=true] Whether to combine adjacent date ranges
  * @returns {Array} An array of consolidated date ranges
  */
-export default function consolidateRanges(ranges) {
+export default function consolidateRanges(ranges, combineAdjacent = true) {
   // Filter out any missing values
   const filteredRanges = ranges.filter(
     (range) => range.startDate && range.endDate,
@@ -19,9 +20,21 @@ export default function consolidateRanges(ranges) {
   const consolidated = sorted.reduce((merged, current) => {
     const lastRange = merged.at(-1);
 
+    // If this is the first range, just add it
+    if (!lastRange) {
+      merged.push(current);
+      return merged;
+    }
+
+    // Determine the end date to use for comparison
+    // Include the day after the last end date to combine adjacent dates
+    const lastEnd = combineAdjacent
+      ? addDays(lastRange.endDate, 1) // Jan 1-2 combines with Jan 3-4 into Jan 1-4
+      : lastRange.endDate; // Jan 1-2 is separate from Jan 3-4
+
     // If the start date of the current range is before (or the same as)
     // the end date of the last range, combine the ranges
-    if (lastRange && !isAfter(current.startDate, lastRange.endDate)) {
+    if (!isAfter(current.startDate, lastEnd)) {
       lastRange.endDate = max([lastRange.endDate, current.endDate]);
     } else {
       merged.push(current);


### PR DESCRIPTION
### Jira Ticket

CMS-1078

### Description
<!-- What did you change, and why? -->

Added 3 more validation rule functions. These ones check if the Reservation dates in a Feature/Area form are exactly equal to the combined Tier 1 and 2 dates for the Park, and vice-versa.

I had to add some metadata to the Park and Area API payloads to include the Park Tier1/2 dates, and include the feature reservation dates in the Park payload.

I still need to confirm some of the logic with Amanda but everything else is ready to review as-is. If I have to change anything, I'll explain it in a comment.

- [x] Confirm reservation dates logic w/ Amanda before merging