### PR TITLE
CMS-1626: Add list styles to match main site/CMS

### DIFF
--- a/frontend/src/styles/_list.scss
+++ b/frontend/src/styles/_list.scss
@@ -1,0 +1,46 @@
+// List styles for content from the rich text editor/CMS
+// Intended to match the styles on the main BCParks.ca website
+
+ol {
+  list-style-type: decimal;
+
+  li.lower-alpha {
+    list-style-type: lower-alpha;
+  }
+}
+
+ul {
+  list-style-type: disc;
+
+  ul {
+    list-style-type: circle;
+  }
+}
+
+// Match styles in CKEditor: override the default CKEditor styles for lists
+.ck-content {
+  ol {
+    list-style-type: decimal;
+
+    ol,
+    ol ol,
+    ol ol ol,
+    ol ol ol ol {
+      list-style-type: decimal;
+    }
+
+    li.lower-alpha {
+      list-style-type: lower-alpha;
+    }
+  }
+
+  ul {
+    list-style-type: disc;
+
+    ul,
+    ul ul,
+    ul ul ul {
+      list-style-type: circle;
+    }
+  }
+}

--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -19,6 +19,9 @@
 // Advisories portal custom styles
 @use "advisories";
 
+// UL and OL styles
+@use "list";
+
 // Break inside words on when nevessary on top-level headings
 h1 {
   overflow-wrap: break-word;


### PR DESCRIPTION
### Jira Ticket

CMS-1626

### Description
<!-- What did you change, and why? -->

Some minor style updates to make nested list styles match the nested list styles in the CMS and main site (black disc, white circle, white circle, white circle...)

For ordered list, it just uses decimals 1, 2, 3 for all levels.

I added the new styles in a partial called "list"