### PR TITLE
CMS-1652: Update data fetching in ParkInfo

### DIFF
--- a/frontend/src/router/pages/advisories/parkInfo/ParkInfo.jsx
+++ b/frontend/src/router/pages/advisories/parkInfo/ParkInfo.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useContext } from "react";
+import { useState, useEffect, useContext, useCallback } from "react";
 import ErrorContext from "@/contexts/ErrorContext";
 import CmsDataContext from "@/contexts/CmsDataContext";
 import "./ParkInfo.css";
@@ -16,7 +16,6 @@ import qs from "qs";
 export default function ParkInfo() {
   const { cmsGet, cmsPut, getRegions, getSections } = useCms();
   const { setError } = useContext(ErrorContext);
-  const { cmsData, setCmsData } = useContext(CmsDataContext);
   const [isLoading, setIsLoading] = useState(true);
   const [toError, setToError] = useState(false);
   const [protectedArea, setProtectedArea] = useState();
@@ -35,11 +34,125 @@ export default function ParkInfo() {
   const [loadParkInfo, setLoadParkInfo] = useState(true);
   const auth = useAuth();
   const initialized = !auth.isLoading;
-  const keycloak = auth.isAuthenticated ? auth.user : null;
+  const isAuthenticated = auth.isAuthenticated;
   const { id } = useParams();
   const navigate = useNavigate();
 
   const [tabIndex, setTabIndex] = useState(0);
+
+  /**
+   * Fetches and sets CMS data for the selected park:
+   * - protected area details
+   * - activities
+   * - facilities
+   * - camping types
+   * Handles error and loading state. Called by useEffect when dependencies change.
+   * @param {boolean} isMounted Whether the component is still mounted (prevents state updates on unmounted components).
+   * @param {string} query Query string for the CMS API request.
+   * @returns {Promise<void>} Resolves when park info is loaded and state is updated.
+   */
+  const fetchParkInfo = useCallback(
+    async (isMounted, query) => {
+      try {
+        const [protectedAreas, regions, sections] = await Promise.all([
+          cmsGet(`/protected-areas?${query}`),
+          getRegions(),
+          getSections(),
+        ]);
+        const protectedAreaData = protectedAreas[0];
+
+        if (protectedAreaData.managementAreas?.length > 0) {
+          const managementArea = protectedAreaData.managementAreas[0];
+
+          protectedAreaData.managementAreaName =
+            managementArea.managementAreaName;
+          const region = regions.filter(
+            (r) => r.documentId === managementArea.region.documentId,
+          );
+
+          if (region.length > 0) {
+            protectedAreaData.regionName = region[0].regionName;
+          }
+          const section = sections.filter(
+            (s) => s.documentId === managementArea.section.documentId,
+          );
+
+          if (section.length > 0) {
+            protectedAreaData.sectionName = section[0].sectionName;
+          }
+        }
+        if (protectedAreaData.parkActivities?.length > 0) {
+          const activities = protectedAreaData.parkActivities.map(
+            (activity) => ({
+              id: activity.documentId,
+              description: activity.description,
+              name: activity.name,
+              isActivityOpen: activity.isActivityOpen,
+              isActive: activity.isActive,
+              protectedArea: activity.protectedArea,
+              site: activity.site,
+              activityType: activity.activityType,
+            }),
+          );
+
+          if (isMounted) {
+            setParkActivities([...activities]);
+          }
+        }
+        if (protectedAreaData.parkFacilities?.length > 0) {
+          const facilities = protectedAreaData.parkFacilities.map(
+            (facility) => ({
+              id: facility.documentId,
+              description: facility.description,
+              name: facility.name,
+              isFacilityOpen: facility.isFacilityOpen,
+              isActive: facility.isActive,
+              protectedArea: facility.protectedArea,
+              site: facility.site,
+              facilityType: facility.facilityType,
+            }),
+          );
+
+          if (isMounted) {
+            setParkFacilities([...facilities]);
+          }
+        }
+        if (protectedAreaData.parkCampingTypes?.length > 0) {
+          const campingTypes = protectedAreaData.parkCampingTypes.map(
+            (campingType) => ({
+              id: campingType.documentId,
+              description: campingType.description,
+              name: campingType.name,
+              isCampingOpen: campingType.isCampingOpen,
+              isActive: campingType.isActive,
+              protectedArea: campingType.protectedArea,
+              site: campingType.site,
+              campingType: campingType.campingType,
+            }),
+          );
+
+          if (isMounted) {
+            setParkCampingTypes([...campingTypes]);
+          }
+        }
+        if (isMounted) {
+          setProtectedArea(protectedAreaData);
+          setIsLoading(false);
+          setLoadParkInfo(false);
+        }
+      } catch {
+        if (isMounted) {
+          setToError(true);
+          setError({
+            status: 500,
+            message: "Error fetching park information",
+          });
+          setIsLoading(false);
+        }
+      }
+    },
+    [cmsGet, getRegions, getSections, setError],
+  );
 
   useEffect(() => {
     let isMounted = true;
@@ -74,125 +187,13 @@ export default function ParkInfo() {
       },
     );
 
-    if (initialized && keycloak && loadParkInfo) {
-      Promise.all([
-        cmsGet(`/protected-areas?${query}`),
-        getRegions(),
-        getSections(),
-      ])
-        .then(([protectedAreas, regions, sections]) => {
-          const protectedAreaData = protectedAreas[0];
-
-          if (protectedAreaData.managementAreas?.length > 0) {
-            const managementArea = protectedAreaData.managementAreas[0];
-
-            protectedAreaData.managementAreaName =
-              managementArea.managementAreaName;
-            const region = regions.filter(
-              (r) => r.documentId === managementArea.region.documentId,
-            );
-
-            if (region.length > 0) {
-              protectedAreaData.regionName = region[0].regionName;
-            }
-            const section = sections.filter(
-              (s) => s.documentId === managementArea.section.documentId,
-            );
-
-            if (section.length > 0) {
-              protectedAreaData.sectionName = section[0].sectionName;
-            }
-          }
-          if (protectedAreaData.parkActivities?.length > 0) {
-            const activities = protectedAreaData.parkActivities.map(
-              (activity) => ({
-                id: activity.documentId,
-                description: activity.description,
-                name: activity.name,
-                isActivityOpen: activity.isActivityOpen,
-                isActive: activity.isActive,
-                protectedArea: activity.protectedArea,
-                site: activity.site,
-                activityType: activity.activityType,
-              }),
-            );
-
-            if (isMounted) {
-              setParkActivities([...activities]);
-            }
-          }
-          if (protectedAreaData.parkFacilities?.length > 0) {
-            const facilities = protectedAreaData.parkFacilities.map(
-              (facility) => ({
-                id: facility.documentId,
-                description: facility.description,
-                name: facility.name,
-                isFacilityOpen: facility.isFacilityOpen,
-                isActive: facility.isActive,
-                protectedArea: facility.protectedArea,
-                site: facility.site,
-                facilityType: facility.facilityType,
-              }),
-            );
-
-            if (isMounted) {
-              setParkFacilities([...facilities]);
-            }
-          }
-          if (protectedAreaData.parkCampingTypes?.length > 0) {
-            const campingTypes = protectedAreaData.parkCampingTypes.map(
-              (campingType) => ({
-                id: campingType.documentId,
-                description: campingType.description,
-                name: campingType.name,
-                isCampingOpen: campingType.isCampingOpen,
-                isActive: campingType.isActive,
-                protectedArea: campingType.protectedArea,
-                site: campingType.site,
-                campingType: campingType.campingType,
-              }),
-            );
-
-            if (isMounted) {
-              setParkCampingTypes([...campingTypes]);
-            }
-          }
-          if (isMounted) {
-            setProtectedArea(protectedAreaData);
-            setIsLoading(false);
-            setLoadParkInfo(false);
-          }
-        })
-        .catch(() => {
-          if (isMounted) {
-            setToError(true);
-            setError({
-              status: 500,
-              message: "Error fetching park information",
-            });
-            setIsLoading(false);
-          }
-        });
+    if (initialized && isAuthenticated && loadParkInfo) {
+      fetchParkInfo(isMounted, query);
     }
     return () => {
       isMounted = false;
     };
-  }, [
-    cmsData,
-    id,
-    initialized,
-    keycloak,
-    setCmsData,
-    setError,
-    setIsLoading,
-    loadParkInfo,
-    setProtectedArea,
-    setToError,
-    setLoadParkInfo,
-    setParkActivities,
-    setParkFacilities,
-    setParkCampingTypes,
-  ]);
+  }, [id, initialized, isAuthenticated, loadParkInfo, fetchParkInfo]);
 
   function handleTabChange(val) {
     setTabIndex(val);
@@ -249,6 +250,33 @@ export default function ParkInfo() {
     finishEditActivityDesc(activityId, true);
   }
 
+  /**
+   * Saves the updated activity data to the CMS and updates state accordingly.
+   * @param {string} activityId The ID of the activity to update.
+   * @param {Object} parkActivity The activity data to save.
+   * @param {boolean} expand Whether to expand the activity accordion after save.
+   * @returns {Promise<void>} Resolves when the activity is saved and state is updated.
+   */
+  async function saveActivityToCms(activityId, parkActivity, expand) {
+    try {
+      await cmsPut(`park-activities/${activityId}`, { data: parkActivity });
+      const currentActivities = submittingActivities.filter(
+        (a) => a !== activityId,
+      );
+
+      setSubmittingActivities([...currentActivities]);
+      finishEditActivityDesc(activityId, expand);
+      setLoadParkInfo(true);
+    } catch (error) {
+      console.error("error occurred", error);
+      setToError(true);
+      setError({
+        status: 500,
+        message: "Could not update activity",
+      });
+    }
+  }
+
   function saveActivity(activityId, expand) {
     const activities = parkActivities.filter((d) => d.id === activityId);
 
@@ -266,24 +294,7 @@ export default function ParkInfo() {
         activityType: activity.activityType?.documentId,
       };
 
-      cmsPut(`park-activities/${activityId}`, { data: parkActivity })
-        .then(() => {
-          const currentActivities = submittingActivities.filter(
-            (a) => a !== activityId,
-          );
-
-          setSubmittingActivities([...currentActivities]);
-          finishEditActivityDesc(activityId, expand);
-          setLoadParkInfo(true);
-        })
-        .catch((error) => {
-          console.error("error occurred", error);
-          setToError(true);
-          setError({
-            status: 500,
-            message: "Could not update activity",
-          });
-        });
+      saveActivityToCms(activityId, parkActivity, expand);
     }
   }
 
