### PR TITLE
NOBUG: Change port to 3000 and add not-so-secret values to env.example

### DIFF
--- a/backend/.env.local.example
+++ b/backend/.env.local.example
@@ -1,8 +1,8 @@
 # JSON Web Key Set (JWKS) endpoint
-JWKS_URI="https://<KEYCLOAK-SERVER>/auth/realms/<KEYCLOAK-REALM>/protocol/openid-connect/certs"
+JWKS_URI="https://dev.loginproxy.gov.bc.ca/auth/realms/bcparks-service-transformation/protocol/openid-connect/certs"
 
 # Keycloak OICD authority
-JWT_ISSUER="https://<KEYCLOAK-SERVER>/auth/realms/<KEYCLOAK-REALM>"
+JWT_ISSUER="https://dev.loginproxy.gov.bc.ca/auth/realms/bcparks-service-transformation"
 
 # AdminJS login credentials
 ADMIN_USER="admin"

--- a/backend/package.json
+++ b/backend/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "nodemon index.js",
+    "develop": "npm run dev",
     "start": "node index.js",
     "lint": "eslint .",
     "migrate": "sequelize-cli db:migrate",

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -8,7 +8,7 @@ services:
     environment:
       FONTAWESOME_PACKAGE_TOKEN: ${FONTAWESOME_PACKAGE_TOKEN}
     ports:
-      - "8101:8101"
+      - "3000:3000"
     volumes:
       - .:/app:cached
       - ${HOME}/.config/git:/home/node/.config/git:ro

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,12 +1,12 @@
-VITE_OIDC_AUTHORITY=https://<KEYCLOAK-SERVER>/auth/realms/<KEYCLOAK-REALM>
+VITE_OIDC_AUTHORITY=https://dev.loginproxy.gov.bc.ca/auth/realms/bcparks-service-transformation
 VITE_OIDC_CLIENT_ID=staff-portal
 
-VITE_FRONTEND_BASE_URL=http://localhost:8101
-VITE_API_BASE_URL=http://0.0.0.0:8100/api
+VITE_FRONTEND_BASE_URL=http://localhost:3000
+VITE_API_BASE_URL=http://localhost:8100/api
 
 VITE_BCPARKS_PUBLIC_URL=http://localhost:8000
 VITE_CMS_BASE_URL=http://localhost:1337
 
 VITE_STAT_HOLIDAY_API=https://canada-holidays.ca/api/v1/provinces/BC
 
-VITE_CKEDITOR_LICENSE_KEY=ckeditor-license-key
+VITE_CKEDITOR_LICENSE_KEY=GPL

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -8,7 +8,7 @@ WORKDIR /app
 # Copy the files
 COPY . .
 
-EXPOSE 8101
+EXPOSE 3000
 
 # Command to run the application
 CMD ["npm", "run", "dev"]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "develop": "npm run dev",
     "build": "vite build",
     "lint": "eslint .",
     "preview": "vite preview"

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -13,7 +13,7 @@ export default defineConfig({
 
   server: {
     host: true,
-    port: 8101,
+    port: 3000,
   },
 
   resolve: {


### PR DESCRIPTION
### Jira Ticket

None

### Description
- Changed the port for the staff portal on localdev from 8101 to 3000. 
    - 3000 was the port used by the legacy staff portal and it is the port used by Caddy on production. 
    - 8101 was the DOOT port
- Added some values to .env.example files that aren't really secrets to simplify dev environment setup
- Add aliases so we can use `npm run develop` instead of `npm run dev` without having to think about which project we are working on (the CMS project uses `develop`)


