### PR TITLE
CMS-1238: Add filter nulls

### DIFF
--- a/backend/routes/api/export.js
+++ b/backend/routes/api/export.js
@@ -467,8 +467,9 @@ router.get(
         // Get the final sameEveryYear value
         // For gate (operating) date type, use the value from getGateDisplayValues
         // For other date types, always show the isDateRangeAnnual value
-        const sameEveryYear = isGateType ?
-          gateSameEveryYear : formatBoolean(annualData?.isDateRangeAnnual);
+        const sameEveryYear = isGateType
+          ? gateSameEveryYear
+          : formatBoolean(annualData?.isDateRangeAnnual);
 
         // Skip this row if this is a gate type and hasGate is false
         if (isGateType && !hasGate) {
@@ -507,7 +508,8 @@ router.get(
             .map(formatChangeLog)
             .join("\n"),
         };
-      });
+      })
+      .filter(Boolean);
 
     // Sort results
     const sortedRows = _.sortBy(rows, [


### PR DESCRIPTION
### Jira Ticket

CMS-1238

### Description
<!-- What did you change, and why? -->
- Fix the error at `/export` by filtering `null` values
```Executing (default): SELECT "DateRange"."id", "DateRange"."startDate", "DateRange"."endDate", "DateRange"."dateableId", "DateRange"."dateTypeId", "season"."id" AS "season.id", "season"."operatingYear" AS "season.operatingYear", "season"."status" AS "season.status", "season"."readyToPublish" AS "season.readyToPublish", "season->park"."id" AS "season.park.id", "season->park"."name" AS "season.park.name", "season->park"."orcs" AS "season.park.orcs", "season->park"."managementAreas" AS "season.park.managementAreas", "season->park"."inReservationSystem" AS "season.park.inReservationSystem", "season->park"."hasTier1Dates" AS "season.park.hasTier1Dates", "season->park"."hasTier2Dates" AS "season.park.hasTier2Dates", "season->park"."hasWinterFeeDates" AS "season.park.hasWinterFeeDates", "season->parkArea"."id" AS "season.parkArea.id", "season->parkArea"."name" AS "season.parkArea.name", "season->parkArea"."inReservationSystem" AS "season.parkArea.inReservationSystem", "season->parkArea->park"."id" AS "season.parkA...
Executing (default): SELECT "id", "dateTypeId", "publishableId", "dateableId", "isDateRangeAnnual", "createdAt", "updatedAt" FROM "DateRangeAnnuals" AS "DateRangeAnnual";
node:internal/streams/writable:459
throw new ERR_STREAM_NULL_VALUES();
^
TypeError [ERR_STREAM_NULL_VALUES]: May not write null values to stream
at _write (node:internal/streams/writable:459:11)
at Writable.write (node:internal/streams/writable:508:10)
at /app/node_modules/@fast-csv/format/build/src/index.js:47:19
at node:internal/util:432:7
at new Promise (<anonymous>)
at node:internal/util:418:12
at /app/node_modules/@fast-csv/format/build/src/index.js:51:20
at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
Emitted 'error' event on CsvFormatterStream instance at:
at /app/node_modules/@fast-csv/format/build/src/index.js:58:19
at process.processTicksAndRejections (node:internal/process/task_queues:95:5) {
code: 'ERR_STREAM_NULL_VALUES'
}
```