@@ -370,6 +381,33 @@ export default function ParkInfo() {
     finishEditFacilityDesc(facilityId, true);
   }
 
+  /**
+   * Saves the updated facility data to the CMS and updates state accordingly.
+   * @param {string} facilityId The ID of the facility to update.
+   * @param {Object} parkFacility The facility data to save.
+   * @param {boolean} expand Whether to expand the facility accordion after save.
+   * @returns {Promise<void>} Resolves when the facility is saved and state is updated.
+   */
+  async function saveFacilityToCms(facilityId, parkFacility, expand) {
+    try {
+      await cmsPut(`park-facilities/${facilityId}`, { data: parkFacility });
+      const currentFacilities = submittingFacilities.filter(
+        (f) => f !== facilityId,
+      );
+
+      setSubmittingFacilities([...currentFacilities]);
+      finishEditFacilityDesc(facilityId, expand);
+      setLoadParkInfo(true);
+    } catch (error) {
+      console.error("error occurred", error);
+      setToError(true);
+      setError({
+        status: 500,
+        message: "Could not update facility",
+      });
+    }
+  }
+
   function saveFacility(facilityId, expand) {
     const facilities = parkFacilities.filter((d) => d.id === facilityId);
 
@@ -387,24 +425,7 @@ export default function ParkInfo() {
         facilityType: facility.facilityType?.documentId,
       };
 
-      cmsPut(`park-facilities/${facilityId}`, { data: parkFacility })
-        .then(() => {
-          const currentFacilities = submittingFacilities.filter(
-            (f) => f !== facilityId,
-          );
-
-          setSubmittingFacilities([...currentFacilities]);
-          finishEditFacilityDesc(facilityId, expand);
-          setLoadParkInfo(true);
-        })
-        .catch((error) => {
-          console.error("error occurred", error);
-          setToError(true);
-          setError({
-            status: 500,
-            message: "Could not update facility",
-          });
-        });
+      saveFacilityToCms(facilityId, parkFacility, expand);
     }
   }
 
