### PR TITLE
CMS-1079: Fetch feature reservation dates when there are winter fees

### DIFF
--- a/backend/routes/api/seasons.js
+++ b/backend/routes/api/seasons.js
@@ -264,8 +264,11 @@ const SEASON_ATTRIBUTES = [
  * @returns {Promise<Array>} - Array of reservation feature dates
  */
 async function getFeatureReservationDates(park, operatingYear) {
-  // Don't fetch other dates if the park doesn't have both Tier 1 and Tier 2 dates
-  if (!(park.hasTier1Dates && park.hasTier2Dates)) return [];
+  // Don't fetch other dates if the park doesn't have Winter fee dates,
+  // or both Tier 1 and Tier 2 dates.
+  // This data is only needed for Winter/Tier date validation.
+  if (!(park.hasWinterFeeDates || (park.hasTier1Dates && park.hasTier2Dates)))
+    return [];
 
   // Get the ID of the applicable Reservation date type
   const reservationDateType = await DateType.findOne({


### PR DESCRIPTION
### Jira Ticket

CMS-1079

### Description
<!-- What did you change, and why? -->

A bugfix for an issue found by QA: If a park has winter fees but no Tier 1/2 dates (such as Bamberton Park on the alpha-test environment), the `getFeatureReservationDates` would skip the query and not get the required data for the validation rules.

This branch updates he check to still run the query if `park.hasWinterFeeDates` is true