### PR TITLE
CMS-1636: Update CKEditor style overrides in _ckeditor partial

### DIFF
--- a/frontend/src/styles/_ckeditor.scss
+++ b/frontend/src/styles/_ckeditor.scss
@@ -16,3 +16,42 @@
 .ck-content .table {
   width: auto;
 }
+
+/*
+ * Override the default CKEditor styles for nested lists to match the main BCParks.ca site
+ * Match the list-style-types in _list.scss
+ */
+.ck-content {
+  ol {
+    list-style-type: decimal;
+
+    ol,
+    ol ol,
+    ol ol ol,
+    ol ol ol ol {
+      list-style-type: decimal;
+    }
+
+    li.lower-alpha {
+      list-style-type: lower-alpha;
+    }
+  }
+
+  ul {
+    list-style-type: disc;
+
+    ul,
+    ul ul,
+    ul ul ul {
+      list-style-type: circle;
+    }
+  }
+}
+
+/*
+ * Override the Bootstrap theme's "!important" h2 styles
+ * Affects inline popups for links
+ */
+.ck.ck-form__header .ck-form__header__label {
+  font-size: var(--ck-font-size-base) !important;
+}

--- a/frontend/src/styles/_list.scss
+++ b/frontend/src/styles/_list.scss
@@ -16,31 +16,3 @@ ul {
     list-style-type: circle;
   }
 }
-
-// Match styles in CKEditor: override the default CKEditor styles for lists
-.ck-content {
-  ol {
-    list-style-type: decimal;
-
-    ol,
-    ol ol,
-    ol ol ol,
-    ol ol ol ol {
-      list-style-type: decimal;
-    }
-
-    li.lower-alpha {
-      list-style-type: lower-alpha;
-    }
-  }
-
-  ul {
-    list-style-type: disc;
-
-    ul,
-    ul ul,
-    ul ul ul {
-      list-style-type: circle;
-    }
-  }
-}


### PR DESCRIPTION
### Jira Ticket

CMS-1636

### Description
<!-- What did you change, and why? -->

The Bootstrap theme has `!important` styles on the h2 tag, which was overriding the CKEditor UI styles. This branch adds an override of our own to restore the correct size of h2 tags in inline popups:
<img width="376" height="218" alt="image" src="https://github.com/user-attachments/assets/d70219ad-a421-4b7f-bf8f-27beba0dfe0f" />

I also also moved the CKEditor-specific list styles into the ckeditor style file. They were in the lists file, but this way all of the CKEditor styles are in one place so they can be updated or swapped out in one file if we ever need to.