### PR TITLE
CMS-1635: Use activityName in Park Info table

### DIFF
--- a/frontend/src/router/pages/advisories/parkInfo/ParkInfo.jsx
+++ b/frontend/src/router/pages/advisories/parkInfo/ParkInfo.jsx
@@ -666,9 +666,12 @@ export default function ParkInfo() {
                             </div>
                           </div>
                           {parkActivities.map((a) => (
-                            <div className="row pt2b2 mx-0" key={`activity-${a.id}`}>
+                            <div
+                              className="row pt2b2 mx-0"
+                              key={`activity-${a.id}`}
+                            >
                               <div className="col-xl-3 col-12 park-content">
-                                {a.name}
+                                {a.activityType.activityName}
                               </div>
                               <div className="col-xl-1 col-12 park-content">
                                 <SwitchButton
@@ -821,9 +824,12 @@ export default function ParkInfo() {
                             </div>
                           </div>
                           {parkFacilities.map((f) => (
-                            <div className="row pt2b2 mx-0" key={`facility-${f.id}`}>
+                            <div
+                              className="row pt2b2 mx-0"
+                              key={`facility-${f.id}`}
+                            >
                               <div className="col-xl-3 col-12 park-content">
-                                {f.name}
+                                {f.facilityType.facilityName}
                               </div>
                               <div className="col-xl-1 col-12 park-content">
                                 <SwitchButton
@@ -981,7 +987,7 @@ export default function ParkInfo() {
                               key={`campingType-${f.id}`}
                             >
                               <div className="col-xl-3 col-12 park-content">
-                                {f.name.split(":")[1] || f.name}
+                                {f.campingType.campingTypeName}
                               </div>
                               <div className="col-xl-1 col-12 park-content">
                                 <SwitchButton


### PR DESCRIPTION
### Jira Ticket

CMS-1635

### Description
<!-- What did you change, and why? -->

Updates the "Facilities & Activites" table to use the `activityType.activityName` value instead of the `name`, so it won't show the orcs number in that string. As long as `activityType.activityName` is always defined (and correct) this should work as a fix.