### PR TITLE
CMS-899: Add publish page

### DIFF
--- a/backend/routes/api/publish.js
+++ b/backend/routes/api/publish.js
@@ -107,9 +107,19 @@ router.get(
       }),
       ParkArea.findAll({
         where: { publishableId: { [Op.in]: publishableIds } },
+        attributes: ["id", "publishableId", "name"],
+        include: [
+          { model: Park, as: "park", attributes: ["id", "name"] },
+          { model: Feature, as: "features", attributes: ["id", "name"] },
+        ],
       }),
       Feature.findAll({
         where: { publishableId: { [Op.in]: publishableIds } },
+        attributes: ["id", "publishableId", "name"],
+        include: [
+          { model: Park, as: "park", attributes: ["id", "name"] },
+          { model: ParkArea, as: "parkArea", attributes: ["id", "name"] },
+        ],
       }),
     ]);
 
@@ -143,20 +153,26 @@ router.get(
       }
 
       // Extract names based on publishable type
-      let parkName = null;
-      let parkAreaName = null;
-      let featureName = null;
+      let parkName = "-";
+      let parkAreaName = "-";
+      let featureNames = [];
 
       if (publishable?.type === "park") {
-        parkName = publishable.name;
+        parkName = publishable.name || "-";
       } else if (publishable?.type === "parkArea") {
-        parkName = publishable.park?.name ?? null;
-        parkAreaName = publishable.name;
-        // featureName = publishable.name;
+        parkName = publishable.park?.name || "-";
+        parkAreaName = publishable.name || "-";
+        const parkAreaFeatures = publishable.features;
+
+        featureNames = Array.isArray(parkAreaFeatures)
+          ? parkAreaFeatures
+              .filter((parkFeature) => parkFeature && parkFeature.name)
+              .map((parkFeature) => parkFeature.name)
+          : [];
       } else if (publishable?.type === "feature") {
-        parkName = publishable.park?.name ?? null;
-        parkAreaName = publishable.parkArea?.name ?? null;
-        featureName = publishable.name;
+        parkName = publishable.park?.name || "-";
+        parkAreaName = publishable.parkArea?.name || "-";
+        featureNames = publishable.name ? [publishable.name] : [];
       }
 
       return {
@@ -168,7 +184,7 @@ router.get(
         dateRanges: season.dateRanges,
         parkName,
         parkAreaName,
-        featureName,
+        featureNames,
       };
     });
 

--- a/backend/routes/api/publish.js
+++ b/backend/routes/api/publish.js
@@ -124,7 +124,7 @@ router.get(
     );
 
     // Build output
