### PR TITLE
CMS-1680: Update page size option

### DIFF
--- a/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.jsx
+++ b/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.jsx
@@ -702,6 +702,9 @@ export default function AdvisoryDashboard() {
     [urgencies, advisoryStatuses, publishedAdvisories],
   );
 
+  const totalPageSizeOption =
+    publicAdvisories.length > 50 ? [publicAdvisories.length] : [];
+
   if (toCreate) {
     return <Navigate to="/create-advisory" />;
   }
@@ -831,7 +834,7 @@ export default function AdvisoryDashboard() {
                 filtering: true,
                 search: false,
                 pageSize: 50,
-                pageSizeOptions: [25, 50, publicAdvisories.length],
+                pageSizeOptions: [25, 50, ...totalPageSizeOption],
               }}
               onFilterChange={(tableFilters) => {
                 const advisoryFilters = JSON.parse(


### PR DESCRIPTION
### Jira Ticket

CMS-1680

### Description
<!-- What did you change, and why? -->
- Issue: When there are 3 advisories after searching/filtering: `totalPageSizeOption` becomes [3, 25, 50] but it should be [25, 50]
- Fix: Display the default `totalPageSizeOption` [25, 50, total page size] or display [25, 50] if a search result returns less than 25