@@ -493,6 +514,35 @@ export default function ParkInfo() {
     finishEditCampingTypeDesc(campingTypeId, true);
   }
 
+  /**
+   * Saves the updated camping type data to the CMS and updates state accordingly.
+   * @param {string} campingTypeId The ID of the camping type to update.
+   * @param {Object} parkCampingType The camping type data to save.
+   * @param {boolean} expand Whether to expand the camping type accordion after save.
+   * @returns {Promise<void>} Resolves when the camping type is saved and state is updated.
+   */
+  async function saveCampingTypeToCms(campingTypeId, parkCampingType, expand) {
+    try {
+      await cmsPut(`park-camping-types/${campingTypeId}`, {
+        data: parkCampingType,
+      });
+      const currentCampingTypes = submittingCampingTypes.filter(
+        (f) => f !== campingTypeId,
+      );
+
+      setSubmittingCampingTypes([...currentCampingTypes]);
+      finishEditCampingTypeDesc(campingTypeId, expand);
+      setLoadParkInfo(true);
+    } catch (error) {
+      console.error("error occurred", error);
+      setToError(true);
+      setError({
+        status: 500,
+        message: "Could not update campingType",
+      });
+    }
+  }
+
   function saveCampingType(campingTypeId, expand) {
     const campingTypes = parkCampingTypes.filter((d) => d.id === campingTypeId);
 
@@ -510,24 +560,7 @@ export default function ParkInfo() {
         campingType: campingType.campingType?.documentId,
       };
 
-      cmsPut(`park-camping-types/${campingTypeId}`, { data: parkCampingType })
-        .then(() => {
-          const currentCampingTypes = submittingCampingTypes.filter(
-            (f) => f !== campingTypeId,
-          );
-
-          setSubmittingCampingTypes([...currentCampingTypes]);
-          finishEditCampingTypeDesc(campingTypeId, expand);
-          setLoadParkInfo(true);
-        })
-        .catch((error) => {
-          console.error("error occurred", error);
-          setToError(true);
-          setError({
-            status: 500,
-            message: "Could not update campingType",
-          });
-        });
+      saveCampingTypeToCms(campingTypeId, parkCampingType, expand);
     }
   }
 

