### PR TITLE
CMS-1261: Change caddy rules to not cache /index.html

### DIFF
--- a/frontend/Caddyfile
+++ b/frontend/Caddyfile
@@ -13,8 +13,10 @@
         try_files {path} /index.html
     }
 
-    header /dates/* Cache-Control "no-store, must-revalidate, no-cache, max-age=0, private"
+    header /* Cache-Control "no-store, must-revalidate, no-cache, max-age=0, private"
     header /dates/assets/* -Cache-Control
+    header /static/* -Cache-Control
+    header /images/* -Cache-Control
 
     encode gzip
 


### PR DESCRIPTION
### Jira Ticket

CMS-1261

### Description
Modified the caching rules on the frontend-legacy application to resolve a caching issue that prevented the previous modifications from working as expected.

