### PR TITLE
CMS-1215: Set hasTier1Dates for Golden Ears Park

### DIFF
--- a/backend/tasks/populate-park-tier-types/2025-tier-data.json
+++ b/backend/tasks/populate-park-tier-types/2025-tier-data.json
@@ -74,6 +74,14 @@
   {
     "parkName": "Golden Ears Park",
     "orcs": "8",
+    "note": "T1 added by request in CMS-1215 for consistency / validation logic",
+    "tierType": "t1",
+    "startDate": "2025-01-01",
+    "endDate": "2026-01-01"
+  },
+  {
+    "parkName": "Golden Ears Park",
+    "orcs": "8",
     "note": "T2 in effect **Note: Golden Ears will remain in Tier 2 until further notice due to internet connectivity issues.",
     "tierType": "t2",
     "startDate": "2025-01-01",

--- a/backend/tasks/populate-park-tier-types/populate-park-tier-types.js
+++ b/backend/tasks/populate-park-tier-types/populate-park-tier-types.js
@@ -19,6 +19,12 @@ export async function populateParkTierTypes() {
         throw new Error(`Park with orcs ${orcs} not found.`);
       }
 
+      // Skip updating if the field is already set
+      if (park[columnName] === true) {
+        console.log(`Park ${orcs} already has ${tierType} dates.`);
+        return null;
+      }
+
       // Update the park with the appropriate tier type
       const updateQuery = await park.update({
         [columnName]: true,
@@ -37,9 +43,15 @@ export async function populateParkTierTypes() {
   await Promise.all(updateQueries);
 }
 
-// run directly
+// Run directly
 if (process.argv[1] === new URL(import.meta.url).pathname) {
-  populateParkTierTypes().then(() => {
+  try {
+    await populateParkTierTypes();
     console.log("Done");
-  });
+  } catch (error) {
+    console.error("Error:", error);
+  } finally {
+    // Close the database connection
+    await Park.sequelize.close();
+  }
 }


### PR DESCRIPTION
### Jira Ticket

CMS-1215

### Description
<!-- What did you change, and why? -->

This branch has two small commits, since it was a very quick fix and I had time:

1. Updated the "2025 park tier data" to add Tier 1 dates for Golden Ears. It was the only park that had Tier 2 without Tier 1, and we've been asked to request Tier 1 dates for consistency. This will make the Tier 1+2/Reservation date validation work for Golden Ears as well. 
Run `node tasks/populate-park-tier-types/populate-park-tier-types.js` and `node tasks/create-seasons.js 2026` to test it. I'll update the post-deploy tasks list, but this will be handled by the re-sync-all script anyway 👍 
2. An optional second commit to slightly optimize the script: Skip the update query if the column value didn't change, and close the DB connection at the end if the script is called directly. This prevents it from hanging for a few seconds when it finishes. If it looks good, we could probably do this pattern on every script that can be called directly. Nice to have, but not urgent.
It's still not very efficient and it could be optimized more, but I think it's fine for a small temporary script that updates 30 things until we can get that data from Strapi 😅 