### PR TITLE
CMS-1624: Wrap auth error redirect in useEffect

### DIFF
--- a/frontend/src/router/ProtectedRoute.jsx
+++ b/frontend/src/router/ProtectedRoute.jsx
@@ -68,11 +68,17 @@ export default function ProtectedRoute({ children }) {
     }
   }, [auth, hasTriedSignin, params, navigate]);
 
+  useEffect(() => {
+    if (auth.error) {
+      // If there's an error, redirect to the sign-in page
+      console.error("Authentication error:", auth.error);
+      console.error("Redirecting to sign-in page...");
+      auth.signoutRedirect();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- auth.signoutRedirect is stable; only re-run when error status changes
+  }, [auth.error]);
+
   if (auth.error) {
-    // If there's an error, redirect to the sign-in page
-    console.error("Authentication error:", auth.error);
-    console.error("Redirecting to sign-in page...");
-    auth.signoutRedirect();
     return <div>Authentication error: {auth.error?.message}</div>;
   }
 

--- a/frontend/src/router/pages/advisories/advisory/Advisory.jsx
+++ b/frontend/src/router/pages/advisories/advisory/Advisory.jsx
@@ -536,8 +536,6 @@ export default function Advisory({ mode }) {
           setEventTypes([...newEventTypes]);
           const accessStatusData = res[9];
 
-          console.log("Access Status Data:", accessStatusData);
-
           const newAccessStatuses = accessStatusData.map((a) => ({
             label: a.accessStatus,
             value: a.documentId,
@@ -1139,7 +1137,6 @@ export default function Advisory({ mode }) {
                   className="btn btn-link btn-back mt-4"
                   onClick={() => {
                     setToBack();
-                    sessionStorage.clear();
                   }}
                 >
                   <FontAwesomeIcon icon={faArrowLeft} className="me-1" />

--- a/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.jsx
+++ b/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.jsx
@@ -834,7 +834,6 @@ export default function AdvisoryDashboard() {
               label="Create a new Advisory"
               styling="bcgov-normal-yellow btn"
               onClick={() => {
-                sessionStorage.clear();
                 setToCreate(true);
               }}
             />

--- a/frontend/src/router/pages/advisories/error/Error.jsx
+++ b/frontend/src/router/pages/advisories/error/Error.jsx
@@ -95,7 +95,6 @@ export default function Error({ error }) {
               label="Home"
               styling="bcgov-normal-blue btn"
               onClick={() => {
-                sessionStorage.clear();
                 setToHome(true);
               }}
             />


### PR DESCRIPTION
CMS-1624: Remove sessionStorage.clear calls on back buttons

### Jira Ticket

CMS-1624

### Description
<!-- What did you change, and why? -->

Some minor tweaks to hopefully address some more unexpected behavior with keycloak.
- Wrap the signoutRedirect in a useEffect to prevent it from checking/firing on every render. (QA saw some weird stuff happening in Incognito windows, though I couldn't reproduce it)
- Removed calls to clear session storage when clicking some navigation buttons. The keycloak token is now stored in sessionStorage (see keycloak.js) so we probably don't want to do that. We could remove specific items from sessionStorage if we wanted to reset filters or something, but I don't think we want to do that when we navigate. Can anyone confirm?
- Also removed a console log line that got left in there 🙈 