### PR TITLE
CMS-1194: Filter nextYearFeatures for in inReservationSystem

### DIFF
--- a/backend/tasks/create-seasons.js
+++ b/backend/tasks/create-seasons.js
@@ -392,8 +392,10 @@ seasonsAdded = 0;
 
 // Find all features that need to request dates for next year
 const nextYearFeatures = await Feature.findAll({
+  // Only active features in the BC Parks reservation system
   where: {
     active: true,
+    inReservationSystem: true,
   },
 
   include: {


### PR DESCRIPTION
### Jira Ticket

CMS-1194

### Description
<!-- What did you change, and why? -->

An extra filter for the features that get seasons requested for "the next year" (ie 2027) - it should only be for features in the BCP reservation system.

This is a 2.0.1 ticket, so I'll move it down in the git history so it can come right after the current v2.0.1-uat.1 tag. It shouldn't cause any conflicts because it just changes the one line in one backend file, but I'll give everyone a heads up before I do that 😛 