### PR TITLE
CMS-1624: Update auth redirects

### DIFF
--- a/frontend/src/config/keycloak.js
+++ b/frontend/src/config/keycloak.js
@@ -1,6 +1,8 @@
 import getEnv from "./getEnv";
 import { WebStorageStateStore } from "oidc-client-ts";
 
+const frontendBaseUrl = getEnv("VITE_FRONTEND_BASE_URL");
+
 export const oidcConfig = {
   authority: getEnv("VITE_OIDC_AUTHORITY"),
   client_id: getEnv("VITE_OIDC_CLIENT_ID"),
@@ -10,8 +12,11 @@ export const oidcConfig = {
   }),
 
   // Redirect back to the page you were on after logging in
-  redirect_uri: `${window.location.origin}${window.location.pathname}`,
-  post_logout_redirect_uri: `${window.location.origin}/dates/?logged-out`,
+  redirect_uri: new URL(window.location.pathname, frontendBaseUrl).toString(),
+  post_logout_redirect_uri: new URL(
+    "/login?logged-out",
+    frontendBaseUrl,
+  ).toString(),
 
   // Automatically renew the access token before it expires
   automaticSilentRenew: true,

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -3,7 +3,6 @@ import { createRoot } from "react-dom/client";
 import { RouterProvider } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import router from "@/router";
-import ProtectedRoute from "@/router/ProtectedRoute";
 import { AuthProvider } from "react-oidc-context";
 import { oidcConfig, onSigninCallback } from "@/config/keycloak.js";
 
