### PR TITLE
CMS-1662: Restrict Activities & Facilities to approvers only

### DIFF
--- a/frontend/src/router/index.jsx
+++ b/frontend/src/router/index.jsx
@@ -124,9 +124,7 @@ const RouterConfig = createBrowserRouter([
       {
         path: "activities-and-facilities",
         element: (
-          <AccessControlledRoute
-            allowedRoles={[ROLES.ADVISORY_SUBMITTER, ROLES.ADVISORY_APPROVER]}
-          >
+          <AccessControlledRoute allowedRoles={[ROLES.ADVISORY_APPROVER]}>
             <ParkSearch />
           </AccessControlledRoute>
         ),


### PR DESCRIPTION
### Jira Ticket

CMS-1662

### Description
<!-- What did you change, and why? -->

Restrict access to the Activities & Facilities route (ParkSearch component) to Approvers only. It was already hidden in the side menu, but the route was still viewable for Submitters. 

If you hit the route with the wrong roles, it forwards you to "/" (the Advisories dashboard page).

- [ ] The ticket has a few other items mentioned, but those can be solved in Keycloak. (Legacy SP roles might be set in a different tab than the newer ones inherited from groups). I'll sort that out with QA tomorrow