--- a/frontend/src/router/pages/advisories/parkInfo/ParkInfo.jsx
+++ b/frontend/src/router/pages/advisories/parkInfo/ParkInfo.jsx
@@ -81,81 +81,79 @@ export default function ParkInfo() {
             protectedAreaData.sectionName = section[0].sectionName;
           }
         }
-        if (protectedAreaData.parkActivities?.length > 0) {
-          const activities = protectedAreaData.parkActivities.map(
-            (activity) => ({
-              id: activity.documentId,
-              description: activity.description,
-              name: activity.name,
-              isActivityOpen: activity.isActivityOpen,
-              isActive: activity.isActive,
-              protectedArea: activity.protectedArea,
-              site: activity.site,
-              activityType: activity.activityType,
-            }),
-          );
 
-          // Sort results alphabetically by activity type name
-          const sortedActivities = orderBy(
-            activities,
-            ["activityType.activityName"],
-            ["asc"],
-          );
+        const activities = (protectedAreaData.parkActivities || []).map(
+          (activity) => ({
+            id: activity.documentId,
+            description: activity.description,
+            name: activity.name,
+            isActivityOpen: activity.isActivityOpen,
+            isActive: activity.isActive,
+            protectedArea: activity.protectedArea,
+            site: activity.site,
+            activityType: activity.activityType,
+          }),
+        );
 
-          if (isMountedRef.current) {
-            setParkActivities([...sortedActivities]);
-          }
+        // Sort results alphabetically by activity type name
+        const sortedActivities = orderBy(
+          activities,
+          ["activityType.activityName"],
+          ["asc"],
+        );
+
+        if (isMountedRef.current) {
+          setParkActivities([...sortedActivities]);
         }
-        if (protectedAreaData.parkFacilities?.length > 0) {
-          const facilities = protectedAreaData.parkFacilities.map(
-            (facility) => ({
-              id: facility.documentId,
-              description: facility.description,
-              name: facility.name,
-              isFacilityOpen: facility.isFacilityOpen,
-              isActive: facility.isActive,
-              protectedArea: facility.protectedArea,
-              site: facility.site,
-              facilityType: facility.facilityType,
-            }),
-          );
 
-          // Sort results alphabetically by facility type name
-          const sortedFacilities = orderBy(
-            facilities,
-            ["facilityType.facilityName"],
-            ["asc"],
-          );
+        const facilities = (protectedAreaData.parkFacilities || []).map(
+          (facility) => ({
+            id: facility.documentId,
+            description: facility.description,
+            name: facility.name,
+            isFacilityOpen: facility.isFacilityOpen,
+            isActive: facility.isActive,
+            protectedArea: facility.protectedArea,
+            site: facility.site,
+            facilityType: facility.facilityType,
+          }),
+        );
 
-          if (isMountedRef.current) {
-            setParkFacilities([...sortedFacilities]);
-          }
+        // Sort results alphabetically by facility type name
+        const sortedFacilities = orderBy(
+          facilities,
+          ["facilityType.facilityName"],
+          ["asc"],
+        );
+
+        if (isMountedRef.current) {
+          setParkFacilities([...sortedFacilities]);
         }
-        if (protectedAreaData.parkCampingTypes?.length > 0) {
-          const campingTypes = protectedAreaData.parkCampingTypes.map(
-            (campingType) => ({
-              id: campingType.documentId,
-              description: campingType.description,
-              name: campingType.name,
-              isCampingOpen: campingType.isCampingOpen,
-              isActive: campingType.isActive,
-              protectedArea: campingType.protectedArea,
-              site: campingType.site,
-              campingType: campingType.campingType,
-            }),
-          );
 
-          // Sort results alphabetically by camping type name
-          const sortedCampingTypes = orderBy(
-            campingTypes,
-            ["campingType.campingTypeName"],
-            ["asc"],
-          );
+        const campingTypes = (protectedAreaData.parkCampingTypes || []).map(
+          (campingType) => ({
+            id: campingType.documentId,
+            description: campingType.description,
+            name: campingType.name,
+            isCampingOpen: campingType.isCampingOpen,
+            isActive: campingType.isActive,
+            protectedArea: campingType.protectedArea,
+            site: campingType.site,
+            campingType: campingType.campingType,
+          }),
+        );
 
-          if (isMountedRef.current) {
-            setParkCampingTypes([...sortedCampingTypes]);
-          }
+        // Sort results alphabetically by camping type name
+        const sortedCampingTypes = orderBy(
+          campingTypes,
+          ["campingType.campingTypeName"],
+          ["asc"],
+        );
+
+        if (isMountedRef.current) {
+          setParkCampingTypes([...sortedCampingTypes]);
         }
+
         if (isMountedRef.current) {
           setProtectedArea(protectedAreaData);
           setIsLoading(false);

--- a/frontend/src/router/pages/advisories/parkInfo/ParkInfo.jsx
+++ b/frontend/src/router/pages/advisories/parkInfo/ParkInfo.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useContext, useCallback } from "react";
+import { orderBy } from "lodash-es";
 import ErrorContext from "@/contexts/ErrorContext";
-import CmsDataContext from "@/contexts/CmsDataContext";
 import "./ParkInfo.css";
 import { Navigate, useParams, useNavigate } from "react-router-dom";
 import { Loader } from "@/components/advisories/shared/loader/Loader";
@@ -95,8 +95,15 @@ export default function ParkInfo() {
             }),
           );
 
+          // Sort results alphabetically by activity type name
+          const sortedActivities = orderBy(
+            activities,
+            ["activityType.activityName"],
+            ["asc"],
+          );
+
           if (isMounted) {
-            setParkActivities([...activities]);
+            setParkActivities([...sortedActivities]);
           }
         }
         if (protectedAreaData.parkFacilities?.length > 0) {
@@ -113,8 +120,15 @@ export default function ParkInfo() {
             }),
           );
 
