### PR TITLE
CMS-1656: Fix show archived return

### DIFF
--- a/frontend/src/lib/advisories/utils/AdvisoryDataUtil.js
+++ b/frontend/src/lib/advisories/utils/AdvisoryDataUtil.js
@@ -7,24 +7,27 @@ const advisoryArchiveDays = 30;
 const archiveDate = moment()
   .subtract(advisoryArchiveDays, "days")
   .format("YYYY-MM-DD");
+const modifiedDate = moment().subtract(18, "months").format("YYYY-MM-DD");
 
 export function getLatestPublicAdvisoryAudits(keycloakToken, showArchived) {
-  let advisoryFilter = {};
+  const advisoryFilter = showArchived
+    ? {
+        $or: [
+          { advisoryStatus: { code: { $ne: "INA" } } },
+          {
+            updatedAt: {
+              $gt: modifiedDate,
+            },
+          },
+        ],
+      }
+    : {
+        $or: [
+          { advisoryStatus: { code: { $ne: "INA" } } },
+          { updatedAt: { $gt: archiveDate } },
+        ],
+      };
 
-  if (!showArchived) {
-    advisoryFilter = {
-      $or: [
-        { advisoryStatus: { code: { $ne: "INA" } } },
-        { updatedAt: { $gt: archiveDate } },
-      ],
-    };
-  } else {
-    const modifiedDate = moment().subtract(18, "months").format("YYYY-MM-DD");
-
-    advisoryFilter = {
-      updatedAt: { $gt: modifiedDate },
-    };
-  }
   const query = qs.stringify(
     {
       fields: [

--- a/frontend/src/lib/advisories/utils/AdvisoryDataUtil.js
+++ b/frontend/src/lib/advisories/utils/AdvisoryDataUtil.js
@@ -3,11 +3,11 @@ import moment from "moment";
 import "moment-timezone";
 import qs from "qs";
 
-const advisoryArchiveDays = 30;
-const archiveDate = moment()
-  .subtract(advisoryArchiveDays, "days")
+const standardInactiveAdvisoryWindowDays = 30;
+const standardInactiveAdvisoryCutoffDate = moment()
+  .subtract(standardInactiveAdvisoryWindowDays, "days")
   .format("YYYY-MM-DD");
-const modifiedDate = moment().subtract(18, "months").format("YYYY-MM-DD");
+const extendedInactiveAdvisoryCutoffDate = moment().subtract(18, "months").format("YYYY-MM-DD");
 
 export function getLatestPublicAdvisoryAudits(keycloakToken, showArchived) {
   const advisoryFilter = showArchived
@@ -16,7 +16,7 @@ export function getLatestPublicAdvisoryAudits(keycloakToken, showArchived) {
           { advisoryStatus: { code: { $ne: "INA" } } },
           {
             updatedAt: {
-              $gt: modifiedDate,
+              $gt: extendedInactiveAdvisoryCutoffDate,
             },
           },
         ],
@@ -24,7 +24,7 @@ export function getLatestPublicAdvisoryAudits(keycloakToken, showArchived) {
     : {
         $or: [
           { advisoryStatus: { code: { $ne: "INA" } } },
-          { updatedAt: { $gt: archiveDate } },
+          { updatedAt: { $gt: standardInactiveAdvisoryCutoffDate } },
         ],
       };
 
@@ -103,7 +103,7 @@ export function updatePublicAdvisories(publicAdvisories, managementAreas) {
 
     publicAdvisory.archived =
       publicAdvisory.advisoryStatus.code === "INA" &&
-      publicAdvisory.updatedAt < archiveDate;
+      publicAdvisory.updatedAt < standardInactiveAdvisoryCutoffDate;
 
     return publicAdvisory;
   });

--- a/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.jsx
+++ b/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.jsx
@@ -22,6 +22,7 @@ import {
   faTriangleExclamation,
   faClock,
   faCircleQuestion,
+  faFolderArrowDown,
   faPencil,
   faThumbsUp,
 } from "@fa-kit/icons/classic/solid";
@@ -184,7 +185,7 @@ export default function AdvisoryDashboard() {
     setIsLoading(true);
     setPublicAdvisories([]);
 
-    let res = null;
+    let res;
 
     try {
       res = await getLatestPublicAdvisoryAudits(
@@ -195,6 +196,7 @@ export default function AdvisoryDashboard() {
       setError({ status: 500, message: "Error loading data" });
       setToError(true);
       setIsLoading(false);
+      return;
     }
 
     const advisoryAuditRows = res?.data.data;
@@ -541,7 +543,7 @@ export default function AdvisoryDashboard() {
                   }
                 >
                   <span>
-                    <FontAwesomeIcon icon={faClock} className="inactiveIcon" />
+                    <FontAwesomeIcon icon={faFolderArrowDown} className="archivedIcon" />
                   </span>
                 </OverlayTrigger>
               )}


### PR DESCRIPTION
### Jira Ticket

CMS-1656

### Description
<!-- What did you change, and why? -->
- Added an archived icon
- Fixed lint warnings
- Fixed show archived return: the archived filter should keep all non-inactive advisories (same as default) and also include inactive advisories updated within 18 months