-    const output = approvedSeasons?.map((season) => {
+    const output = approvedSeasons.map((season) => {
       const publishable = publishableMap.get(season.publishableId);
 
       if (!publishable) {

--- a/backend/routes/api/publish.js
+++ b/backend/routes/api/publish.js
@@ -60,29 +60,10 @@ router.get(
     const approvedSeasons = await Season.findAll({
       where: {
         status: STATUS.APPROVED,
+        // TODO: CMS-1153
         // readyToPublish: true,
       },
-      attributes: [
-        "id",
-        "publishableId",
-        "operatingYear",
-        "status",
-        "readyToPublish",
-      ],
-      include: [
-        {
-          model: DateRange,
-          as: "dateRanges",
-          attributes: ["id", "startDate", "endDate", "dateTypeId", "adminNote"],
-          include: [
-            {
-              model: DateType,
-              as: "dateType",
-              attributes: ["id", "name"],
-            },
-          ],
-        },
-      ],
+      attributes: ["id", "publishableId", "operatingYear", "readyToPublish"],
     });
 
     // Return if no seasons found
@@ -181,7 +162,6 @@ router.get(
         readyToPublish: season.readyToPublish,
         publishableType: publishable?.type ?? null,
         publishable: publishable ?? null,
-        dateRanges: season.dateRanges,
         parkName,
         parkAreaName,
         featureNames,

--- a/backend/tasks/populate-previous-dates/populate-previous-dates.js
+++ b/backend/tasks/populate-previous-dates/populate-previous-dates.js
@@ -49,7 +49,7 @@ export async function populatePreviousDates() {
           {
             publishableId: park.publishableId,
             operatingYear,
-            status: "approved",
+            status: "published",
             readyToPublish: true,
             seasonType: "regular",
           },
@@ -57,7 +57,7 @@ export async function populatePreviousDates() {
         );
       } else {
         // update status, readyToPublish, seasonType
-        season.status = "approved";
+        season.status = "published";
         season.readyToPublish = true;
         season.seasonType = "regular";
         await season.save({ transaction });

--- a/frontend/src/router/layouts/LandingPageTabs.jsx
+++ b/frontend/src/router/layouts/LandingPageTabs.jsx
@@ -11,10 +11,10 @@ export default function LandingPageTabs() {
   const { data: userData } = useContext(UserContext);
 
   // Check user permissions
-  const { isApprover, canExport, hasAllParkAccess } = useMemo(
+  const { isApprover, hqStaff, hasAllParkAccess } = useMemo(
     () => ({
       isApprover: checkAccess(ROLES.APPROVER),
-      canExport: hasAnyRole([ROLES.APPROVER, ROLES.ALL_PARK_ACCESS]),
+      hqStaff: hasAnyRole([ROLES.APPROVER, ROLES.ALL_PARK_ACCESS]),
       hasAllParkAccess: checkAccess(ROLES.ALL_PARK_ACCESS),
     }),
     [checkAccess, hasAnyRole, ROLES.APPROVER, ROLES.ALL_PARK_ACCESS],
@@ -40,20 +40,19 @@ export default function LandingPageTabs() {
                 Edit{isApprover && " and review"}
               </NavLink>
             </li>
-            {/* Hidden temporarily until the Publish page is re-implemented */}
-            {/* {approver && (
-              <li className="nav-item">
-                <NavLink className="nav-link" to="/publish">
-                  Publish
-                </NavLink>
-              </li>
-            )} */}
-            {canExport && (
-              <li className="nav-item">
-                <NavLink className="nav-link" to="/export">
-                  Export
-                </NavLink>
-              </li>
+            {hqStaff && (
+              <>
+                <li className="nav-item">
+                  <NavLink className="nav-link" to="/publish">
+                    Publish
+                  </NavLink>
+                </li>
+                <li className="nav-item">
+                  <NavLink className="nav-link" to="/export">
+                    Export
+                  </NavLink>
+                </li>
+              </>
             )}
           </ul>
         </div>

--- a/frontend/src/router/pages/PublishPage.jsx
+++ b/frontend/src/router/pages/PublishPage.jsx
@@ -102,7 +102,7 @@ function PublishPage() {
         </div>
 
         <div className="table-responsive">
-          <table className="table table-striped">
+          <table className="table table-striped table-publish">
             <thead>
               <tr>
                 <th scope="col">Park name</th>
@@ -112,27 +112,25 @@ function PublishPage() {
               </tr>
             </thead>
             <tbody>
-              {seasons.length > 0 ? (
-                seasons.map((season) => (
-                  <tr key={season.id}>
-                    <td>{season.parkName}</td>
-                    <td className="fw-bold">{season.parkAreaName}</td>
-                    <td>
-                      <ul className="list-unstyled mb-0">
-                        {season.featureNames.length > 0
-                          ? season.featureNames.map((name, index) => (
-                              <li key={index}>{name}</li>
-                            ))
-                          : "-"}
-                      </ul>
-                    </td>
-                    <td>
-                      {season.operatingYear}
-                      <NotReadyFlag show={!season.readyToPublish} />
-                    </td>
-                  </tr>
-                ))
-              ) : (
+              {seasons.map((season) => (
+                <tr key={season.id}>
+                  <td>{season.parkName}</td>
+                  <td className="fw-bold">{season.parkAreaName}</td>
+                  <td>
+                    <ul className="list-unstyled mb-0">
+                      {season.featureNames.map((name, index) => (
+                        <li key={index}>{name}</li>
+                      ))}
+                      {season.featureNames.length === 0 && <li>-</li>}
+                    </ul>
+                  </td>
+                  <td>
+                    {season.operatingYear}
+                    <NotReadyFlag show={!season.readyToPublish} />
+                  </td>
+                </tr>
+              ))}
+              {seasons.length === 0 && (
                 <tr>
                   <td colSpan="4">No seasons ready to publish</td>
                 </tr>

--- a/frontend/src/router/pages/PublishPage.jsx
+++ b/frontend/src/router/pages/PublishPage.jsx
@@ -6,6 +6,7 @@ import ConfirmationDialog from "@/components/ConfirmationDialog";
 import FlashMessage from "@/components/FlashMessage";
 import LoadingBar from "@/components/LoadingBar";
 import NotReadyFlag from "@/components/NotReadyFlag";
+import "./PublishPage.scss";
 
 function PublishPage() {
   const confirmation = useConfirmation();

--- a/frontend/src/router/pages/PublishPage.jsx
+++ b/frontend/src/router/pages/PublishPage.jsx
@@ -16,8 +16,6 @@ function PublishPage() {
   const { data, loading, error } = useApiGet("/publish/ready-to-publish/");
   const { seasons = [] } = data ?? {};
 
-  console.log("seasons", seasons);
-
   const { sendData: publishData, loading: saving } = useApiPost(
     "/publish/publish-to-api/",
   );
@@ -87,7 +85,11 @@ function PublishPage() {
         <ConfirmationDialog {...confirmation.props} />
 
         <div className="d-flex justify-content-end mb-2">
-          <button className="btn btn-primary" onClick={publishToApi}>
+          <button
+            onClick={publishToApi}
+            disabled={seasons.length === 0}
+            className="btn btn-primary"
+          >
             Publish to API
           </button>
 

--- a/frontend/src/router/pages/PublishPage.jsx
+++ b/frontend/src/router/pages/PublishPage.jsx
@@ -14,6 +14,9 @@ function PublishPage() {
   const errorFlash = useFlashMessage();
 
   const { data, loading, error } = useApiGet("/publish/ready-to-publish/");
+  const { seasons = [] } = data ?? {};
+
+  console.log("seasons", seasons);
 
   const { sendData: publishData, loading: saving } = useApiPost(
     "/publish/publish-to-api/",
@@ -101,21 +104,31 @@ function PublishPage() {
             <thead>
               <tr>
                 <th scope="col">Park name</th>
+                <th scope="col">Area</th>
                 <th scope="col">Feature</th>
                 <th scope="col">Year</th>
               </tr>
             </thead>
             <tbody>
-              {data?.features.map((feature) => (
-                <tr key={`${feature.id}-${feature.season}`}>
-                  <td>{feature.park.name}</td>
-                  <td>{feature.name}</td>
-                  <td>
-                    {feature.season}
-                    <NotReadyFlag show={!feature.readyToPublish} />
-                  </td>
+              {seasons.length > 0 ? (
+                seasons.map((season) => (
+                  <tr key={season.id}>
+                    <td>{season.parkName}</td>
+                    <td>{season.parkAreaName ? season.parkAreaName : ""}</td>
+                    <td>
+                      {season.parkFeatureName ? season.parkFeatureName : ""}
+                    </td>
+                    <td>
+                      {season.operatingYear}
+                      <NotReadyFlag show={!season.readyToPublish} />
+                    </td>
+                  </tr>
+                ))
+              ) : (
+                <tr>
+                  <td colSpan="4">No seasons ready to publish</td>
                 </tr>
-              ))}
+              )}
             </tbody>
           </table>
         </div>

--- a/frontend/src/router/pages/PublishPage.jsx
+++ b/frontend/src/router/pages/PublishPage.jsx
@@ -114,9 +114,15 @@ function PublishPage() {
                 seasons.map((season) => (
                   <tr key={season.id}>
                     <td>{season.parkName}</td>
-                    <td>{season.parkAreaName ? season.parkAreaName : ""}</td>
+                    <td className="fw-bold">{season.parkAreaName}</td>
                     <td>
-                      {season.parkFeatureName ? season.parkFeatureName : ""}
+                      <ul className="list-unstyled mb-0">
+                        {season.featureNames.length > 0
+                          ? season.featureNames.map((name, index) => (
+                              <li key={index}>{name}</li>
+                            ))
+                          : "-"}
+                      </ul>
                     </td>
                     <td>
                       {season.operatingYear}

--- a/frontend/src/router/pages/PublishPage.scss
+++ b/frontend/src/router/pages/PublishPage.scss
@@ -1,0 +1,7 @@
+table {
+  &.table-publish {
+    thead > tr > th {
+      width: 25%;
+    }
+  }
+}

--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -243,10 +243,4 @@ table {
         var(--surface-color-border-default);
     }
   }
-  
-  &.table-publish {
-    thead > tr > th {
-      width: 25%;
-    }
-  }
 }

--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -233,14 +233,20 @@ label.form-check-label {
 // custom table styles
 table {
   // override bootstrap table border
+  thead {
+    border-bottom: 2px solid var(--surface-color-border-dark);
+  }
   &.has-header-row {
     border: var(--layout-border-width-medium) solid var(--theme-primary-blue);
-    thead {
-      border-bottom: 2px solid var(--surface-color-border-dark);
-    }
     tbody {
       border-bottom: var(--layout-border-width-small) solid
         var(--surface-color-border-default);
+    }
+  }
+  
+  &.table-striped {
+    thead > tr > th {
+      width: 25%;
     }
   }
 }

--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -244,7 +244,7 @@ table {
     }
   }
   
-  &.table-striped {
+  &.table-publish {
     thead > tr > th {
       width: 25%;
     }


### PR DESCRIPTION
### Jira Ticket

CMS-899

### Description
<!-- What did you change, and why? -->
- Add the publish page back for HQ stuff
- Update the API `/ready-to-publish` endpoint using the v2 data model
- Update the publish table and display park, area, features, and year
- Update populatePreviousDates to change 2025 Tier 1& 2 dates season status "approved" to "published" so that there will be no seasons on the publish page
  - For testing, run `node tasks/populate-previous-dates/populate-previous-dates.js`