+          // Sort results alphabetically by facility type name
+          const sortedFacilities = orderBy(
+            facilities,
+            ["facilityType.facilityName"],
+            ["asc"],
+          );
+
           if (isMounted) {
-            setParkFacilities([...facilities]);
+            setParkFacilities([...sortedFacilities]);
           }
         }
         if (protectedAreaData.parkCampingTypes?.length > 0) {
@@ -131,8 +145,15 @@ export default function ParkInfo() {
             }),
           );
 
+          // Sort results alphabetically by camping type name
+          const sortedCampingTypes = orderBy(
+            campingTypes,
+            ["campingType.campingTypeName"],
+            ["asc"],
+          );
+
           if (isMounted) {
-            setParkCampingTypes([...campingTypes]);
+            setParkCampingTypes([...sortedCampingTypes]);
           }
         }
         if (isMounted) {
@@ -176,6 +197,7 @@ export default function ParkInfo() {
           "parkCampingTypes.protectedArea",
           "parkCampingTypes.site",
         ],
+
         filters: {
           orcs: {
             $eq: `${id}`,

--- a/frontend/src/router/pages/advisories/parkInfo/ParkInfo.jsx
+++ b/frontend/src/router/pages/advisories/parkInfo/ParkInfo.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useContext, useCallback } from "react";
+import { useState, useEffect, useContext, useCallback, useRef } from "react";
 import { orderBy } from "lodash-es";
 import ErrorContext from "@/contexts/ErrorContext";
 import "./ParkInfo.css";
@@ -47,12 +47,12 @@ export default function ParkInfo() {
    * - facilities
    * - camping types
    * Handles error and loading state. Called by useEffect when dependencies change.
-   * @param {boolean} isMounted Whether the component is still mounted (prevents state updates on unmounted components).
+   * @param {{ current: boolean }} isMountedRef Ref object tracking if the component is still mounted (prevents state updates on unmounted components).
    * @param {string} query Query string for the CMS API request.
    * @returns {Promise<void>} Resolves when park info is loaded and state is updated.
    */
   const fetchParkInfo = useCallback(
-    async (isMounted, query) => {
+    async (isMountedRef, query) => {
       try {
         const [protectedAreas, regions, sections] = await Promise.all([
           cmsGet(`/protected-areas?${query}`),
@@ -102,7 +102,7 @@ export default function ParkInfo() {
             ["asc"],
           );
 
-          if (isMounted) {
+          if (isMountedRef.current) {
             setParkActivities([...sortedActivities]);
           }
         }
@@ -127,7 +127,7 @@ export default function ParkInfo() {
             ["asc"],
           );
 
-          if (isMounted) {
+          if (isMountedRef.current) {
             setParkFacilities([...sortedFacilities]);
           }
         }
@@ -152,17 +152,17 @@ export default function ParkInfo() {
             ["asc"],
           );
 
-          if (isMounted) {
+          if (isMountedRef.current) {
             setParkCampingTypes([...sortedCampingTypes]);
           }
         }
-        if (isMounted) {
+        if (isMountedRef.current) {
           setProtectedArea(protectedAreaData);
           setIsLoading(false);
           setLoadParkInfo(false);
         }
       } catch {
-        if (isMounted) {
+        if (isMountedRef.current) {
           setToError(true);
           setError({
             status: 500,
@@ -175,8 +175,10 @@ export default function ParkInfo() {
     [cmsGet, getRegions, getSections, setError],
   );
 
+  const isMountedRef = useRef(true);
+
   useEffect(() => {
-    let isMounted = true;
+    isMountedRef.current = true;
 
     const query = qs.stringify(
       {
@@ -210,10 +212,10 @@ export default function ParkInfo() {
     );
 
     if (initialized && isAuthenticated && loadParkInfo) {
-      fetchParkInfo(isMounted, query);
+      fetchParkInfo(isMountedRef, query);
     }
     return () => {
-      isMounted = false;
+      isMountedRef.current = false;
     };
   }, [id, initialized, isAuthenticated, loadParkInfo, fetchParkInfo]);
 

--- a/frontend/src/router/pages/advisories/parkInfo/ParkInfo.jsx
+++ b/frontend/src/router/pages/advisories/parkInfo/ParkInfo.jsx
@@ -5,8 +5,7 @@ import "./ParkInfo.css";
 import { Navigate, useParams, useNavigate } from "react-router-dom";
 import { Loader } from "@/components/advisories/shared/loader/Loader";
 import { useAuth } from "react-oidc-context";
-import { cmsAxios } from "@/lib/advisories/axios_config";
-import { getRegions, getSections } from "@/lib/advisories/utils/CmsDataUtil";
+import useCms from "@/hooks/useCms";
 import { Button } from "@/components/advisories/shared/button/Button";
 import { Accordion, Form, Tab, Tabs } from "react-bootstrap";
 import moment from "moment";
@@ -15,6 +14,7 @@ import HTMLArea from "@/components/advisories/base/HTMLArea/HTMLArea";
 import qs from "qs";
 
 export default function ParkInfo() {
+  const { cmsGet, cmsPut, getRegions, getSections } = useCms();
   const { setError } = useContext(ErrorContext);
   const { cmsData, setCmsData } = useContext(CmsDataContext);
   const [isLoading, setIsLoading] = useState(true);
@@ -36,7 +36,6 @@ export default function ParkInfo() {
   const auth = useAuth();
   const initialized = !auth.isLoading;
   const keycloak = auth.isAuthenticated ? auth.user : null;
-  const keycloakToken = auth.user?.access_token;
   const { id } = useParams();
   const navigate = useNavigate();
 
@@ -77,26 +76,26 @@ export default function ParkInfo() {
 
     if (initialized && keycloak && loadParkInfo) {
       Promise.all([
-        cmsAxios.get(`/protected-areas?${query}`),
-        getRegions(cmsData, setCmsData),
-        getSections(cmsData, setCmsData),
+        cmsGet(`/protected-areas?${query}`),
+        getRegions(),
+        getSections(),
       ])
-        .then((res) => {
-          const protectedAreaData = res[0].data.data[0];
+        .then(([protectedAreas, regions, sections]) => {
+          const protectedAreaData = protectedAreas[0];
 
           if (protectedAreaData.managementAreas?.length > 0) {
             const managementArea = protectedAreaData.managementAreas[0];
 
             protectedAreaData.managementAreaName =
               managementArea.managementAreaName;
-            const region = cmsData.regions.filter(
+            const region = regions.filter(
               (r) => r.documentId === managementArea.region.documentId,
             );
 
             if (region.length > 0) {
               protectedAreaData.regionName = region[0].regionName;
             }
-            const section = cmsData.sections.filter(
+            const section = sections.filter(
               (s) => s.documentId === managementArea.section.documentId,
             );
 
@@ -267,14 +266,7 @@ export default function ParkInfo() {
         activityType: activity.activityType?.documentId,
       };
 
-      cmsAxios
-        .put(
-          `park-activities/${activityId}`,
-          { data: parkActivity },
-          {
-            headers: { Authorization: `Bearer ${keycloakToken}` },
-          },
-        )
+      cmsPut(`park-activities/${activityId}`, { data: parkActivity })
         .then(() => {
           const currentActivities = submittingActivities.filter(
             (a) => a !== activityId,
@@ -395,14 +387,7 @@ export default function ParkInfo() {
         facilityType: facility.facilityType?.documentId,
       };
 
-      cmsAxios
-        .put(
-          `park-facilities/${facilityId}`,
-          { data: parkFacility },
-          {
-            headers: { Authorization: `Bearer ${keycloakToken}` },
-          },
-        )
+      cmsPut(`park-facilities/${facilityId}`, { data: parkFacility })
         .then(() => {
           const currentFacilities = submittingFacilities.filter(
             (f) => f !== facilityId,
@@ -525,14 +510,7 @@ export default function ParkInfo() {
         campingType: campingType.campingType?.documentId,
       };
 
-      cmsAxios
-        .put(
-          `park-camping-types/${campingTypeId}`,
-          { data: parkCampingType },
-          {
-            headers: { Authorization: `Bearer ${keycloakToken}` },
-          },
-        )
+      cmsPut(`park-camping-types/${campingTypeId}`, { data: parkCampingType })
         .then(() => {
           const currentCampingTypes = submittingCampingTypes.filter(
             (f) => f !== campingTypeId,

--- a/frontend/src/router/pages/advisories/parkInfo/ParkInfo.jsx
+++ b/frontend/src/router/pages/advisories/parkInfo/ParkInfo.jsx
@@ -159,7 +159,9 @@ export default function ParkInfo() {
           setIsLoading(false);
           setLoadParkInfo(false);
         }
-      } catch {
+      } catch (error) {
+        console.error("Error fetching park information", error);
+
         if (isMountedRef.current) {
           setToError(true);
           setError({


### PR DESCRIPTION
### Jira Ticket

CMS-1652

### Description
<!-- What did you change, and why? -->

When an update is made on the ParkInfo component (Activities & Facilities page), the page re-fetches the data from the CMS after the update. The most recent update was being sorted to the bottom of the result set, so the table row you changed would jump to the bottom after you clicked something. I couldn't see how to set the sort order for nested fields in the query so I've just sorted the three result sets in JS here (alphabetically by name). This keeps the sort order stable when you update the table.

I also refactored the page a bit so it uses useCms instead of the keycloak token, and I moved a bunch of the logic out of the big useEffect block into functions with async/await/try/catch for readability.

The intent was to organize the code and improve readability with a different syntax, but the logic is all the same. I'd love to react-query but that's definitely out of scope for this bug fix branch 😄 This leaves just 3 pages that directly use `cmsAxios` and `keycloakToken`.