### PR TITLE
CMS-1149: Move "saved" flash message to promptAndSave

### DIFF
--- a/frontend/src/components/FormPanel.jsx
+++ b/frontend/src/components/FormPanel.jsx
@@ -307,8 +307,8 @@ function SeasonForm({
    * @param {boolean} allowInvalid allows saving even if the form has validation errors
    * @returns {Promise<void>}
    */
-  async function onSave(close = true, allowInvalid = false) {
-    // onSave is called on any kind of form submission, so validation happens here
+  async function saveForm(close = true, allowInvalid = false) {
+    // saveForm is called on any kind of form submission, so validation happens here
     // If the form is submitted by some other means, call the validation function there too
     setSubmitted(true);
 
@@ -363,11 +363,6 @@ function SeasonForm({
     setNotes("");
     setDeletedDateRangeIds([]);
 
-    flashMessage.open(
-      "Dates saved as draft",
-      `${seasonTitle} ${season.operatingYear} details saved`,
-    );
-
     if (close) {
       closePanel();
     } else {
@@ -395,13 +390,18 @@ If dates have already been published, they will not be updated until new dates a
     }
 
     // Save draft, and allow saving with validation errors
-    onSave(close, true);
+    await saveForm(close, true);
+
+    flashMessage.open(
+      "Dates saved as draft",
+      `${seasonTitle} ${season.operatingYear} details saved`,
+    );
   }
 
   async function onApprove() {
     try {
       // Save first, then approve
-      await onSave(false); // Don't close the form after saving
+      await saveForm(false); // Don't close the form after saving
 
       await sendApprove();
 
@@ -422,7 +422,7 @@ If dates have already been published, they will not be updated until new dates a
   async function onSubmit() {
     try {
       // Save first, then submit
-      await onSave(false); // Don't close the form after saving
+      await saveForm(false); // Don't close the form after saving
 
       await sendSubmit();
 

--- a/frontend/src/hooks/useValidation/useValidation.js
+++ b/frontend/src/hooks/useValidation/useValidation.js
@@ -149,7 +149,7 @@ export default function useValidation(seasonData, context) {
 
   /**
    * Validates the form data and returns any validation errors.
-   * This is used in the onSave function to ensure the form is valid before saving.
+   * This is used in the saveForm function to ensure the form is valid before saving.
    * @param {boolean} [submitted=true] Whether the form has been submitted.
    * @returns {Array} Array of validation error objects
    */


### PR DESCRIPTION
rename onSave for clarity

### Jira Ticket

CMS-1149

### Description
<!-- What did you change, and why? -->

The onSave function was showing the "saved" confirmation flash message every time it got called. This was a problem because the onSubmit and onApprove functions call onSave. 
Approve would open the "saved" flash message and then quickly replace it with the "approved" flash message, so the user wouldn't notice. However, "Submit to HQ" doesn't have its own confirmation flash message yet, so the "saved" message would remain.

This branch changes two things:
1. Move the "saved" flash message into the "prompAndSave" wrapper function, so only "Save draft" clicks will show the flash message.
2. Rename onSave to saveForm. It doesn't get called from clicking any buttons, it only gets called from other functions, so it was slightly confusing to have a name with `on__`. 

### Other thoughts 😆

I also want to move the "close panel" code out of the saveForm function, but we have more tickets coming up that will involve moving things around in there, so we can update that later. (It would be good if saveForm just saved the form and the wrapper functions did other stuff, rather than having to pass "close=false" most of the time.

It would also be nice to split out the "save" stuff in the backend, so we don't have to make two network requests in a row on the frontend anyway!