@@ -16,15 +15,13 @@ createRoot(document.getElementById("root")).render(
   <StrictMode>
     <AuthProvider onSigninCallback={onSigninCallback} {...oidcConfig}>
       <QueryClientProvider client={queryClient}>
-        <ProtectedRoute>
-          <RouterProvider
-            router={router}
-            future={{
-              // eslint-disable-next-line camelcase -- vendor flag
-              v7_startTransition: true,
-            }}
-          />
-        </ProtectedRoute>
+        <RouterProvider
+          router={router}
+          future={{
+            // eslint-disable-next-line camelcase -- vendor flag
+            v7_startTransition: true,
+          }}
+        />
       </QueryClientProvider>
     </AuthProvider>
   </StrictMode>,

--- a/frontend/src/router/AccessControlledRoute.jsx
+++ b/frontend/src/router/AccessControlledRoute.jsx
@@ -7,7 +7,14 @@ export default function AccessControlledRoute({
   allowedRoles,
   redirectTo = "/",
 }) {
-  const { hasAnyRole } = useAccess();
+  const { hasAnyRole, isAuthenticated } = useAccess();
+
+  // If not authenticated, redirect to login
+  if (!isAuthenticated) {
+    return <Navigate to="/login" replace />;
+  }
+
+  // If authenticated but lacks required roles, redirect to the provided location
   const hasAccess = hasAnyRole(allowedRoles);
 
   if (!hasAccess) {

--- a/frontend/src/router/ProtectedRoute.jsx
+++ b/frontend/src/router/ProtectedRoute.jsx
@@ -41,7 +41,7 @@ export default function ProtectedRoute({ children }) {
   }, [auth, navigate]);
 
   /**
-   * Attempt to auomatically sign in
+   * Attempt to automatically sign in
    * See {@link https://github.com/authts/react-oidc-context?tab=readme-ov-file#automatic-sign-in}
    */
   useEffect(() => {

--- a/frontend/src/router/ProtectedRoute.jsx
+++ b/frontend/src/router/ProtectedRoute.jsx
@@ -1,8 +1,8 @@
 import { useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { hasAuthParams, useAuth } from "react-oidc-context";
 import PropTypes from "prop-types";
 import AccessProvider from "@/router/AccessProvider";
-import routerconfig from "@/router/index";
 
 // Higher-order component that wraps a route component for authentication
 // Wrap a "layout" component in this component to protect all of its children
@@ -10,14 +10,35 @@ import routerconfig from "@/router/index";
 // https://github.com/authts/sample-keycloak-react-oidc-context/
 export default function ProtectedRoute({ children }) {
   const auth = useAuth();
+  const navigate = useNavigate();
   // Get the query params from the URL
   const params = useMemo(() => new URLSearchParams(window.location.search), []);
 
-  // Get the base path from the router config
-  const basepath = routerconfig.basename;
-
   // Track if a redirect has happened to prevent redirect loops
   const [hasTriedSignin, setHasTriedSignin] = useState(false);
+
+  /**
+   * Immediately redirect to /login when the library detects the Keycloak
+   * session has ended (e.g. killed from the admin panel) or silent renew fails.
+   * This fires faster than waiting for the next render cycle.
+   * See {@link https://authts.github.io/oidc-client-ts/interfaces/UserManagerEvents.html}
+   */
+  useEffect(() => {
+    const unsubscribeSignedOut = auth.events.addUserSignedOut(() => {
+      auth.removeUser();
+      navigate("/login", { replace: true });
+    });
+
+    const unsubscribeRenewError = auth.events.addSilentRenewError(() => {
+      auth.removeUser();
+      navigate("/login", { replace: true });
+    });
+
+    return () => {
+      unsubscribeSignedOut();
+      unsubscribeRenewError();
+    };
+  }, [auth, navigate]);
 
   /**
    * Attempt to auomatically sign in
@@ -40,14 +61,12 @@ export default function ProtectedRoute({ children }) {
       auth.clearStaleState();
       setHasTriedSignin(true);
 
-      if (
-        !auth.isAuthenticated &&
-        !window.location.pathname.startsWith(`${basepath}login`)
-      ) {
-        window.location.replace(`${basepath}login`);
+      // Only redirect if not already on the login page
+      if (!auth.isAuthenticated && window.location.pathname !== "/login") {
+        navigate("/login", { replace: true });
       }
     }
-  }, [auth, hasTriedSignin, params, basepath]);
+  }, [auth, hasTriedSignin, params, navigate]);
 
   if (auth.error) {
     // If there's an error, redirect to the sign-in page
@@ -58,12 +77,17 @@ export default function ProtectedRoute({ children }) {
   }
 
   if (auth.isLoading && auth.activeNavigator !== "signinSilent") {
-    return <div>Redirecting...</div>;
+    return <div>Checking authentication...</div>;
   }
 
   // If the URL has the "logged-out" query param, display a message
   if (params.has("logged-out")) {
     return <div>Logged out.</div>;
+  }
+
+  if (!auth.isAuthenticated) {
+    // Block rendering until authenticated, or redirecting
+    return <div>Redirecting to login...</div>;
   }
 
   return <AccessProvider auth={auth}>{children}</AccessProvider>;

--- a/frontend/src/router/index.jsx
+++ b/frontend/src/router/index.jsx
@@ -36,8 +36,8 @@ const RouterConfig = createBrowserRouter([
   // Root path - Advisories portal
   {
     path: "/",
-    // Protect the entire route with the AuthProvider
 
+    // Protect the entire route with the ProtectedRoute component
     element: (
       <ProtectedRoute>
         <ErrorProvider>
@@ -152,7 +152,8 @@ const RouterConfig = createBrowserRouter([
   // /dates/ path - Dates of Operation Tool
   {
     path: "/dates/",
-    // Protect the entire app with the AuthProvider
+
+    // Protect the entire route with the ProtectedRoute component
     element: (
       <ProtectedRoute>
         <AccessControlledRoute

--- a/frontend/src/router/index.jsx
+++ b/frontend/src/router/index.jsx
@@ -5,6 +5,7 @@ import EditAndReview from "./pages/EditAndReview";
 import PublishPage from "./pages/PublishPage";
 import ExportPage from "./pages/ExportPage";
 import MainLayout from "./layouts/MainLayout";
+import MainLayoutPublic from "./layouts/MainLayoutPublic";
 import LandingPageTabs from "./layouts/LandingPageTabs";
 import ErrorPage from "./pages/Error";
 import LoginPage from "./pages/LoginPage";
@@ -19,6 +20,7 @@ import ParkInfo from "./pages/advisories/parkInfo/ParkInfo";
 import Advisory from "./pages/advisories/advisory/Advisory";
 import AdvisorySummary from "./pages/advisories/advisorySummary/AdvisorySummary";
 import AdvisoryLink from "./pages/advisories/advisoryLink/AdvisoryLink";
+import ProtectedRoute from "./ProtectedRoute";
 
 import { ROLES } from "@/config/permissions";
 
@@ -27,7 +29,7 @@ const RouterConfig = createBrowserRouter([
   // or redirect to "/" if already authenticated.
   {
     path: "/login",
-    element: <MainLayout isPublic />,
+    element: <MainLayoutPublic />,
     children: [{ path: "", element: <LoginPage /> }],
   },
 
@@ -37,11 +39,13 @@ const RouterConfig = createBrowserRouter([
     // Protect the entire route with the AuthProvider
 
     element: (
-      <ErrorProvider>
-        <CmsDataProvider>
-          <MainLayout />
-        </CmsDataProvider>
-      </ErrorProvider>
+      <ProtectedRoute>
+        <ErrorProvider>
+          <CmsDataProvider>
+            <MainLayout />
+          </CmsDataProvider>
+        </ErrorProvider>
+      </ProtectedRoute>
     ),
 
     children: [
@@ -141,7 +145,7 @@ const RouterConfig = createBrowserRouter([
   // DOOT "Unauthorized" message for users without the doot user role in Keycloak
   {
     path: "/dates/unauthorized",
-    element: <MainLayout isPublic />,
+    element: <MainLayoutPublic />,
     children: [{ path: "", element: <Unauthorized /> }],
   },
 
@@ -150,12 +154,14 @@ const RouterConfig = createBrowserRouter([
     path: "/dates/",
     // Protect the entire app with the AuthProvider
     element: (
-      <AccessControlledRoute
-        redirectTo="/dates/unauthorized"
-        allowedRoles={[ROLES.DOOT_USER]}
-      >
-        <MainLayout />
-      </AccessControlledRoute>
+      <ProtectedRoute>
+        <AccessControlledRoute
+          redirectTo="/dates/unauthorized"
+          allowedRoles={[ROLES.DOOT_USER]}
+        >
+          <MainLayout />
+        </AccessControlledRoute>
+      </ProtectedRoute>
     ),
     errorElement: <ErrorPage />,
 

--- a/frontend/src/router/layouts/MainLayout.jsx
+++ b/frontend/src/router/layouts/MainLayout.jsx
@@ -1,5 +1,4 @@
 import { useMemo, useState, useEffect } from "react";
-import PropTypes from "prop-types";
 import { Outlet, Link } from "react-router-dom";
 import "./MainLayout.scss";
 import logo from "@/assets/bc-parks-logo.svg";
@@ -17,7 +16,7 @@ import { Alert } from "react-bootstrap";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCircleExclamation } from "@fa-kit/icons/classic/regular";
 
-export default function MainLayout({ isPublic = false }) {
+export default function MainLayout() {
   const { logOut, isAuthenticated } = useAccess();
   const globalFlashMessage = useFlashMessage();
 
@@ -148,11 +147,8 @@ export default function MainLayout({ isPublic = false }) {
           )}
 
           <main className="p-0 d-flex flex-column flex-md-row">
-            {/* Use the layout with no sidebar for public pages page */}
-            {isPublic && <Outlet />}
-
             {/* Authenticated user with roles: show sidebar and main content */}
-            {!isPublic && isAuthenticated && (
+            {isAuthenticated && (
               <>
                 <NavSidebar />
                 <div className="flex-fill" style={{ overflowX: "auto" }}>
@@ -195,7 +191,3 @@ export default function MainLayout({ isPublic = false }) {
     </FlashMessageContext.Provider>
   );
 }
-
-MainLayout.propTypes = {
-  isPublic: PropTypes.bool,
-};

--- a/frontend/src/router/layouts/MainLayoutPublic.jsx
+++ b/frontend/src/router/layouts/MainLayoutPublic.jsx
@@ -1,0 +1,125 @@
+import { useMemo, useEffect } from "react";
+import { Outlet, Link } from "react-router-dom";
+import "./MainLayout.scss";
+import logo from "@/assets/bc-parks-logo.svg";
+import logoVertical from "@/assets/bc-parks-logo-vertical.svg";
+import FlashMessage from "@/components/FlashMessage";
+import FlashMessageContext from "@/contexts/FlashMessageContext";
+import useFlashMessage from "@/hooks/useFlashMessage";
+import { Alert } from "react-bootstrap";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faCircleExclamation } from "@fa-kit/icons/classic/regular";
+
+export default function MainLayout() {
+  const globalFlashMessage = useFlashMessage();
+
+  // Check if the app is running in production
+  const isProduction =
+    typeof window !== "undefined" &&
+    window.location.hostname === "staff.bcparks.ca";
+
+  const flashMessageContextValue = useMemo(
+    () => ({
+      open: globalFlashMessage.open,
+      close: globalFlashMessage.close,
+    }),
+    [globalFlashMessage.open, globalFlashMessage.close],
+  );
+
+  // Close flash message when a button is clicked
+  useEffect(() => {
+    function handleClick(e) {
+      if (!globalFlashMessage.isOpen) return;
+
+      const isLink = e.target.closest("a");
+      const isButton = e.target.closest("button");
+      const isFormButton = e.target.closest(".form-btn");
+      const isInput = e.target.closest("input");
+
+      // Don't close if clicking form action buttons (Save/Approve/Submit)
+      if (isFormButton) return;
+
+      // Close if clicking any other button, link, or input
+      if (isButton || isLink || isInput) {
+        globalFlashMessage.close();
+      }
+    }
+
+    document.addEventListener("click", handleClick);
+
+    return () => {
+      document.removeEventListener("click", handleClick);
+    };
+  }, [globalFlashMessage]);
+
+  return (
+    <FlashMessageContext.Provider value={flashMessageContextValue}>
+      <div className="layout main">
+        <header className="bcparks-global navbar navbar-dark px-3 d-flex align-items-center container-fluid py-1 bg-primary-nav">
+          <Link
+            to={`/`}
+            className="d-inline-block d-flex align-items-center align-items-md-end logo-link"
+            href="/"
+          >
+            <img
+              className="d-block d-md-none"
+              src={logoVertical}
+              height="60"
+              alt="BC Parks logo"
+            />
+            {/* swap logo images on larger screens */}
+            <img
+              className="d-none d-md-block"
+              src={logo}
+              height="60"
+              alt="BC Parks logo"
+            />
+
+            <div className="app-title text-white mx-3 mx-md-1">
+              Staff web portal
+            </div>
+          </Link>
+        </header>
+
+        {!isProduction && (
+          <Alert
+            variant="danger"
+            className="text-center text-white border-0 rounded-0 mb-0"
+          >
+            <FontAwesomeIcon className="me-2" icon={faCircleExclamation} />
+            Testing environment only. Information entered will not appear on the
+            live reservation site or on bcparks.ca.
+          </Alert>
+        )}
+
+        <main className="p-0 d-flex flex-column flex-md-row">
+          {/* Use the layout with no sidebar for public pages page */}
+          <Outlet />
+        </main>
+
+        <footer className="bcparks-global py-2 py-md-0 d-flex justify-content-md-end align-items-center container-fluid text-bg-primary-nav">
+          <div className="quick-links d-flex flex-column flex-md-row me-md-4">
+            <span>Quick links:</span>
+
+            <a href="https://attendance-revenue.bcparks.ca/">
+              Attendance and Revenue
+            </a>
+
+            <a href="https://reserve-admin.bcparks.ca/dayuse/">
+              Day-use Pass admin
+            </a>
+
+            <a href="mailto:parksweb@gov.bc.ca">Contact us</a>
+          </div>
+        </footer>
+      </div>
+
+      <FlashMessage
+        title={globalFlashMessage.title}
+        message={globalFlashMessage.message}
+        isVisible={globalFlashMessage.isOpen}
+        onClose={globalFlashMessage.close}
+      />
+    </FlashMessageContext.Provider>
+  );
+}

--- a/frontend/src/router/layouts/MainLayoutPublic.jsx
+++ b/frontend/src/router/layouts/MainLayoutPublic.jsx
@@ -10,7 +10,7 @@ import { Alert } from "react-bootstrap";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCircleExclamation } from "@fa-kit/icons/classic/regular";
 
-export default function MainLayout() {
+export default function MainLayoutPublic() {
   const globalFlashMessage = useFlashMessage();
 
   // Check if the app is running in production

--- a/frontend/src/router/pages/LoginPage.jsx
+++ b/frontend/src/router/pages/LoginPage.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useCallback } from "react";
 import { Navigate } from "react-router-dom";
 import { useAuth } from "react-oidc-context";
-import routerconfig from "@/router/index";
+import getEnv from "@/config/getEnv";
 import "./LoginPage.scss";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faArrowUpRightFromSquare } from "@fa-kit/icons/classic/regular";
@@ -9,22 +9,19 @@ import { faArrowUpRightFromSquare } from "@fa-kit/icons/classic/regular";
 export default function LoginPage() {
   const auth = useAuth();
 
-  // get the base path from the router config
-  const basepath = routerconfig.basename;
-
   // function to redirect to Keycloak for the selected login provider
   const handleLogin = useCallback(
     (idp) => {
       auth.signinRedirect({
         // eslint-disable-next-line camelcase -- 'redirect_uri' is required by Keycloak
-        redirect_uri: `${window.location.origin}${basepath}`,
+        redirect_uri: getEnv("VITE_FRONTEND_BASE_URL"),
         extraQueryParams: {
           // eslint-disable-next-line camelcase -- 'kc_idp_hint' is required by Keycloak
           kc_idp_hint: idp,
         },
       });
     },
-    [auth, basepath],
+    [auth],
   );
 
   useEffect(() => {
@@ -38,10 +35,9 @@ export default function LoginPage() {
     }
   }, [handleLogin]);
 
-  // if already authenticated or login_idp is set, don't show the login page
-  if (auth.isAuthenticated || sessionStorage.getItem("login_idp")) {
+  // if already authenticated, don't show the login page
+  if (auth.isAuthenticated) {
     // Redirect to "/" (which will redirect to a dashboard)
-    console.log("navigate to /");
     return <Navigate to="/" replace />;
   }
 

--- a/frontend/src/router/pages/LoginPage.jsx
+++ b/frontend/src/router/pages/LoginPage.jsx
@@ -14,7 +14,7 @@ export default function LoginPage() {
     (idp) => {
       auth.signinRedirect({
         // eslint-disable-next-line camelcase -- 'redirect_uri' is required by Keycloak
-        redirect_uri: getEnv("VITE_FRONTEND_BASE_URL"),
+        redirect_uri: new URL("/", getEnv("VITE_FRONTEND_BASE_URL")).toString(),
         extraQueryParams: {
           // eslint-disable-next-line camelcase -- 'kc_idp_hint' is required by Keycloak
           kc_idp_hint: idp,

--- a/frontend/src/router/pages/advisories/advisoryLink/AdvisoryLink.jsx
+++ b/frontend/src/router/pages/advisories/advisoryLink/AdvisoryLink.jsx
@@ -21,7 +21,7 @@ export default function AdvisoryLink() {
         if (!auth.isAuthenticated) {
           auth.signinRedirect({
             // eslint-disable-next-line camelcase -- 'redirect_uri' is required by Keycloak
-            redirect_uri: `${getEnv("VITE_FRONTEND_BASE_URL")}/advisory-link/${advisoryNumber}`,
+            redirect_uri: new URL(`/advisory-link/${advisoryNumber}`, getEnv("VITE_FRONTEND_BASE_URL")).toString(),
             // eslint-disable-next-line camelcase -- 'kc_idp_hint' is required by Keycloak
             extraQueryParams: { kc_idp_hint: "idir" },
           });


### PR DESCRIPTION
### Jira Ticket

CMS-1624

### Description
<!-- What did you change, and why? -->

The third and hopefully final part of big Copilot-assisted changes for CMS-1624 to stop useEffect and redirects causing infinite loops. This builds on the changes in #493 and updates some of the logic around auth checks and redirects.

Changes:

Removed references to "basepath" in the keycloak files because we're not using a basepath anymore (it was "/dates" to work with the proxy server)

Instead of wrapping the entire site in the `ProtectedRoute` component and whitelisting certain pages like login, now we just wrap the protected pages.

Public routes ("/login" and "/dates/unauthorized") now have a public copy of the MainLayout called MainLayoutPublic that doesn't show the nav menu. (Just the basic header and footer)

Removed public route stuff from the regular MainLayout since it will not be used for public pages anymore.

With Copilot's help, I added and updated a bunch of checks to prevent unintended redirects and renders when things happen to the token (5 minute refresh, manually killed from the Keycloak control panel, etc).

- [x] Copilot suggested a minor tweak to make the OIDC redirect URL more robust; I'll do this on Monday