### PR TITLE
CMS-1079: Trigger winterDateYears when either date field is filled

### DIFF
--- a/frontend/src/hooks/useValidation/rules/winterDateYears.js
+++ b/frontend/src/hooks/useValidation/rules/winterDateYears.js
@@ -21,8 +21,8 @@ export default function winterDateYears(seasonData, context) {
   const winterDates = dateRanges.filter(
     (dateRange) =>
       dateRange.dateType.name === "Winter fee" &&
-      dateRange.startDate &&
-      dateRange.endDate,
+      // Check if either start or end date is present
+      (dateRange.startDate || dateRange.endDate),
   );
 
   // Get the operating year from the current season data
@@ -34,13 +34,12 @@ export default function winterDateYears(seasonData, context) {
     const endDate = normalizeToLocalDate(winterDateRange.endDate);
     const idOrTempId = winterDateRange.id || winterDateRange.tempId;
 
-    // Start date must be October-December of the season operating year
+    if (startDate && !isWithinInterval(startDate, validStartDates)) {
     const validStartDates = {
       start: new Date(operatingYear, 9, 1), // October 1 of operating year
       end: new Date(operatingYear, 11, 31), // December 31 of operating year
     };
 
-    if (!isWithinInterval(startDate, validStartDates)) {
       context.addError(
         // Show the error below the empty end date field
         elements.dateField(idOrTempId, "startDate"),
@@ -48,10 +47,9 @@ export default function winterDateYears(seasonData, context) {
       );
     }
 
-    // End date must be before April of the next year
+    if (endDate && !isBefore(endDate, april1)) {
     const april1 = new Date(operatingYear + 1, 3, 1);
 
-    if (!isBefore(endDate, april1)) {
       context.addError(
         // Show the error below the empty end date field
         elements.dateField(idOrTempId, "endDate"),

--- a/frontend/src/hooks/useValidation/rules/winterDateYears.js
+++ b/frontend/src/hooks/useValidation/rules/winterDateYears.js
@@ -28,6 +28,15 @@ export default function winterDateYears(seasonData, context) {
   // Get the operating year from the current season data
   const operatingYear = current.operatingYear;
 
+  // Start date must be October-December of the season operating year
+  const validStartDates = {
+    start: new Date(operatingYear, 9, 1), // October 1 of operating year
+    end: new Date(operatingYear, 11, 31), // December 31 of operating year
+  };
+
+  // End date must be before April of the next year
+  const april1 = new Date(operatingYear + 1, 3, 1);
+
   // Check each winter date
   winterDates.forEach((winterDateRange) => {
     const startDate = normalizeToLocalDate(winterDateRange.startDate);
@@ -35,11 +44,6 @@ export default function winterDateYears(seasonData, context) {
     const idOrTempId = winterDateRange.id || winterDateRange.tempId;
 
     if (startDate && !isWithinInterval(startDate, validStartDates)) {
-    const validStartDates = {
-      start: new Date(operatingYear, 9, 1), // October 1 of operating year
-      end: new Date(operatingYear, 11, 31), // December 31 of operating year
-    };
-
       context.addError(
         // Show the error below the empty end date field
         elements.dateField(idOrTempId, "startDate"),
@@ -48,8 +52,6 @@ export default function winterDateYears(seasonData, context) {
     }
 
     if (endDate && !isBefore(endDate, april1)) {
-    const april1 = new Date(operatingYear + 1, 3, 1);
-
       context.addError(
         // Show the error below the empty end date field
         elements.dateField(idOrTempId, "endDate"),


### PR DESCRIPTION
### Jira Ticket

CMS-1079

### Description
<!-- What did you change, and why? -->

A small fix for the trigger of the "winter date years" validation rules. 
Previously, it wouldn't check unless both start and end date fields were filled in. As per the requirements, this updates it to check when at least one field is filled in.

I also moved two variable definitions out of the loop so they don't have to get defined over and over again.