### PR TITLE
CMS-1239: Include incomplete date ranges in CSV

### DIFF
--- a/backend/routes/api/export.js
+++ b/backend/routes/api/export.js
@@ -316,8 +316,6 @@ router.get(
     const dateRangeAnnuals = await getDateRangeAnnualsMap();
 
     const rows = dateRanges
-      // Filter out incomplete date ranges
-      .filter((dateRange) => dateRange.startDate && dateRange.endDate)
       // Format into a flat array for CSV output
       .map((dateRange) => {
         const { season } = dateRange;


### PR DESCRIPTION
### Jira Ticket

CMS-1239

### Description
<!-- What did you change, and why? -->

A new requirement has emerged for the CSV export feature: now we will include all date ranges in the document, even those with no start or end date.

Testing it on my local db, the CSV has 1180 rows, which exactly matches the number of dateRange records for that year.

```sql
-- to get the number of dateRanges for 2026 in psql, for example
select count(*) from "DateRanges" where "seasonId" IN (SELECT id from "Seasons" where "operatingYear" = 2026);

-- On my local environment, with a freshly-reset DB from the production CMS, the query returns this:
 count 
-------
  1180
```

Then export a 2026 CSV from the same environment and note the number of rows (including the header row at the top)