### PR TITLE
CMS-1265: Delete reservation dates if hasReservations is false

### DIFF
--- a/backend/tasks/delete-reservation-date-ranges/README.md
+++ b/backend/tasks/delete-reservation-date-ranges/README.md
@@ -1,0 +1,28 @@
+# delete-reservation-date-ranges.js
+
+This script deletes all `DateRange` records of type "Reservation" for features where `hasReservations` is set to `false`.
+
+## What does the script do?
+
+- Finds the `DateType` record with the name "Reservation".
+- Finds all `Feature` records where `hasReservations` is `false`.
+- Deletes all `DateRange` records for those features where the `dateType` is "Reservation".
+- All operations are performed in a database transaction for safety.
+
+## How to run
+
+From your project root, run:
+
+```sh
+node tasks/delete-reservation-date-ranges/delete-reservation-date-ranges.js
+```
+
+## Output
+
+- Logs the number of deleted reservation date ranges.
+- If an error occurs, the transaction is rolled back and the error is logged.
+
+## Notes
+
+- Only affects features with `hasReservations: false`.
+- Make sure to backup your database before running destructive scripts.

--- a/backend/tasks/delete-reservation-date-ranges/delete-reservation-date-ranges.js
+++ b/backend/tasks/delete-reservation-date-ranges/delete-reservation-date-ranges.js
@@ -1,0 +1,63 @@
+// This script deletes reservation DateRanges for parks/features where hasReservations is false
+
+import "../../env.js";
+
+import { Op } from "sequelize";
+import { DateType, DateRange, Feature } from "../../models/index.js";
+
+async function deleteReservationDateRanges(transaction = null) {
+  try {
+    // Find the reservation DateType id
+    const reservationDateType = await DateType.findOne({
+      where: { name: "Reservation" },
+      attributes: ["id"],
+      transaction,
+    });
+
+    if (!reservationDateType) {
+      throw new Error("No Reservation DateType found");
+    }
+
+    // Find all features with hasReservations false
+    const features = await Feature.findAll({
+      where: { hasReservations: false },
+      attributes: ["dateableId"],
+      transaction,
+    });
+    const featureDateableIds = features.map((feature) => feature.dateableId);
+
+    // Delete reservation DateRanges for features
+    const deleteCount = await DateRange.destroy({
+      where: {
+        dateTypeId: reservationDateType.id,
+        dateableId: {
+          [Op.in]: [...featureDateableIds],
+        },
+      },
+      transaction,
+    });
+
+    console.log(
+      `Deleted ${deleteCount} Reservation DateRanges where hasReservations is false.`,
+    );
+    return deleteCount;
+  } catch (err) {
+    console.error("Error deleting Reservation DateRanges:", err);
+    throw err;
+  }
+}
+
+// Run directly:
+if (process.argv[1] === new URL(import.meta.url).pathname) {
+  const transaction = await DateRange.sequelize.transaction();
+
+  try {
+    await deleteReservationDateRanges(transaction);
+    await transaction.commit();
+    console.log("Done deleting Reservation DateRanges.");
+  } catch (err) {
+    await transaction.rollback();
+    console.error("Transaction rolled back due to error:", err);
+    throw err;
+  }
+}


### PR DESCRIPTION
### Jira Ticket

CMS-1265

### Description
<!-- What did you change, and why? -->
- Some park-operation-sub-areas `hasReservations` are updated from true to false recently, but DOOT still has "Reservation" dates in these features (sub-areas), so we need to sync `hasReservations` again and delete "Reservation" dates if it's false
- For testing:
  - Run `node strapi-sync/import-data.js` to update Feature `hasReservations`
  - Run `node tasks/delete-reservation-date-ranges/delete-reservation-date-ranges.js` to delete existing "Reservation" dates if Feature's `hasReservations` is false 
 - @duncan-oxd Do you happen to remember how "Reservation" dates are created? Is it based on `hasReservations`  and the past dates? It might be related to CMS-970, so I wanted to ask you if you know 🙂