### PR TITLE
CMS-1180: Show validation errors under Operation/Reservation sections

### DIFF
--- a/frontend/src/hooks/useValidation/rules/reservationEndsBeforeOperatingEnds.js
+++ b/frontend/src/hooks/useValidation/rules/reservationEndsBeforeOperatingEnds.js
@@ -89,10 +89,18 @@ export default function reservationEndsBeforeOperatingEnds(
 
       // Add an error if the difference between operating and reservation end dates is 1+ days
       if (daysDifference < 1) {
+        const errorText =
+          "The reservation end date must be one or more days before the operating end date.";
+
+        // Show the error below the Operation and Reservation date range sections
         context.addError(
-          // Show the error below the Dateable's form section
-          elements.dateableSection(dateableId),
-          "The reservation end date must be one or more days before the operating end date.",
+          elements.dateableDateType(dateableId, "Operation"),
+          errorText,
+        );
+
+        context.addError(
+          elements.dateableDateType(dateableId, "Reservation"),
+          errorText,
         );
       }
     },

--- a/frontend/src/hooks/useValidation/rules/reservationWithinOperating.js
+++ b/frontend/src/hooks/useValidation/rules/reservationWithinOperating.js
@@ -46,10 +46,18 @@ export default function reservationWithinOperating(seasonData, context) {
       );
 
       if (!allWithin) {
+        const errorText =
+          "Enter the reservation dates that fall within the operating dates selected.";
+
+        // Show the error below the Operation and Reservation date range sections
         context.addError(
-          // Show the error below the Dateable's form section
-          elements.dateableSection(dateableId),
-          "Enter the reservation dates that fall within the operating dates selected.",
+          elements.dateableDateType(dateableId, "Operation"),
+          errorText,
+        );
+
+        context.addError(
+          elements.dateableDateType(dateableId, "Reservation"),
+          errorText,
         );
       }
 
@@ -58,10 +66,18 @@ export default function reservationWithinOperating(seasonData, context) {
       const reservationStartDate = reservationRanges.at(0).startDate;
 
       if (isBefore(reservationStartDate, operatingStartDate)) {
+        const errorText =
+          "The reservation start date must be on or after the operating start date.";
+
+        // Show the error below the Operation and Reservation date range sections
         context.addError(
-          // Show the error below the Dateable's form section
-          elements.dateableSection(dateableId),
-          "The reservation start date must be on or after the operating start date.",
+          elements.dateableDateType(dateableId, "Operation"),
+          errorText,
+        );
+
+        context.addError(
+          elements.dateableDateType(dateableId, "Reservation"),
+          errorText,
         );
       }
     },


### PR DESCRIPTION
### Jira Ticket

CMS-1180

### Description
<!-- What did you change, and why? -->

A minor update to the validation functions - for the "Operation + Reservation" rules, instead of showing the message at the bottom of the form, we're now showing it under both the Operation dates section and the Reservation dates section. 

See before and after screenshots in the ticket, CMS-1180

The Tier 1 + Tier 2 validation rules already do this, so this ticket just updates the Operation + Reservation rules to use the same pattern. Now nothing is using the "dateableSection" validation message slot, but I'm leaving it in for now, in case we need it for other rules.