### PR TITLE
CMS-1242: Fix missing names for Area-Features

### DIFF
--- a/backend/routes/api/export.js
+++ b/backend/routes/api/export.js
@@ -193,7 +193,35 @@ function getFeatureType(season) {
     return season.parkArea.features[0].featureType.name;
   }
 
-  // Return an empty string if not applicable
+  // Return an empty string if not applicable (e.g., Park seasons)
+  return "";
+}
+
+/**
+ * Gets the name of the Feature associated with a DateRange.
+ * @param {DateRange} dateRange The DateRange with its season details
+ * @returns {string} The name of the Feature or an empty string
+ */
+function getFeatureName(dateRange) {
+  // For Feature Seasons, return the Feature's name
+  if (dateRange.season.feature) {
+    return dateRange.season.feature.name;
+  }
+
+  // For ParkArea Seasons, find the Feature that this DateRange applies to
+  if (dateRange.season.parkArea?.features?.length) {
+    // Find the Feature in the ParkArea with the matching Dateable ID for this DateRange
+    const dateRangeFeature = dateRange.season.parkArea.features.find(
+      (feature) => feature.dateableId === dateRange.dateableId,
+    );
+
+    // If the DateRange's dateableId matches a Feature, return its name
+    if (dateRangeFeature) {
+      return dateRangeFeature.name;
+    }
+  }
+
+  // Return an empty string if not applicable (e.g., Park seasons)
   return "";
 }
 
@@ -261,7 +289,7 @@ router.get(
                 {
                   model: Feature,
                   as: "features",
-                  attributes: ["id", "name"],
+                  attributes: ["id", "name", "dateableId"],
                   required: false,
 
                   include: [
@@ -376,7 +404,7 @@ router.get(
           [colNames.ORCS]: park.orcs,
           [colNames.PARK_NAME]: park.name,
           [colNames.AREA]: season.parkArea?.name ?? "",
-          [colNames.FEATURE]: season.feature?.name ?? "",
+          [colNames.FEATURE]: getFeatureName(dateRange),
           [colNames.FEATURE_ID]: season.feature?.strapiFeatureId ?? "",
           [colNames.FEATURE_TYPE]: getFeatureType(season),
           [colNames.OPERATING_YEAR]: season.operatingYear,


### PR DESCRIPTION
### Jira Ticket

CMS-1242

### Description
<!-- What did you change, and why? -->

On the CSV export, the Feature name was missing if the Feature was part of a ParkArea. This branch adds a function to find the name of the Feature that the DateRange relates to:
- If it's a Feature season, return the name of that one Feature
- If it's a ParkArea season, find the feature with the matching Dateable ID and return its name
- If it's a Park, there's no Feature name so just return `""`