### PR TITLE
CMS-1240: Display first feature type as park area type

### DIFF
--- a/backend/routes/api/export.js
+++ b/backend/routes/api/export.js
@@ -316,8 +316,6 @@ router.get(
     const dateRangeAnnuals = await getDateRangeAnnualsMap();
 
     const rows = dateRanges
-      // Filter out incomplete date ranges
-      .filter((dateRange) => dateRange.startDate && dateRange.endDate)
       // Format into a flat array for CSV output
       .map((dateRange) => {
         const { season } = dateRange;


### PR DESCRIPTION
### Jira Ticket

CMS-1240

### Description
<!-- What did you change, and why? -->

A new requirement has emerged for the CSV export feature: We need to display a feature type for Park Area dates. Park Areas don't have a feature type, but we'll do what we're doing elsewhere, which is to just use the feature type of the first feature in the area.

Now, the CSV will have a value in the "Feature type" column for all dates, except Park-level dates.
It would also be blank if there was a ParkArea with no features, but that case doesn't exist in the data right now.