### PR TITLE
CMS-1616: Add server side pagination to advisory table

### DIFF
--- a/frontend/src/components/PaginationBar.jsx
+++ b/frontend/src/components/PaginationBar.jsx
@@ -41,7 +41,10 @@ export default function PaginationBar({
     return <></>;
   }
 
-  const totalPages = Math.ceil(totalItems / itemsPerPage);
+  // If "All" is selected, itemsPerPage will be -1
+  // We set totalPages to 1 to show all items on a single page
+  const totalPages =
+    itemsPerPage > 0 ? Math.ceil(totalItems / itemsPerPage) : 1;
 
   let page = currentPage;
 

--- a/frontend/src/components/PaginationControls.jsx
+++ b/frontend/src/components/PaginationControls.jsx
@@ -24,7 +24,7 @@ export default function PaginationControls({
           >
             {pageSizeOptions.map((option) => (
               <option key={option} value={option}>
-                {option}
+                {option < 0 ? "All" : option}
               </option>
             ))}
           </select>

--- a/frontend/src/components/advisories/composite/dataTable/DataTable.jsx
+++ b/frontend/src/components/advisories/composite/dataTable/DataTable.jsx
@@ -300,6 +300,18 @@ export default function DataTable(props) {
 
   const totalItems = options.totalItems ?? sortedRows.length;
 
+  // In server-side mode, the parent already sends only the current page's rows.
+  // In client-side mode, slice sortedRows to the current page/pageSize here.
+  const displayedRows = useMemo(() => {
+    if (options.serverSide || currentPageSize < 0) {
+      return sortedRows;
+    }
+
+    const start = (currentPage - 1) * currentPageSize;
+
+    return sortedRows.slice(start, start + currentPageSize);
+  }, [currentPage, currentPageSize, options.serverSide, sortedRows]);
+
   function handleSort(column, index) {
     if ((!column.field && !column.customSort) || column.sorting === false) {
       return;
@@ -482,7 +494,7 @@ export default function DataTable(props) {
                 </td>
               </tr>
             )}
-            {sortedRows.map((row, rowIndex) => {
+            {displayedRows.map((row, rowIndex) => {
               const rowKey = row.documentId || row.id || rowIndex;
               const rowProps = {};
 

--- a/frontend/src/components/advisories/composite/dataTable/DataTable.jsx
+++ b/frontend/src/components/advisories/composite/dataTable/DataTable.jsx
@@ -194,7 +194,18 @@ export default function DataTable(props) {
   const {
     columns,
     data,
-    options,
+    exportMenu,
+    filtering,
+    pageSize: pageSizeProp,
+    pageSizeOptions: pageSizeOptionsProp,
+    search,
+    serverSide,
+    totalItems: totalItemsProp,
+    currentPage: currentPageProp,
+    onPageChange,
+    onPageSizeChange: onPageSizeChangeProp,
+    onSortChange,
+    onFilterChange,
     title,
     onRowClick,
     initialFilterValues,
@@ -211,13 +222,13 @@ export default function DataTable(props) {
   const [filterValues, setFilterValues] = useState(initialFilterValues || {});
   const [sortConfig, setSortConfig] = useState(null);
   const [page, setPage] = useState(1);
-  const initialPageSize = options.pageSize || 5;
+  const initialPageSize = pageSizeProp || 5;
   const [pageSize, setPageSize] = useState(initialPageSize);
-  const hasSort = Boolean(options.onSortChange);
-  const currentPage = options.currentPage ?? page;
-  const currentPageSize = options.pageSize ?? pageSize;
+  const hasSort = Boolean(onSortChange);
+  const currentPage = currentPageProp ?? page;
+  const currentPageSize = pageSizeProp ?? pageSize;
   const pageSizeOptions = useMemo(() => {
-    const configured = options.pageSizeOptions || [5, 10, 25, 50, 100];
+    const configured = pageSizeOptionsProp || [5, 10, 25, 50, 100];
     const combined = [...configured, initialPageSize].filter(
       (value) => value !== 0,
     );
@@ -231,7 +242,7 @@ export default function DataTable(props) {
       if (right < 0) return -1;
       return left - right;
     });
-  }, [initialPageSize, options.pageSizeOptions]);
+  }, [initialPageSize, pageSizeOptionsProp]);
 
   useEffect(() => {
     setPageSize(initialPageSize);
@@ -239,12 +250,12 @@ export default function DataTable(props) {
 
   const filteredRows = useMemo(() => {
     // Skip local filtering when the parent handles it server-side
-    if (options.serverSide) {
+    if (serverSide) {
       return data;
     }
 
     return data.filter((row) => {
-      const matchesSearch = options.search
+      const matchesSearch = search
         ? rowMatchesSearch(row, visibleColumns, searchText)
         : true;
       const matchesFilters = visibleColumns.every((column, index) => {
@@ -258,14 +269,14 @@ export default function DataTable(props) {
   }, [
     data,
     filterValues,
-    options.search,
-    options.serverSide,
+    search,
+    serverSide,
     searchText,
     visibleColumns,
   ]);
 
   const sortedRows = useMemo(() => {
-    if (!sortConfig || options.serverSide) {
+    if (!sortConfig || serverSide) {
       return filteredRows;
     }
 
@@ -290,7 +301,7 @@ export default function DataTable(props) {
     });
 
     return nextRows;
-  }, [filteredRows, options.serverSide, sortConfig, visibleColumns]);
+  }, [filteredRows, serverSide, sortConfig, visibleColumns]);
 
   useEffect(() => {
     const totalPages = Math.max(1, Math.ceil(sortedRows.length / pageSize));
@@ -300,20 +311,22 @@ export default function DataTable(props) {
     }
   }, [page, pageSize, sortedRows.length]);
 
-  const totalItems = options.totalItems ?? sortedRows.length;
+  const totalItems = totalItemsProp ?? sortedRows.length;
 
   // In server-side mode, the parent already sends only the current page's rows.
   // In client-side mode, slice sortedRows to the current page/pageSize here.
   const displayedRows = useMemo(() => {
-    if (options.serverSide || currentPageSize < 0) {
+    if (serverSide || currentPageSize < 0) {
       return sortedRows;
     }
 
     const start = (currentPage - 1) * currentPageSize;
 
     return sortedRows.slice(start, start + currentPageSize);
-  }, [currentPage, currentPageSize, options.serverSide, sortedRows]);
+  }, [currentPage, currentPageSize, serverSide, sortedRows]);
 
+  // Toggles sort state for a column (asc -> desc -> unsorted),
+  // resets to page 1, and notifies the parent in server-side mode.
   function handleSort(column, index) {
     if ((!column.field && !column.customSort) || column.sorting === false) {
       return;
@@ -321,8 +334,10 @@ export default function DataTable(props) {
 
     const columnId = getColumnId(column, index);
 
+    // Determine next sort state (asc -> desc -> unsorted)
     let nextSort;
 
+    // Cycle sort direction each time the same header is clicked
     if (!sortConfig || sortConfig.columnId !== columnId) {
       nextSort = { columnId, direction: "asc" };
     } else if (sortConfig.direction === "asc") {
@@ -334,8 +349,8 @@ export default function DataTable(props) {
     setSortConfig(nextSort);
     setPage(1);
 
-    if (options.onSortChange) {
-      options.onSortChange(
+    if (onSortChange) {
+      onSortChange(
         nextSort
           ? { field: column.field, direction: nextSort.direction }
           : null,
@@ -355,8 +370,8 @@ export default function DataTable(props) {
     setFilterValues(nextFilterValues);
     setPage(1);
     // Notify parent of server-side filter change
-    if (options.onFilterChange) {
-      options.onFilterChange({ field: column.field, value });
+    if (onFilterChange) {
+      onFilterChange({ field: column.field, value });
     }
     // Pass the new values to the parent if a callback was provided
     onFilterValuesChange?.(nextFilterValues);
@@ -428,10 +443,10 @@ export default function DataTable(props) {
       ) : (
         <DefaultToolbar
           title={title}
-          searchEnabled={Boolean(options.search)}
+          searchEnabled={Boolean(search)}
           searchText={searchText}
           onSearchChange={handleSearchChange}
-          exportMenu={options.exportMenu || []}
+          exportMenu={exportMenu || []}
           exportColumns={visibleColumns}
           exportRows={sortedRows}
         />
@@ -445,7 +460,7 @@ export default function DataTable(props) {
                 const columnId = getColumnId(column, index);
                 const isSorted = sortConfig?.columnId === columnId;
                 const isSortable =
-                  (!options.serverSide || hasSort) &&
+                  (!serverSide || hasSort) &&
                   (column.field || column.customSort) &&
                   column.sorting !== false;
 
@@ -471,7 +486,7 @@ export default function DataTable(props) {
                 );
               })}
             </tr>
-            {options.filtering && (
+            {filtering && (
               <tr>
                 {visibleColumns.map((column, index) => {
                   const columnId = getColumnId(column, index);
@@ -532,8 +547,8 @@ export default function DataTable(props) {
         totalItems={totalItems}
         currentPage={currentPage}
         pageSize={currentPageSize}
-        onPageChange={options.onPageChange ?? setPage}
-        onPageSizeChange={options.onPageSizeChange ?? handlePageSizeChange}
+        onPageChange={onPageChange ?? setPage}
+        onPageSizeChange={onPageSizeChangeProp ?? handlePageSizeChange}
         pageSizeLabel="Rows per page"
         pageSizeOptions={pageSizeOptions}
       />
@@ -544,25 +559,23 @@ export default function DataTable(props) {
 DataTable.propTypes = {
   columns: PropTypes.arrayOf(PropTypes.object).isRequired,
   data: PropTypes.arrayOf(PropTypes.object).isRequired,
-  options: PropTypes.shape({
-    exportMenu: PropTypes.arrayOf(
-      PropTypes.shape({
-        label: PropTypes.string.isRequired,
-        exportFunc: PropTypes.func.isRequired,
-      }),
-    ),
-    filtering: PropTypes.bool,
-    pageSize: PropTypes.number,
-    pageSizeOptions: PropTypes.arrayOf(PropTypes.number),
-    search: PropTypes.bool,
-    serverSide: PropTypes.bool,
-    totalItems: PropTypes.number,
-    currentPage: PropTypes.number,
-    onPageChange: PropTypes.func,
-    onPageSizeChange: PropTypes.func,
-    onSortChange: PropTypes.func,
-    onFilterChange: PropTypes.func,
-  }),
+  exportMenu: PropTypes.arrayOf(
+    PropTypes.shape({
+      label: PropTypes.string.isRequired,
+      exportFunc: PropTypes.func.isRequired,
+    }),
+  ),
+  filtering: PropTypes.bool,
+  pageSize: PropTypes.number,
+  pageSizeOptions: PropTypes.arrayOf(PropTypes.number),
+  search: PropTypes.bool,
+  serverSide: PropTypes.bool,
+  totalItems: PropTypes.number,
+  currentPage: PropTypes.number,
+  onPageChange: PropTypes.func,
+  onPageSizeChange: PropTypes.func,
+  onSortChange: PropTypes.func,
+  onFilterChange: PropTypes.func,
   title: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   onRowClick: PropTypes.func,
   initialFilterValues: PropTypes.objectOf(PropTypes.string),
@@ -574,7 +587,18 @@ DataTable.propTypes = {
 };
 
 DataTable.defaultProps = {
-  options: {},
+  exportMenu: null,
+  filtering: false,
+  pageSize: null,
+  pageSizeOptions: null,
+  search: false,
+  serverSide: false,
+  totalItems: null,
+  currentPage: null,
+  onPageChange: null,
+  onPageSizeChange: null,
+  onSortChange: null,
+  onFilterChange: null,
   title: "",
   onRowClick: null,
   initialFilterValues: null,

--- a/frontend/src/components/advisories/composite/dataTable/DataTable.jsx
+++ b/frontend/src/components/advisories/composite/dataTable/DataTable.jsx
@@ -299,7 +299,6 @@ export default function DataTable(props) {
   }, [page, pageSize, sortedRows.length]);
 
   const totalItems = options.totalItems ?? sortedRows.length;
-  const paginatedRows = sortedRows;
 
   function handleSort(column, index) {
     if ((!column.field && !column.customSort) || column.sorting === false) {
@@ -308,28 +307,26 @@ export default function DataTable(props) {
 
     const columnId = getColumnId(column, index);
 
-    setSortConfig((currentSortConfig) => {
-      let nextSort;
+    let nextSort;
 
-      if (!currentSortConfig || currentSortConfig.columnId !== columnId) {
-        nextSort = { columnId, direction: "asc" };
-      } else if (currentSortConfig.direction === "asc") {
-        nextSort = { columnId, direction: "desc" };
-      } else {
-        nextSort = null;
-      }
+    if (!sortConfig || sortConfig.columnId !== columnId) {
+      nextSort = { columnId, direction: "asc" };
+    } else if (sortConfig.direction === "asc") {
+      nextSort = { columnId, direction: "desc" };
+    } else {
+      nextSort = null;
+    }
 
-      if (options.onSortChange) {
-        options.onSortChange(
-          nextSort
-            ? { field: column.field, direction: nextSort.direction }
-            : null,
-        );
-      }
-
-      return nextSort;
-    });
+    setSortConfig(nextSort);
     setPage(1);
+
+    if (options.onSortChange) {
+      options.onSortChange(
+        nextSort
+          ? { field: column.field, direction: nextSort.direction }
+          : null,
+      );
+    }
   }
 
   // Handle a change to a column filter input
@@ -475,7 +472,7 @@ export default function DataTable(props) {
             )}
           </thead>
           <tbody>
-            {paginatedRows.length === 0 && (
+            {sortedRows.length === 0 && (
               <tr>
                 <td
                   colSpan={visibleColumns.length}
@@ -485,7 +482,7 @@ export default function DataTable(props) {
                 </td>
               </tr>
             )}
-            {paginatedRows.map((row, rowIndex) => {
+            {sortedRows.map((row, rowIndex) => {
               const rowKey = row.documentId || row.id || rowIndex;
               const rowProps = {};
 

--- a/frontend/src/components/advisories/composite/dataTable/DataTable.jsx
+++ b/frontend/src/components/advisories/composite/dataTable/DataTable.jsx
@@ -213,7 +213,7 @@ export default function DataTable(props) {
   const [page, setPage] = useState(1);
   const initialPageSize = options.pageSize || 5;
   const [pageSize, setPageSize] = useState(initialPageSize);
-  const hasRemoteSort = Boolean(options.onSortChange);
+  const hasSort = Boolean(options.onSortChange);
   const currentPage = options.currentPage ?? page;
   const currentPageSize = options.pageSize ?? pageSize;
   const pageSizeOptions = useMemo(() => {
@@ -224,7 +224,8 @@ export default function DataTable(props) {
     const unique = [...new Set(combined)];
 
     return unique.sort((left, right) => {
-      if (left < 0) return 1; // negative (All) sorts to end
+      // "All" (-1) sorts to end
+      if (left < 0) return 1;
       if (right < 0) return -1;
       return left - right;
     });
@@ -433,7 +434,7 @@ export default function DataTable(props) {
                 const columnId = getColumnId(column, index);
                 const isSorted = sortConfig?.columnId === columnId;
                 const isSortable =
-                  (!options.serverSide || hasRemoteSort) &&
+                  (!options.serverSide || hasSort) &&
                   (column.field || column.customSort) &&
                   column.sorting !== false;
 

--- a/frontend/src/components/advisories/composite/dataTable/DataTable.jsx
+++ b/frontend/src/components/advisories/composite/dataTable/DataTable.jsx
@@ -213,13 +213,21 @@ export default function DataTable(props) {
   const [page, setPage] = useState(1);
   const initialPageSize = options.pageSize || 5;
   const [pageSize, setPageSize] = useState(initialPageSize);
+  const hasRemoteSort = Boolean(options.onSortChange);
+  const currentPage = options.currentPage ?? page;
+  const currentPageSize = options.pageSize ?? pageSize;
   const pageSizeOptions = useMemo(() => {
     const configured = options.pageSizeOptions || [5, 10, 25, 50, 100];
     const combined = [...configured, initialPageSize].filter(
-      (value) => value > 0,
+      (value) => value !== 0,
     );
+    const unique = [...new Set(combined)];
 
-    return [...new Set(combined)].sort((left, right) => left - right);
+    return unique.sort((left, right) => {
+      if (left < 0) return 1; // negative (All) sorts to end
+      if (right < 0) return -1;
+      return left - right;
+    });
   }, [initialPageSize, options.pageSizeOptions]);
 
   useEffect(() => {
@@ -244,7 +252,7 @@ export default function DataTable(props) {
   );
 
   const sortedRows = useMemo(() => {
-    if (!sortConfig) {
+    if (!sortConfig || options.serverSide) {
       return filteredRows;
     }
 
@@ -269,7 +277,7 @@ export default function DataTable(props) {
     });
 
     return nextRows;
-  }, [filteredRows, sortConfig, visibleColumns]);
+  }, [filteredRows, options.serverSide, sortConfig, visibleColumns]);
 
   useEffect(() => {
     const totalPages = Math.max(1, Math.ceil(sortedRows.length / pageSize));
@@ -279,11 +287,8 @@ export default function DataTable(props) {
     }
   }, [page, pageSize, sortedRows.length]);
 
-  const paginatedRows = useMemo(() => {
-    const startIndex = (page - 1) * pageSize;
-
-    return sortedRows.slice(startIndex, startIndex + pageSize);
-  }, [page, pageSize, sortedRows]);
+  const totalItems = options.totalItems ?? sortedRows.length;
+  const paginatedRows = sortedRows;
 
   function handleSort(column, index) {
     if ((!column.field && !column.customSort) || column.sorting === false) {
@@ -404,6 +409,7 @@ export default function DataTable(props) {
                 const columnId = getColumnId(column, index);
                 const isSorted = sortConfig?.columnId === columnId;
                 const isSortable =
+                  (!options.serverSide || hasRemoteSort) &&
                   (column.field || column.customSort) &&
                   column.sorting !== false;
 
@@ -487,11 +493,11 @@ export default function DataTable(props) {
       </div>
 
       <PaginationControls
-        totalItems={sortedRows.length}
-        currentPage={page}
-        pageSize={pageSize}
-        onPageChange={setPage}
-        onPageSizeChange={handlePageSizeChange}
+        totalItems={totalItems}
+        currentPage={currentPage}
+        pageSize={currentPageSize}
+        onPageChange={options.onPageChange ?? setPage}
+        onPageSizeChange={options.onPageSizeChange ?? handlePageSizeChange}
         pageSizeLabel="Rows per page"
         pageSizeOptions={pageSizeOptions}
       />
@@ -513,6 +519,12 @@ DataTable.propTypes = {
     pageSize: PropTypes.number,
     pageSizeOptions: PropTypes.arrayOf(PropTypes.number),
     search: PropTypes.bool,
+    serverSide: PropTypes.bool,
+    totalItems: PropTypes.number,
+    currentPage: PropTypes.number,
+    onPageChange: PropTypes.func,
+    onPageSizeChange: PropTypes.func,
+    onSortChange: PropTypes.func,
   }),
   title: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   onRowClick: PropTypes.func,

--- a/frontend/src/components/advisories/composite/dataTable/DataTable.jsx
+++ b/frontend/src/components/advisories/composite/dataTable/DataTable.jsx
@@ -224,7 +224,9 @@ export default function DataTable(props) {
     const unique = [...new Set(combined)];
 
     return unique.sort((left, right) => {
-      // "All" (-1) sorts to end
+      // Keep numeric page sizes ascending
+      // but force "All" (value -1) to the end
+      // so the selector reads naturally: 25, 50, All
       if (left < 0) return 1;
       if (right < 0) return -1;
       return left - right;

--- a/frontend/src/components/advisories/composite/dataTable/DataTable.jsx
+++ b/frontend/src/components/advisories/composite/dataTable/DataTable.jsx
@@ -234,22 +234,32 @@ export default function DataTable(props) {
     setPageSize(initialPageSize);
   }, [initialPageSize]);
 
-  const filteredRows = useMemo(
-    () =>
-      data.filter((row) => {
-        const matchesSearch = options.search
-          ? rowMatchesSearch(row, visibleColumns, searchText)
-          : true;
-        const matchesFilters = visibleColumns.every((column, index) => {
-          const filterValue = filterValues[getColumnId(column, index)] || "";
+  const filteredRows = useMemo(() => {
+    // Skip local filtering when the parent handles it server-side
+    if (options.serverSide) {
+      return data;
+    }
 
-          return rowMatchesFilter(row, column, filterValue);
-        });
+    return data.filter((row) => {
+      const matchesSearch = options.search
+        ? rowMatchesSearch(row, visibleColumns, searchText)
+        : true;
+      const matchesFilters = visibleColumns.every((column, index) => {
+        const filterValue = filterValues[getColumnId(column, index)] || "";
 
-        return matchesSearch && matchesFilters;
-      }),
-    [data, filterValues, options.search, searchText, visibleColumns],
-  );
+        return rowMatchesFilter(row, column, filterValue);
+      });
+
+      return matchesSearch && matchesFilters;
+    });
+  }, [
+    data,
+    filterValues,
+    options.search,
+    options.serverSide,
+    searchText,
+    visibleColumns,
+  ]);
 
   const sortedRows = useMemo(() => {
     if (!sortConfig || options.serverSide) {
@@ -298,15 +308,25 @@ export default function DataTable(props) {
     const columnId = getColumnId(column, index);
 
     setSortConfig((currentSortConfig) => {
+      let nextSort;
+
       if (!currentSortConfig || currentSortConfig.columnId !== columnId) {
-        return { columnId, direction: "asc" };
+        nextSort = { columnId, direction: "asc" };
+      } else if (currentSortConfig.direction === "asc") {
+        nextSort = { columnId, direction: "desc" };
+      } else {
+        nextSort = null;
       }
 
-      if (currentSortConfig.direction === "asc") {
-        return { columnId, direction: "desc" };
+      if (options.onSortChange) {
+        options.onSortChange(
+          nextSort
+            ? { field: column.field, direction: nextSort.direction }
+            : null,
+        );
       }
 
-      return null;
+      return nextSort;
     });
     setPage(1);
   }
@@ -322,6 +342,10 @@ export default function DataTable(props) {
     // always update local state for UI
     setFilterValues(nextFilterValues);
     setPage(1);
+    // Notify parent of server-side filter change
+    if (options.onFilterChange) {
+      options.onFilterChange({ field: column.field, value });
+    }
     // Pass the new values to the parent if a callback was provided
     onFilterValuesChange?.(nextFilterValues);
   }
@@ -525,6 +549,7 @@ DataTable.propTypes = {
     onPageChange: PropTypes.func,
     onPageSizeChange: PropTypes.func,
     onSortChange: PropTypes.func,
+    onFilterChange: PropTypes.func,
   }),
   title: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   onRowClick: PropTypes.func,

--- a/frontend/src/hooks/useCms.js
+++ b/frontend/src/hooks/useCms.js
@@ -68,6 +68,19 @@ export default function useCms() {
     [withAuthorization],
   );
 
+  /**
+   * Get full response payload including meta.pagination.
+   * Use this instead of cmsGet when you need pagination metadata.
+   */
+  const cmsGetRaw = useCallback(
+    async (url, config = {}) => {
+      const response = await cmsAxios.get(url, withAuthorization(config));
+
+      return response.data;
+    },
+    [withAuthorization],
+  );
+
   const cmsPost = useCallback(
     async (url, data, config = {}) => {
       const response = await cmsAxios.post(
@@ -264,6 +277,7 @@ export default function useCms() {
   return {
     calculateIsStatHoliday,
     cmsGet,
+    cmsGetRaw,
     cmsPost,
     cmsPut,
     getProtectedAreas,

--- a/frontend/src/hooks/useCms.js
+++ b/frontend/src/hooks/useCms.js
@@ -63,21 +63,21 @@ export default function useCms() {
    * Performs a GET request to the CMS and returns the nested data at the provided `path`.
    * @param {string} url CMS endpoint to fetch
    * @param {Object} [config={}] axios.get request config
-   * @param {string|Array} [path="data"] lodash.get path to the nested data in the response
-   * @returns {Promise<any>} The nested data at the provided path in the CMS response
+   * @param {string|Array} [path="data"] lodash.get path inside the CMS response body
+   * @returns {Promise<any>} The nested data at the provided path in the CMS response body
    */
   const cmsGet = useCallback(
-    async (url, config = {}, path = "data.data") => {
+    async (url, config = {}, path = "data") => {
       const response = await cmsAxios.get(url, withAuthorization(config));
 
-      // If an empty path is provided, return the whole response data
+      // If an empty path is provided, return the full CMS response body
       if (path.length === 0) {
         return response.data;
       }
 
-      // Default to Strapi's usual response.data.data shape,
-      // but allow callers to request a different path (e.g. response.data when meta is needed)
-      return get(response, path) ?? response.data;
+      // Default to Strapi's usual data path,
+      // but allow callers to request a different CMS response path such as meta.pagination
+      return get(response.data, path);
     },
     [withAuthorization],
   );
@@ -126,15 +126,16 @@ export default function useCms() {
    * Returns cached CMS data if available, or fetches it from the CMS and caches the result.
    * @param {string} key Cache key in CmsDataContext
    * @param {string} url CMS endpoint to fetch
+   * @param {string|Array} [path="data"] lodash.get path inside the CMS response body
    * @returns {Promise<any>} The value from the CMS or the CmsDataContext cache
    */
   const fetchCached = useCallback(
-    async (key, url) => {
+    async (key, url, path = "data") => {
       if (cmsData[key]) {
         return cmsData[key];
       }
 
-      const payload = await cmsGet(url);
+      const payload = await cmsGet(url, {}, path);
 
       return storeResult(key, payload);
     },
@@ -144,7 +145,8 @@ export default function useCms() {
   // Metadata getters using fetchCached so each endpoint API is hit only once per session.
 
   const getProtectedAreas = useCallback(
-    () => fetchCached("protectedAreas", "/protected-areas/items"),
+    // This custom endpoint returns an array at the response root, not under data.
+    () => fetchCached("protectedAreas", "/protected-areas/items", ""),
     [fetchCached],
   );
 

--- a/frontend/src/hooks/useCms.js
+++ b/frontend/src/hooks/useCms.js
@@ -1,5 +1,6 @@
 import { useCallback, useContext, useEffect, useRef } from "react";
 import qs from "qs";
+import get from "lodash-es/get";
 import { useAuth } from "react-oidc-context";
 import { cmsAxios } from "@/lib/advisories/axios_config";
 import CmsDataContext from "@/contexts/CmsDataContext";
@@ -58,25 +59,25 @@ export default function useCms() {
 
   // Authenticated wrappers around cmsAxios methods
 
-  const cmsGet = useCallback(
-    async (url, config = {}) => {
-      const response = await cmsAxios.get(url, withAuthorization(config));
-
-      // Read the Axios response payload and strip the extra Strapi "data" wrapper if it exists.
-      return response.data?.data ?? response.data;
-    },
-    [withAuthorization],
-  );
-
   /**
-   * Get full response payload including meta.pagination.
-   * Use this instead of cmsGet when you need pagination metadata.
+   * Performs a GET request to the CMS and returns the nested data at the provided `path`.
+   * @param {string} url CMS endpoint to fetch
+   * @param {Object} [config={}] axios.get request config
+   * @param {string|Array} [path="data"] lodash.get path to the nested data in the response
+   * @returns {Promise<any>} The nested data at the provided path in the CMS response
    */
-  const cmsGetRaw = useCallback(
-    async (url, config = {}) => {
+  const cmsGet = useCallback(
+    async (url, config = {}, path = "data.data") => {
       const response = await cmsAxios.get(url, withAuthorization(config));
 
-      return response.data;
+      // If an empty path is provided, return the whole response data
+      if (path.length === 0) {
+        return response.data;
+      }
+
+      // Default to Strapi's usual response.data.data shape,
+      // but allow callers to request a different path (e.g. response.data when meta is needed)
+      return get(response, path) ?? response.data;
     },
     [withAuthorization],
   );
@@ -277,7 +278,6 @@ export default function useCms() {
   return {
     calculateIsStatHoliday,
     cmsGet,
-    cmsGetRaw,
     cmsPost,
     cmsPut,
     getProtectedAreas,

--- a/frontend/src/lib/advisories/utils/AdvisoryDashboardQuery.js
+++ b/frontend/src/lib/advisories/utils/AdvisoryDashboardQuery.js
@@ -8,6 +8,46 @@ function toIsoDateFilter(value) {
 }
 
 /**
+ * Maps a DataTable column field to the Strapi $and filter builder.
+ */
+const COLUMN_FILTERS = [
+  {
+    key: "urgency.urgency",
+    build: (value) => ({ urgency: { urgency: { $eq: value } } }),
+  },
+  {
+    key: "advisoryStatus.advisoryStatus",
+    build: (value) => ({ advisoryStatus: { advisoryStatus: { $eq: value } } }),
+  },
+  {
+    key: "advisoryDate",
+    build: (value) => ({ advisoryDate: { $containsi: toIsoDateFilter(value) } }),
+  },
+  {
+    key: "endDate",
+    build: (value) => ({ endDate: { $containsi: toIsoDateFilter(value) } }),
+  },
+  {
+    key: "expiryDate",
+    build: (value) => ({ expiryDate: { $containsi: toIsoDateFilter(value) } }),
+  },
+  {
+    key: "title",
+    build: (value) => ({ title: { $containsi: value } }),
+  },
+  {
+    key: "eventType.eventType",
+    build: (value) => ({ eventType: { eventType: { $containsi: value } } }),
+  },
+  {
+    key: "associatedParks",
+    build: (value) => ({
+      protectedAreas: { protectedAreaName: { $containsi: value } },
+    }),
+  },
+];
+
+/**
  * Builds an array of filters
  * @param {Object} tableFilterValues Column filter values keyed by column field name
  * @param {number} selectedRegionId Selected region id (0 = none)
@@ -23,66 +63,10 @@ export function buildFilter(
 ) {
   const filters = [];
 
-  if (tableFilterValues["urgency.urgency"]) {
-    filters.push({
-      urgency: { urgency: { $eq: tableFilterValues["urgency.urgency"] } },
-    });
-  }
-
-  if (tableFilterValues["advisoryStatus.advisoryStatus"]) {
-    filters.push({
-      advisoryStatus: {
-        advisoryStatus: {
-          $eq: tableFilterValues["advisoryStatus.advisoryStatus"],
-        },
-      },
-    });
-  }
-
-  if (tableFilterValues.advisoryDate) {
-    filters.push({
-      advisoryDate: {
-        $containsi: toIsoDateFilter(tableFilterValues.advisoryDate),
-      },
-    });
-  }
-
-  if (tableFilterValues.endDate) {
-    filters.push({
-      endDate: { $containsi: toIsoDateFilter(tableFilterValues.endDate) },
-    });
-  }
-
-  if (tableFilterValues.expiryDate) {
-    filters.push({
-      expiryDate: { $containsi: toIsoDateFilter(tableFilterValues.expiryDate) },
-    });
-  }
-
-  if (tableFilterValues.title) {
-    filters.push({
-      title: { $containsi: tableFilterValues.title },
-    });
-  }
-
-  if (tableFilterValues["eventType.eventType"]) {
-    filters.push({
-      eventType: {
-        eventType: {
-          $containsi: tableFilterValues["eventType.eventType"],
-        },
-      },
-    });
-  }
-
-  if (tableFilterValues.associatedParks) {
-    filters.push({
-      protectedAreas: {
-        protectedAreaName: {
-          $containsi: tableFilterValues.associatedParks,
-        },
-      },
-    });
+  for (const { key, build } of COLUMN_FILTERS) {
+    if (tableFilterValues[key]) {
+      filters.push(build(tableFilterValues[key]));
+    }
   }
 
   if (selectedRegionId) {

--- a/frontend/src/lib/advisories/utils/AdvisoryDashboardQuery.js
+++ b/frontend/src/lib/advisories/utils/AdvisoryDashboardQuery.js
@@ -21,7 +21,9 @@ const COLUMN_FILTERS = [
   },
   {
     key: "advisoryDate",
-    build: (value) => ({ advisoryDate: { $containsi: toIsoDateFilter(value) } }),
+    build: (value) => ({
+      advisoryDate: { $containsi: toIsoDateFilter(value) },
+    }),
   },
   {
     key: "endDate",
@@ -91,11 +93,16 @@ export function buildFilter(
 }
 
 /**
- * Maps a DataTable column field to the Strapi sort field.
+ * Maps a DataTable column field to Strapi sort fields.
  * Some columns display a name string but should sort by a numeric sequence field.
+ * Array values send multiple sort keys (useful when a column can hold different relation types).
  */
 const SORT_FIELD_MAP = {
   "urgency.urgency": "urgency.sequence",
+  associatedParks: [
+    "protectedAreas.protectedAreaName",
+    "recreationResources.resourceName",
+  ],
 };
 
 /**
@@ -105,9 +112,11 @@ const SORT_FIELD_MAP = {
  */
 export function buildSort(sortConfig) {
   if (sortConfig) {
-    const field = SORT_FIELD_MAP[sortConfig.field] ?? sortConfig.field;
+    const mapped = SORT_FIELD_MAP[sortConfig.field] ?? sortConfig.field;
+    const fields = Array.isArray(mapped) ? mapped : [mapped];
+    const direction = sortConfig.direction.toUpperCase();
 
-    return [`${field}:${sortConfig.direction.toUpperCase()}`];
+    return fields.map((field) => `${field}:${direction}`);
   }
 
   return ["advisoryDate:DESC"];

--- a/frontend/src/lib/advisories/utils/AdvisoryDashboardQuery.js
+++ b/frontend/src/lib/advisories/utils/AdvisoryDashboardQuery.js
@@ -44,7 +44,10 @@ const COLUMN_FILTERS = [
   {
     key: "associatedParks",
     build: (value) => ({
-      protectedAreas: { protectedAreaName: { $containsi: value } },
+      $or: [
+        { protectedAreas: { protectedAreaName: { $containsi: value } } },
+        { recreationResources: { resourceName: { $containsi: value } } },
+      ],
     }),
   },
 ];

--- a/frontend/src/lib/advisories/utils/AdvisoryDashboardQuery.js
+++ b/frontend/src/lib/advisories/utils/AdvisoryDashboardQuery.js
@@ -1,0 +1,120 @@
+/**
+ * Converts a date string from display format (YYYY/MM/DD) to ISO format (YYYY-MM-DD)
+ * @param {string} value Date string in display format
+ * @returns {string} Date string with slashes replaced by dashes
+ */
+function toIsoDateFilter(value) {
+  return value.replace(/\//gu, "-");
+}
+
+/**
+ * Builds an array of filters
+ * @param {Object} tableFilterValues Column filter values keyed by column field name
+ * @param {number} selectedRegionId Selected region id (0 = none)
+ * @param {string|number} selectedParkId Selected park documentId (0 = none)
+ * @param {Array} protectedAreas Full list of protected areas (used to resolve orcs from documentId)
+ * @returns {Array} Array of Strapi filters
+ */
+export function buildFilter(
+  tableFilterValues,
+  selectedRegionId,
+  selectedParkId,
+  protectedAreas,
+) {
+  const filters = [];
+
+  if (tableFilterValues["urgency.urgency"]) {
+    filters.push({
+      urgency: { urgency: { $eq: tableFilterValues["urgency.urgency"] } },
+    });
+  }
+
+  if (tableFilterValues["advisoryStatus.advisoryStatus"]) {
+    filters.push({
+      advisoryStatus: {
+        advisoryStatus: {
+          $eq: tableFilterValues["advisoryStatus.advisoryStatus"],
+        },
+      },
+    });
+  }
+
+  if (tableFilterValues.advisoryDate) {
+    filters.push({
+      advisoryDate: {
+        $containsi: toIsoDateFilter(tableFilterValues.advisoryDate),
+      },
+    });
+  }
+
+  if (tableFilterValues.endDate) {
+    filters.push({
+      endDate: { $containsi: toIsoDateFilter(tableFilterValues.endDate) },
+    });
+  }
+
+  if (tableFilterValues.expiryDate) {
+    filters.push({
+      expiryDate: { $containsi: toIsoDateFilter(tableFilterValues.expiryDate) },
+    });
+  }
+
+  if (tableFilterValues.title) {
+    filters.push({
+      title: { $containsi: tableFilterValues.title },
+    });
+  }
+
+  if (tableFilterValues["eventType.eventType"]) {
+    filters.push({
+      eventType: {
+        eventType: {
+          $containsi: tableFilterValues["eventType.eventType"],
+        },
+      },
+    });
+  }
+
+  if (tableFilterValues.associatedParks) {
+    filters.push({
+      protectedAreas: {
+        protectedAreaName: {
+          $containsi: tableFilterValues.associatedParks,
+        },
+      },
+    });
+  }
+
+  if (selectedRegionId) {
+    filters.push({
+      regions: { id: { $eq: selectedRegionId } },
+    });
+  }
+
+  if (selectedParkId && selectedParkId !== -1) {
+    const park = protectedAreas.find(
+      (protectedArea) => protectedArea.documentId === selectedParkId,
+    );
+
+    if (park) {
+      filters.push({
+        protectedAreas: { orcs: { $eq: park.orcs } },
+      });
+    }
+  }
+
+  return filters;
+}
+
+/**
+ * Builds an array of sorts
+ * @param {{ field: string, direction: "asc"|"desc" } | null} sortConfig Current sort state (null = default)
+ * @returns {string[]} Array of Strapi sorts
+ */
+export function buildSort(sortConfig) {
+  if (sortConfig) {
+    return [`${sortConfig.field}:${sortConfig.direction.toUpperCase()}`];
+  }
+
+  return ["advisoryDate:DESC"];
+}

--- a/frontend/src/lib/advisories/utils/AdvisoryDashboardQuery.js
+++ b/frontend/src/lib/advisories/utils/AdvisoryDashboardQuery.js
@@ -107,13 +107,23 @@ export function buildFilter(
 }
 
 /**
+ * Maps a DataTable column field to the Strapi sort field.
+ * Some columns display a name string but should sort by a numeric sequence field.
+ */
+const SORT_FIELD_MAP = {
+  "urgency.urgency": "urgency.sequence",
+};
+
+/**
  * Builds an array of sorts
  * @param {{ field: string, direction: "asc"|"desc" } | null} sortConfig Current sort state (null = default)
  * @returns {string[]} Array of Strapi sorts
  */
 export function buildSort(sortConfig) {
   if (sortConfig) {
-    return [`${sortConfig.field}:${sortConfig.direction.toUpperCase()}`];
+    const field = SORT_FIELD_MAP[sortConfig.field] ?? sortConfig.field;
+
+    return [`${field}:${sortConfig.direction.toUpperCase()}`];
   }
 
   return ["advisoryDate:DESC"];

--- a/frontend/src/lib/advisories/utils/AdvisoryDataUtil.js
+++ b/frontend/src/lib/advisories/utils/AdvisoryDataUtil.js
@@ -17,9 +17,11 @@ export function updatePublicAdvisories(publicAdvisories, managementAreas) {
 
   return publicAdvisories.map((publicAdvisory) => {
     publicAdvisory.expired = publicAdvisory.expiryDate < today ? "Y" : "N";
+    // Display associated parks/regions, or rec resource name if no parks/regions
     publicAdvisory.associatedParks =
       publicAdvisory.protectedAreas.map((p) => p.protectedAreaName).join(", ") +
-      publicAdvisory.regions.map((r) => r.regionName).join(", ");
+        publicAdvisory.regions.map((r) => r.regionName).join(", ") ||
+      publicAdvisory.recreationResources.map((r) => r.resourceName).join(", ");
 
     let regionsWithParkCount = [];
 

--- a/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.jsx
+++ b/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.jsx
@@ -7,7 +7,6 @@ import {
 import qs from "qs";
 import { Navigate, useNavigate } from "react-router-dom";
 import ErrorContext from "@/contexts/ErrorContext";
-import CmsDataContext from "@/contexts/CmsDataContext";
 import useCms from "@/hooks/useCms";
 import "./AdvisoryDashboard.scss";
 import { Button } from "@/components/advisories/shared/button/Button";
@@ -49,8 +48,10 @@ function getPageFilterValue(storedFilters, filterName, defaultValue = 0) {
 }
 
 export default function AdvisoryDashboard() {
+  const ALL_PAGE_SIZE = -1;
+  const DEFAULT_PAGE_SIZE = 50;
+
   const { setError } = useContext(ErrorContext);
-  const { cmsData } = useContext(CmsDataContext);
   const navigate = useNavigate();
   const {
     getRegions,
@@ -59,6 +60,7 @@ export default function AdvisoryDashboard() {
     getAdvisoryStatuses,
     getUrgencies,
     cmsGet,
+    cmsGetRaw,
   } = useCms();
 
   const [toError, setToError] = useState(false);
@@ -79,6 +81,10 @@ export default function AdvisoryDashboard() {
   const [originalProtectedAreas, setOriginalProtectedAreas] = useState([]);
   const [advisoryStatuses, setAdvisoryStatuses] = useState([]);
   const [urgencies, setUrgencies] = useState([]);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE);
+  const [totalPublicAdvisories, setTotalPublicAdvisories] = useState(0);
+  const [isCmsDataLoaded, setIsCmsDataLoaded] = useState(false);
 
   const defaultPageFilters = [
     { filterName: "region", filterValue: "", type: "page" },
@@ -91,6 +97,7 @@ export default function AdvisoryDashboard() {
     "advisoryFilters",
     defaultPageFilters,
   );
+  const [initialStoredFilters] = useState(() => storedFilters || []);
 
   // Load table filter values from the latest storedFilters
   const initialTableFilterValues = useMemo(() => {
@@ -124,98 +131,35 @@ export default function AdvisoryDashboard() {
     });
   }, 75);
 
-  /**
-   * Fetches the latest public advisory audits from the CMS API.
-   *
-   * - If showArchived is false, returns advisories that are not inactive (INA) or have been updated in the last 30 days.
-   * - If showArchived is true, returns advisories updated in the last 18 months (for archive view).
-   * @param {boolean} showArchived Whether to include archived advisories (18 months) or only recent (30 days)
-   * @returns {Promise<Array>} Array of advisory audit objects from the CMS
-   */
-  async function fetchLatestPublicAdvisoryAudits(showArchived) {
-    // Number of days to keep non-archived advisories
-    const standardInactiveAdvisoryWindowDays = 30;
-
-    // Calculate the cutoff date for recent advisories
-    const standardInactiveAdvisoryCutoffDate = moment()
-      .subtract(standardInactiveAdvisoryWindowDays, "days")
-      .format("YYYY-MM-DD");
-    const extendedInactiveAdvisoryCutoffDate = moment()
-      .subtract(18, "months")
-      .format("YYYY-MM-DD");
-
-    const advisoryFilter = showArchived
-      ? {
-          $or: [
-            { advisoryStatus: { code: { $ne: "INA" } } },
-            {
-              updatedAt: {
-                $gt: extendedInactiveAdvisoryCutoffDate,
-              },
-            },
-          ],
-        }
-      : {
-          $or: [
-            { advisoryStatus: { code: { $ne: "INA" } } },
-            { updatedAt: { $gt: standardInactiveAdvisoryCutoffDate } },
-          ],
-        };
-
-    const query = qs.stringify(
-      {
-        fields: [
-          "advisoryNumber",
-          "advisoryDate",
-          "title",
-          "effectiveDate",
-          "endDate",
-          "expiryDate",
-          "updatedAt",
-        ],
-        // Populate related entities with selected fields
-        populate: {
-          protectedAreas: {
-            fields: ["orcs", "protectedAreaName"],
-          },
-          advisoryStatus: {
-            fields: ["advisoryStatus", "code"],
-          },
-          eventType: {
-            fields: ["eventType"],
-          },
-          urgency: {
-            fields: ["urgency"],
-          },
-          regions: {
-            fields: ["regionName"],
-          },
-        },
-        // Filter for latest revision and by archive/active status
-        filters: {
-          $and: [{ isLatestRevision: true }, advisoryFilter],
-        },
-        // Large limit to fetch all advisories
-        pagination: {
-          limit: 2000,
-        },
-        // Sort by most recent advisory date
-        sort: ["advisoryDate:DESC"],
-      },
-      {
-        encodeValuesOnly: true,
-      },
-    );
-
-    // Fetch advisory audits data from the CMS with the constructed query
-    return await cmsGet(`/public-advisory-audits?${query}`);
-  }
-
   // Persist showArchived in sessionStorage
   const [showArchived, setShowArchived] = useSessionStorage(
     "showArchived",
     false,
   );
+
+  function filterFormattedDate(filterDate, rowData, column) {
+    const value = rowData[column.field];
+
+    if (!filterDate) {
+      return true;
+    }
+    if (!value) {
+      return false;
+    }
+
+    return moment(value)
+      .format("YYYY/MM/DD")
+      .toLowerCase()
+      .includes(filterDate.toLowerCase());
+  }
+
+  function renderCountBadge(label) {
+    return (
+      <Badge pill bg="light" text="dark" className="park-count-badge">
+        {label}
+      </Badge>
+    );
+  }
 
   function removeDuplicatesById(arr) {
     return arr.filter(
@@ -234,6 +178,7 @@ export default function AdvisoryDashboard() {
 
       advisories.forEach((obj) => {
         if (
+          currentParkObj &&
           obj.protectedAreas.some(
             (park) => park.documentId === currentParkObj.documentId,
           )
@@ -290,141 +235,63 @@ export default function AdvisoryDashboard() {
     }
   }
 
-  async function toggleArchivedAdvisories(shouldShowArchived) {
-    setShowArchived(shouldShowArchived);
-    setIsLoading(true);
-    setPublicAdvisories([]);
-
-    try {
-      const advisoryAuditRows =
-        await fetchLatestPublicAdvisoryAudits(shouldShowArchived);
-      const updatedPublicAdvisories = updatePublicAdvisories(
-        advisoryAuditRows,
-        cmsData.managementAreas,
-      );
-
-      setPublicAdvisories(updatedPublicAdvisories);
-      setOriginalPublicAdvisories(updatedPublicAdvisories);
-      setIsLoading(false);
-    } catch {
-      setError({ status: 500, message: "Error loading data" });
-      setToError(true);
-      setIsLoading(false);
-    }
-  }
-
-  function filterFormattedDate(filterDate, rowData, column) {
-    const value = rowData[column.field];
-
-    if (!filterDate) {
-      return true;
-    }
-    if (!value) {
-      return false;
-    }
-
-    return moment(value)
-      .format("YYYY/MM/DD")
-      .toLowerCase()
-      .includes(filterDate.toLowerCase());
-  }
-
-  function renderCountBadge(label) {
-    return (
-      <Badge pill bg="light" text="dark" className="park-count-badge">
-        {label}
-      </Badge>
-    );
-  }
-
-  useEffect(() => {
-    filterAdvisoriesByRegionId(selectedRegionId);
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- Region filtering intentionally derives from the selected region id and the base advisory list.
-  }, [selectedRegionId, originalPublicAdvisories]);
-
-  useEffect(() => {
-    if (selectedParkId !== -1) {
-      filterAdvisoriesByParkId(selectedParkId);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- Park filtering intentionally derives from the selected park id and the region-scoped advisory list.
-  }, [selectedParkId, regionalPublicAdvisories]);
-
+  // Load management areas, advisory statuses, urgencies, and published advisories once on mount.
   useEffect(() => {
     let isMounted = true;
 
-    async function loadCurrentPublishedAdvisories() {
-      try {
-        // Fetch advisory statuses and urgencies for filter options and table icons
-        const [fetchedAdvisoryStatuses, fetchedUrgencies] = await Promise.all([
-          getAdvisoryStatuses(),
-          getUrgencies(),
-        ]);
-
-        setAdvisoryStatuses(fetchedAdvisoryStatuses);
-        setUrgencies(fetchedUrgencies);
-
-        if (fetchedAdvisoryStatuses) {
-          const publishedStatus = fetchedAdvisoryStatuses.filter(
-            (status) => status.code === "PUB",
-          );
-
-          if (publishedStatus?.length > 0) {
-            // Fetch advisories with status PUB
-            const result = await cmsGet(
-              `/public-advisories?filters[advisoryStatus][code]=PUB&fields[0]=advisoryNumber&pagination[limit]=-1&sort=createdAt:DESC`,
-            );
-
-            const currentPublishedAdvisories = result.map(
-              (advisory) => advisory.advisoryNumber,
-            );
-
-            setPublishedAdvisories(currentPublishedAdvisories);
-          }
-        }
-      } catch (error) {
-        console.error("Error fetching published advisories:", error);
-        setHasErrors(true);
-        setError({
-          status: 500,
-          message: "Error loading published advisories.",
-        });
-      }
-    }
-
-    async function fetchData() {
-      setIsLoading(true);
-
+    async function loadDashboardContext() {
       try {
         const [
           regionsData,
           managementAreasData,
           protectedAreasData,
-          advisoryAuditRows,
+          fetchedAdvisoryStatuses,
+          fetchedUrgencies,
         ] = await Promise.all([
           getRegions(),
           getManagementAreas(),
           getProtectedAreas(),
-          fetchLatestPublicAdvisoryAudits(showArchived),
+          getAdvisoryStatuses(),
+          getUrgencies(),
         ]);
 
-        // Public Advisories
-        const updatedPublicAdvisories = updatePublicAdvisories(
-          advisoryAuditRows,
-          managementAreasData,
-        );
+        if (!isMounted) return;
+
+        setRegions(regionsData);
+        setManagementAreas(managementAreasData);
+        setProtectedAreas(protectedAreasData);
+        setOriginalProtectedAreas(protectedAreasData);
+
+        // Fetch advisory statuses and urgencies for filter options and table icons
+        setAdvisoryStatuses(fetchedAdvisoryStatuses);
+        setUrgencies(fetchedUrgencies);
+
+        // Fetch the list of advisory numbers that currently have a live PUB version
+        if (fetchedAdvisoryStatuses?.length > 0) {
+          const publishedStatus = fetchedAdvisoryStatuses.filter(
+            (status) => status.code === "PUB",
+          );
+
+          if (publishedStatus?.length > 0) {
+            try {
+              const result = await cmsGet(
+                `/public-advisories?filters[advisoryStatus][code]=PUB&fields[0]=advisoryNumber&pagination[limit]=-1&sort=createdAt:DESC`,
+              );
+
+              if (isMounted) {
+                setPublishedAdvisories(
+                  result.map((advisory) => advisory.advisoryNumber),
+                );
+              }
+            } catch (error) {
+              console.error("Error fetching published advisories:", error);
+            }
+          }
+        }
 
         if (isMounted) {
-          // Published Advisories
-          loadCurrentPublishedAdvisories();
-          setRegions([...regionsData]);
-          setManagementAreas([...managementAreasData]);
-          setProtectedAreas([...protectedAreasData]);
-          setOriginalProtectedAreas([...protectedAreasData]);
-          setPublicAdvisories(updatedPublicAdvisories);
-          setOriginalPublicAdvisories(updatedPublicAdvisories);
-
           // Preserve filters
-          const regionId = getPageFilterValue(storedFilters || [], "region");
+          const regionId = getPageFilterValue(initialStoredFilters, "region");
 
           if (regionId) {
             const region = regionsData.find((r) => r.id === regionId);
@@ -438,7 +305,7 @@ export default function AdvisoryDashboard() {
             }
           }
 
-          const parkId = getPageFilterValue(storedFilters || [], "park");
+          const parkId = getPageFilterValue(initialStoredFilters, "park");
 
           if (parkId) {
             const park = protectedAreasData.find(
@@ -453,9 +320,125 @@ export default function AdvisoryDashboard() {
               });
             }
           }
+          setIsCmsDataLoaded(true);
         }
       } catch (error) {
-        console.error("Error fetching data:", error);
+        console.error("Error loading dashboard context:", error);
+        setHasErrors(true);
+        setError({ status: 500, message: "Error loading data." });
+      }
+    }
+
+    loadDashboardContext();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [
+    cmsGet,
+    getAdvisoryStatuses,
+    getManagementAreas,
+    getProtectedAreas,
+    getRegions,
+    getUrgencies,
+    initialStoredFilters,
+    setError,
+  ]);
+
+  useEffect(() => {
+    filterAdvisoriesByRegionId(selectedRegionId);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- Region filtering intentionally derives from the selected region id and the current page of advisories.
+  }, [selectedRegionId, originalPublicAdvisories]);
+
+  useEffect(() => {
+    if (selectedParkId !== -1) {
+      filterAdvisoriesByParkId(selectedParkId);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- Park filtering intentionally derives from the selected park id and the region-scoped advisory list.
+  }, [selectedParkId, regionalPublicAdvisories]);
+
+  // Fetch one page of advisories whenever page, pageSize, or showArchived changes.
+  useEffect(() => {
+    let isMounted = true;
+
+    async function fetchAdvisories() {
+      setIsLoading(true);
+      setPublicAdvisories([]);
+
+      try {
+        const standardCutoffDate = moment()
+          .subtract(30, "days")
+          .format("YYYY-MM-DD");
+        const extendedCutoffDate = moment()
+          .subtract(18, "months")
+          .format("YYYY-MM-DD");
+
+        const advisoryFilter = showArchived
+          ? {
+              $or: [
+                { advisoryStatus: { code: { $ne: "INA" } } },
+                { updatedAt: { $gt: extendedCutoffDate } },
+              ],
+            }
+          : {
+              $or: [
+                { advisoryStatus: { code: { $ne: "INA" } } },
+                { updatedAt: { $gt: standardCutoffDate } },
+              ],
+            };
+
+        const pagination =
+          pageSize < 0
+            ? {
+                page: 1,
+                pageSize: Math.max(totalPublicAdvisories, DEFAULT_PAGE_SIZE),
+              }
+            : { page: currentPage, pageSize };
+
+        const query = qs.stringify(
+          {
+            fields: [
+              "advisoryNumber",
+              "advisoryDate",
+              "title",
+              "effectiveDate",
+              "endDate",
+              "expiryDate",
+              "updatedAt",
+            ],
+            populate: {
+              protectedAreas: { fields: ["orcs", "protectedAreaName"] },
+              advisoryStatus: { fields: ["advisoryStatus", "code"] },
+              eventType: { fields: ["eventType"] },
+              urgency: { fields: ["urgency"] },
+              regions: { fields: ["regionName"] },
+            },
+            filters: {
+              $and: [{ isLatestRevision: true }, advisoryFilter],
+            },
+            pagination,
+            sort: ["advisoryDate:DESC"],
+          },
+          { encodeValuesOnly: true },
+        );
+
+        const result = await cmsGetRaw(`/public-advisory-audits?${query}`);
+        const rows = result.data ?? [];
+        const total = result.meta?.pagination?.total ?? 0;
+        const updatedPublicAdvisories = updatePublicAdvisories(
+          rows,
+          managementAreas,
+        );
+
+        if (isMounted) {
+          setPublicAdvisories(updatedPublicAdvisories);
+          setOriginalPublicAdvisories(updatedPublicAdvisories);
+          setRegionalPublicAdvisories(updatedPublicAdvisories);
+          setTotalPublicAdvisories(total);
+          setIsLoading(false);
+        }
+      } catch (error) {
+        console.error("Error fetching advisories:", error);
         setError({
           status: 500,
           message: "Error loading data. Make sure Strapi is running.",
@@ -463,16 +446,25 @@ export default function AdvisoryDashboard() {
         setToError(true);
         setIsLoading(false);
       }
-      setIsLoading(false);
     }
 
-    fetchData();
+    if (isCmsDataLoaded) {
+      fetchAdvisories();
+    }
 
     return () => {
       isMounted = false;
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- This effect should only run once on mount to load initial data.
-  }, []);
+  }, [
+    cmsGetRaw,
+    currentPage,
+    isCmsDataLoaded,
+    managementAreas,
+    pageSize,
+    setError,
+    showArchived,
+    totalPublicAdvisories,
+  ]);
 
   const regionOptions = useMemo(
     () =>
@@ -812,9 +804,6 @@ export default function AdvisoryDashboard() {
     [urgencies, advisoryStatuses, publishedAdvisories],
   );
 
-  const totalPageSizeOption =
-    publicAdvisories.length > 50 ? [publicAdvisories.length] : [];
-
   if (toCreate) {
     return <Navigate to="/create-advisory" />;
   }
@@ -914,9 +903,8 @@ export default function AdvisoryDashboard() {
               id="show-archived"
               checked={showArchived}
               onChange={(e) => {
-                const shouldShowArchived = e ? e.target.checked : false;
-
-                toggleArchivedAdvisories(shouldShowArchived);
+                setShowArchived(e.target.checked);
+                setCurrentPage(1);
               }}
               label={
                 <span>
@@ -945,12 +933,18 @@ export default function AdvisoryDashboard() {
               options={{
                 filtering: true,
                 search: false,
-                pageSize: 50,
-                pageSizeOptions: [25, 50, ...totalPageSizeOption],
+                pageSize,
+                pageSizeOptions: [25, 50, ALL_PAGE_SIZE],
+                serverSide: true,
+                totalItems: totalPublicAdvisories,
+                currentPage,
+                onPageChange: setCurrentPage,
+                onPageSizeChange(nextPageSize) {
+                  setPageSize(nextPageSize);
+                  setCurrentPage(1);
+                },
               }}
-              // Initial filter values: loaded from localStorage on mount
               initialFilterValues={initialTableFilterValues}
-              // Debounced callback to persist filters to localStorage when they change
               onFilterValuesChange={persistTableFilterValues}
               columns={tableColumns}
               data={publicAdvisories}

--- a/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.jsx
+++ b/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.jsx
@@ -47,7 +47,6 @@ const DEFAULT_PAGE_SIZE = 50;
  * @param {any} [defaultValue=0] Default value to return if the filter isn't found in storage
  * @returns {any} The filter value, or default if not found
  */
-
 function getPageFilterValue(storedFilters, filterName, defaultValue = 0) {
   return (
     storedFilters.find(
@@ -326,7 +325,7 @@ export default function AdvisoryDashboard() {
           const countResult = await cmsGet(
             `/public-advisory-audits?${countQuery}`,
             {},
-            "data",
+            "",
           );
           const allTotal =
             countResult.meta?.pagination?.total ?? DEFAULT_PAGE_SIZE;
@@ -372,11 +371,7 @@ export default function AdvisoryDashboard() {
           { encodeValuesOnly: true },
         );
 
-        const result = await cmsGet(
-          `/public-advisory-audits?${query}`,
-          {},
-          "data",
-        );
+        const result = await cmsGet(`/public-advisory-audits?${query}`, {}, "");
         const rows = result.data ?? [];
         const total = result.meta?.pagination?.total ?? 0;
         const updatedPublicAdvisories = updatePublicAdvisories(
@@ -425,13 +420,16 @@ export default function AdvisoryDashboard() {
 
   const regionOptions = useMemo(
     () =>
-      regions.map((r) => ({ label: `${r.regionName} Region`, value: r.id })),
+      (regions || []).map((r) => ({
+        label: `${r.regionName} Region`,
+        value: r.id,
+      })),
     [regions],
   );
 
   const parkOptions = useMemo(
     () =>
-      protectedAreas.map((p) => ({
+      (protectedAreas || []).map((p) => ({
         label: p.protectedAreaName,
         value: p.documentId,
       })),
@@ -899,27 +897,25 @@ export default function AdvisoryDashboard() {
           <br />
           <div className="container-fluid">
             <DataTable
-              options={{
-                filtering: true,
-                search: false,
-                pageSize,
-                pageSizeOptions: [25, 50, ALL_PAGE_SIZE],
-                serverSide: true,
-                totalItems: totalPublicAdvisories,
-                currentPage,
-                onPageChange: setCurrentPage,
-                onPageSizeChange(nextPageSize) {
-                  setPageSize(nextPageSize);
-                  setCurrentPage(1);
-                },
-                onFilterChange({ field, value }) {
-                  setTableFilterValues((prev) => ({ ...prev, [field]: value }));
-                  setCurrentPage(1);
-                },
-                onSortChange(next) {
-                  setSortConfig(next);
-                  setCurrentPage(1);
-                },
+              filtering
+              search={false}
+              pageSize={pageSize}
+              pageSizeOptions={[25, 50, ALL_PAGE_SIZE]}
+              serverSide
+              totalItems={totalPublicAdvisories}
+              currentPage={currentPage}
+              onPageChange={setCurrentPage}
+              onPageSizeChange={(nextPageSize) => {
+                setPageSize(nextPageSize);
+                setCurrentPage(1);
+              }}
+              onFilterChange={({ field, value }) => {
+                setTableFilterValues((prev) => ({ ...prev, [field]: value }));
+                setCurrentPage(1);
+              }}
+              onSortChange={(next) => {
+                setSortConfig(next);
+                setCurrentPage(1);
               }}
               initialFilterValues={initialTableFilterValues}
               onFilterValuesChange={persistTableFilterValues}

--- a/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.jsx
+++ b/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.jsx
@@ -37,6 +37,9 @@ import {
   buildSort,
 } from "@/lib/advisories/utils/AdvisoryDashboardQuery";
 
+const ALL_PAGE_SIZE = -1;
+const DEFAULT_PAGE_SIZE = 50;
+
 /**
  * Returns the value of a page-level filter from the stored filters array, or a default if not found.
  * @param {Array} storedFilters Stored filters, each with { type, filterName/fieldName, filterValue/fieldValue }
@@ -44,8 +47,6 @@ import {
  * @param {any} [defaultValue=0] Default value to return if the filter isn't found in storage
  * @returns {any} The filter value, or default if not found
  */
-const ALL_PAGE_SIZE = -1;
-const DEFAULT_PAGE_SIZE = 50;
 
 function getPageFilterValue(storedFilters, filterName, defaultValue = 0) {
   return (
@@ -65,7 +66,6 @@ export default function AdvisoryDashboard() {
     getAdvisoryStatuses,
     getUrgencies,
     cmsGet,
-    cmsGetRaw,
   } = useCms();
 
   const [toError, setToError] = useState(false);
@@ -188,7 +188,7 @@ export default function AdvisoryDashboard() {
         setUrgencies(fetchedUrgencies);
 
         // Fetch the list of advisory numbers that currently have a live PUB version
-        if (fetchedAdvisoryStatuses?.length > 0) {
+        if (fetchedAdvisoryStatuses.length > 0) {
           const publishedStatus = fetchedAdvisoryStatuses.filter(
             (status) => status.code === "PUB",
           );
@@ -323,8 +323,10 @@ export default function AdvisoryDashboard() {
             },
             { encodeValuesOnly: true },
           );
-          const countResult = await cmsGetRaw(
+          const countResult = await cmsGet(
             `/public-advisory-audits?${countQuery}`,
+            {},
+            "data",
           );
           const allTotal =
             countResult.meta?.pagination?.total ?? DEFAULT_PAGE_SIZE;
@@ -370,7 +372,11 @@ export default function AdvisoryDashboard() {
           { encodeValuesOnly: true },
         );
 
-        const result = await cmsGetRaw(`/public-advisory-audits?${query}`);
+        const result = await cmsGet(
+          `/public-advisory-audits?${query}`,
+          {},
+          "data",
+        );
         const rows = result.data ?? [];
         const total = result.meta?.pagination?.total ?? 0;
         const updatedPublicAdvisories = updatePublicAdvisories(
@@ -403,7 +409,7 @@ export default function AdvisoryDashboard() {
       isMounted = false;
     };
   }, [
-    cmsGetRaw,
+    cmsGet,
     currentPage,
     isCmsDataLoaded,
     managementAreas,

--- a/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.jsx
+++ b/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useContext } from "react";
+import { useState, useEffect, useMemo, useContext, useRef } from "react";
 import {
   useLocalStorage,
   useSessionStorage,
@@ -85,8 +85,9 @@ export default function AdvisoryDashboard() {
   const [currentPage, setCurrentPage] = useState(1);
   const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE);
   const [totalPublicAdvisories, setTotalPublicAdvisories] = useState(0);
+  // Ref keeps the latest total accessible inside fetchAdvisories
+  const totalPublicAdvisoriesRef = useRef(0);
   const [isCmsDataLoaded, setIsCmsDataLoaded] = useState(false);
-  const [tableFilterValues, setTableFilterValues] = useState({});
   const [sortConfig, setSortConfig] = useState(null);
 
   const defaultPageFilters = [
@@ -113,6 +114,10 @@ export default function AdvisoryDashboard() {
       tableEntries.map((f) => [f.fieldName, f.fieldValue]),
     );
   }, [storedFilters]);
+
+  const [tableFilterValues, setTableFilterValues] = useState(
+    initialTableFilterValues,
+  );
 
   // Debounced callback: persist table filter values to localStorage
   // Called by DataTable after user stops typing
@@ -291,7 +296,10 @@ export default function AdvisoryDashboard() {
           pageSize < 0
             ? {
                 page: 1,
-                pageSize: Math.max(totalPublicAdvisories, DEFAULT_PAGE_SIZE),
+                pageSize: Math.max(
+                  totalPublicAdvisoriesRef.current,
+                  DEFAULT_PAGE_SIZE,
+                ),
               }
             : { page: currentPage, pageSize };
 
@@ -318,6 +326,9 @@ export default function AdvisoryDashboard() {
             ],
             populate: {
               protectedAreas: { fields: ["orcs", "protectedAreaName"] },
+              recreationResources: {
+                fields: ["recResourceId", "resourceName"],
+              },
               advisoryStatus: { fields: ["advisoryStatus", "code"] },
               eventType: { fields: ["eventType"] },
               urgency: { fields: ["urgency"] },
@@ -346,6 +357,7 @@ export default function AdvisoryDashboard() {
 
         if (isMounted) {
           setPublicAdvisories(updatedPublicAdvisories);
+          totalPublicAdvisoriesRef.current = total;
           setTotalPublicAdvisories(total);
           setIsLoading(false);
         }
@@ -380,7 +392,6 @@ export default function AdvisoryDashboard() {
     showArchived,
     sortConfig,
     tableFilterValues,
-    totalPublicAdvisories,
   ]);
 
   const regionOptions = useMemo(
@@ -631,33 +642,70 @@ export default function AdvisoryDashboard() {
             );
           }
 
+          // park advisories
           const parksCount = rowData.protectedAreas.length;
           const displayedProtectedAreas = rowData.protectedAreas.slice(
             0,
             displayCount,
           );
 
+          if (parksCount > 0) {
+            return (
+              <div>
+                {displayedProtectedAreas.map((p, i) => (
+                  <span key={i}>
+                    {p.protectedAreaName}
+                    {displayedProtectedAreas.length - 1 > i && ", "}
+                  </span>
+                ))}
+                {parksCount > displayCount && (
+                  <OverlayTrigger
+                    placement="top"
+                    overlay={
+                      <Tooltip
+                        id={`parks-more-${rowData.documentId || rowData.id}`}
+                      >
+                        {`plus ${parksCount - displayCount} more park(s)`}
+                      </Tooltip>
+                    }
+                  >
+                    <span>
+                      {renderCountBadge(`+${parksCount - displayCount}`)}
+                    </span>
+                  </OverlayTrigger>
+                )}
+              </div>
+            );
+          }
+
+          // RST closures
+          const resourcesCount = rowData.recreationResources.length;
+          const displayedResources = rowData.recreationResources.slice(
+            0,
+            displayCount,
+          );
+
           return (
             <div>
-              {displayedProtectedAreas.map((p, i) => (
+              {displayedResources.map((r, i) => (
                 <span key={i}>
-                  {p.protectedAreaName}
-                  {displayedProtectedAreas.length - 1 > i && ", "}
+                  {r.resourceName}
+                  {displayedResources.length - 1 > i && ", "}
                 </span>
               ))}
-              {parksCount > displayCount && (
+              {resourcesCount > displayCount && (
                 <OverlayTrigger
                   placement="top"
                   overlay={
                     <Tooltip
-                      id={`parks-more-${rowData.documentId || rowData.id}`}
+                      id={`resources-more-${rowData.documentId || rowData.id}`}
                     >
-                      {`plus ${parksCount - displayCount} more park(s)`}
+                      {`plus ${resourcesCount - displayCount} more resource(s)`}
                     </Tooltip>
                   }
                 >
                   <span>
-                    {renderCountBadge(`+${parksCount - displayCount}`)}
+                    {renderCountBadge(`+${resourcesCount - displayCount}`)}
                   </span>
                 </OverlayTrigger>
               )}

--- a/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.jsx
+++ b/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.jsx
@@ -43,6 +43,9 @@ import {
  * @param {any} [defaultValue=0] Default value to return if the filter isn't found in storage
  * @returns {any} The filter value, or default if not found
  */
+const ALL_PAGE_SIZE = -1;
+const DEFAULT_PAGE_SIZE = 50;
+
 function getPageFilterValue(storedFilters, filterName, defaultValue = 0) {
   return (
     storedFilters.find(
@@ -52,9 +55,6 @@ function getPageFilterValue(storedFilters, filterName, defaultValue = 0) {
 }
 
 export default function AdvisoryDashboard() {
-  const ALL_PAGE_SIZE = -1;
-  const DEFAULT_PAGE_SIZE = 50;
-
   const { setError } = useContext(ErrorContext);
   const navigate = useNavigate();
   const {
@@ -418,18 +418,6 @@ export default function AdvisoryDashboard() {
           lookup[urgency.urgency] = urgency.urgency;
           return lookup;
         }, {}),
-        customSort(a, b) {
-          const urgencyRank = {
-            low: 1,
-            medium: 2,
-            high: 3,
-          };
-
-          const leftRank = urgencyRank[a.urgency?.urgency?.toLowerCase()] || 0;
-          const rightRank = urgencyRank[b.urgency?.urgency?.toLowerCase()] || 0;
-
-          return leftRank - rightRank;
-        },
         headerStyle: {
           width: 10,
         },
@@ -480,16 +468,6 @@ export default function AdvisoryDashboard() {
           lookup[status.advisoryStatus] = status.advisoryStatus;
           return lookup;
         }, {}),
-        customSort(a, b) {
-          if (a.archived !== b.archived) {
-            return a.archived < b.archived ? 1 : -1;
-          }
-
-          return a.advisoryStatus.advisoryStatus <
-            b.advisoryStatus.advisoryStatus
-            ? -1
-            : 1;
-        },
         cellStyle: {
           textAlign: "center",
         },
@@ -604,8 +582,6 @@ export default function AdvisoryDashboard() {
       {
         field: "title",
         title: "Headline",
-        customSort: (a, b) =>
-          a.title.toLowerCase() > b.title.toLowerCase() ? 1 : -1,
         headerStyle: { width: 400 },
         cellStyle: { width: 400 },
         render(rowData) {

--- a/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.jsx
+++ b/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.jsx
@@ -31,6 +31,10 @@ import {
   faThumbsUp,
 } from "@fa-kit/icons/classic/solid";
 import { updatePublicAdvisories } from "@/lib/advisories/utils/AdvisoryDataUtil";
+import {
+  buildFilter,
+  buildSort,
+} from "@/lib/advisories/utils/AdvisoryDashboardQuery";
 
 /**
  * Returns the value of a page-level filter from the stored filters array, or a default if not found.
@@ -72,19 +76,18 @@ export default function AdvisoryDashboard() {
   const [publishedAdvisories, setPublishedAdvisories] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
   const [hasErrors, setHasErrors] = useState(false);
-  const [originalPublicAdvisories, setOriginalPublicAdvisories] = useState([]);
-  const [regionalPublicAdvisories, setRegionalPublicAdvisories] = useState([]);
   const [publicAdvisories, setPublicAdvisories] = useState([]);
   const [regions, setRegions] = useState([]);
   const [managementAreas, setManagementAreas] = useState([]);
   const [protectedAreas, setProtectedAreas] = useState([]);
-  const [originalProtectedAreas, setOriginalProtectedAreas] = useState([]);
   const [advisoryStatuses, setAdvisoryStatuses] = useState([]);
   const [urgencies, setUrgencies] = useState([]);
   const [currentPage, setCurrentPage] = useState(1);
   const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE);
   const [totalPublicAdvisories, setTotalPublicAdvisories] = useState(0);
   const [isCmsDataLoaded, setIsCmsDataLoaded] = useState(false);
+  const [tableFilterValues, setTableFilterValues] = useState({});
+  const [sortConfig, setSortConfig] = useState(null);
 
   const defaultPageFilters = [
     { filterName: "region", filterValue: "", type: "page" },
@@ -137,102 +140,12 @@ export default function AdvisoryDashboard() {
     false,
   );
 
-  function filterFormattedDate(filterDate, rowData, column) {
-    const value = rowData[column.field];
-
-    if (!filterDate) {
-      return true;
-    }
-    if (!value) {
-      return false;
-    }
-
-    return moment(value)
-      .format("YYYY/MM/DD")
-      .toLowerCase()
-      .includes(filterDate.toLowerCase());
-  }
-
   function renderCountBadge(label) {
     return (
       <Badge pill bg="light" text="dark" className="park-count-badge">
         {label}
       </Badge>
     );
-  }
-
-  function removeDuplicatesById(arr) {
-    return arr.filter(
-      (obj, index, self) => index === self.findIndex((o) => o.id === obj.id),
-    );
-  }
-
-  function filterAdvisoriesByParkId(pId) {
-    const advisories = selectedRegionId
-      ? regionalPublicAdvisories
-      : originalPublicAdvisories;
-
-    if (pId) {
-      const filteredPublicAdvisories = [];
-      const currentParkObj = protectedAreas.find((o) => o.documentId === pId);
-
-      advisories.forEach((obj) => {
-        if (
-          currentParkObj &&
-          obj.protectedAreas.some(
-            (park) => park.documentId === currentParkObj.documentId,
-          )
-        ) {
-          filteredPublicAdvisories.push(obj);
-        }
-      });
-      setPublicAdvisories([...filteredPublicAdvisories]);
-    } else {
-      setPublicAdvisories([...advisories]);
-    }
-  }
-
-  function filterAdvisoriesByRegionId(regId) {
-    if (regId) {
-      const filteredManagementAreas = managementAreas.filter(
-        (managementArea) => managementArea.region?.id === regId,
-      );
-
-      // Filter park names dropdown list
-      let list = [];
-
-      filteredManagementAreas.forEach((obj) => {
-        list = [...list.concat(obj.protectedAreas)];
-      });
-
-      // Remove duplicates
-      const filteredProtectedAreas = removeDuplicatesById(list);
-
-      // Filter advisories in grid
-      const filteredPublicAdvisories = [];
-
-      originalPublicAdvisories.forEach((obj) => {
-        obj.protectedAreas.forEach((park) => {
-          const idx = filteredProtectedAreas.findIndex(
-            (protectedArea) => protectedArea?.orcs === park?.orcs,
-          );
-
-          if (idx !== -1) {
-            filteredPublicAdvisories.push(obj);
-          }
-        });
-      });
-
-      setProtectedAreas([...filteredProtectedAreas]);
-      setPublicAdvisories([...removeDuplicatesById(filteredPublicAdvisories)]);
-      setRegionalPublicAdvisories([
-        ...removeDuplicatesById(filteredPublicAdvisories),
-      ]);
-    } else {
-      setProtectedAreas([...originalProtectedAreas]);
-      setPublicAdvisories([...originalPublicAdvisories]);
-      setRegionalPublicAdvisories([...originalPublicAdvisories]);
-    }
   }
 
   // Load management areas, advisory statuses, urgencies, and published advisories once on mount.
@@ -260,7 +173,6 @@ export default function AdvisoryDashboard() {
         setRegions(regionsData);
         setManagementAreas(managementAreasData);
         setProtectedAreas(protectedAreasData);
-        setOriginalProtectedAreas(protectedAreasData);
 
         // Fetch advisory statuses and urgencies for filter options and table icons
         setAdvisoryStatuses(fetchedAdvisoryStatuses);
@@ -345,18 +257,6 @@ export default function AdvisoryDashboard() {
     setError,
   ]);
 
-  useEffect(() => {
-    filterAdvisoriesByRegionId(selectedRegionId);
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- Region filtering intentionally derives from the selected region id and the current page of advisories.
-  }, [selectedRegionId, originalPublicAdvisories]);
-
-  useEffect(() => {
-    if (selectedParkId !== -1) {
-      filterAdvisoriesByParkId(selectedParkId);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- Park filtering intentionally derives from the selected park id and the region-scoped advisory list.
-  }, [selectedParkId, regionalPublicAdvisories]);
-
   // Fetch one page of advisories whenever page, pageSize, or showArchived changes.
   useEffect(() => {
     let isMounted = true;
@@ -395,6 +295,16 @@ export default function AdvisoryDashboard() {
               }
             : { page: currentPage, pageSize };
 
+        // Build server-side filter params from column filter values and region/park dropdowns
+        const columnFilterClauses = buildFilter(
+          tableFilterValues,
+          selectedRegionId,
+          selectedParkId,
+          protectedAreas,
+        );
+
+        const sort = buildSort(sortConfig);
+
         const query = qs.stringify(
           {
             fields: [
@@ -414,10 +324,14 @@ export default function AdvisoryDashboard() {
               regions: { fields: ["regionName"] },
             },
             filters: {
-              $and: [{ isLatestRevision: true }, advisoryFilter],
+              $and: [
+                { isLatestRevision: true },
+                advisoryFilter,
+                ...columnFilterClauses,
+              ],
             },
             pagination,
-            sort: ["advisoryDate:DESC"],
+            sort,
           },
           { encodeValuesOnly: true },
         );
@@ -432,8 +346,6 @@ export default function AdvisoryDashboard() {
 
         if (isMounted) {
           setPublicAdvisories(updatedPublicAdvisories);
-          setOriginalPublicAdvisories(updatedPublicAdvisories);
-          setRegionalPublicAdvisories(updatedPublicAdvisories);
           setTotalPublicAdvisories(total);
           setIsLoading(false);
         }
@@ -461,8 +373,13 @@ export default function AdvisoryDashboard() {
     isCmsDataLoaded,
     managementAreas,
     pageSize,
+    protectedAreas,
+    selectedParkId,
+    selectedRegionId,
     setError,
     showArchived,
+    sortConfig,
+    tableFilterValues,
     totalPublicAdvisories,
   ]);
 
@@ -654,7 +571,6 @@ export default function AdvisoryDashboard() {
       {
         field: "advisoryDate",
         title: "Posting date",
-        customFilterAndSearch: filterFormattedDate,
         render(rowData) {
           if (rowData.advisoryDate) {
             return moment(rowData.advisoryDate).format("YYYY/MM/DD");
@@ -666,7 +582,6 @@ export default function AdvisoryDashboard() {
       {
         field: "endDate",
         title: "End date",
-        customFilterAndSearch: filterFormattedDate,
         render(rowData) {
           if (rowData.endDate) {
             return moment(rowData.endDate).format("YYYY/MM/DD");
@@ -678,7 +593,6 @@ export default function AdvisoryDashboard() {
       {
         field: "expiryDate",
         title: "Expiry date",
-        customFilterAndSearch: filterFormattedDate,
         render(rowData) {
           if (rowData.expiryDate) {
             return moment(rowData.expiryDate).format("YYYY/MM/DD");
@@ -838,7 +752,8 @@ export default function AdvisoryDashboard() {
                 setSelectedRegionId(e ? e.value : 0);
 
                 setSelectedPark(null);
-                setSelectedParkId(-1); // Do not filter by parkId
+                setSelectedParkId(0);
+                setCurrentPage(1);
 
                 setStoredFilters((currentFilters) => {
                   const nonPageFilters = currentFilters.filter(
@@ -871,6 +786,7 @@ export default function AdvisoryDashboard() {
               onChange={(e) => {
                 setSelectedPark(e);
                 setSelectedParkId(e ? e.value : 0);
+                setCurrentPage(1);
 
                 setStoredFilters((currentFilters) => {
                   // Remove any existing "park" page filter
@@ -941,6 +857,14 @@ export default function AdvisoryDashboard() {
                 onPageChange: setCurrentPage,
                 onPageSizeChange(nextPageSize) {
                   setPageSize(nextPageSize);
+                  setCurrentPage(1);
+                },
+                onFilterChange({ field, value }) {
+                  setTableFilterValues((prev) => ({ ...prev, [field]: value }));
+                  setCurrentPage(1);
+                },
+                onSortChange(next) {
+                  setSortConfig(next);
                   setCurrentPage(1);
                 },
               }}

--- a/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.jsx
+++ b/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.jsx
@@ -3,6 +3,7 @@ import {
   useLocalStorage,
   useSessionStorage,
   useDebounceCallback,
+  useDebounceValue,
 } from "usehooks-ts";
 import qs from "qs";
 import { Navigate, useNavigate } from "react-router-dom";
@@ -118,6 +119,9 @@ export default function AdvisoryDashboard() {
   const [tableFilterValues, setTableFilterValues] = useState(
     initialTableFilterValues,
   );
+  // Debounced copy used as the fetchAdvisories dependency
+  // Prevents Strapi request on every keystroke while keeping filter inputs responsive
+  const [debouncedTableFilterValues] = useDebounceValue(tableFilterValues, 300);
 
   // Debounced callback: persist table filter values to localStorage
   // Called by DataTable after user stops typing
@@ -292,24 +296,43 @@ export default function AdvisoryDashboard() {
               ],
             };
 
-        const pagination =
-          pageSize < 0
-            ? {
-                page: 1,
-                pageSize: Math.max(
-                  totalPublicAdvisoriesRef.current,
-                  DEFAULT_PAGE_SIZE,
-                ),
-              }
-            : { page: currentPage, pageSize };
-
         // Build server-side filter params from column filter values and region/park dropdowns
         const columnFilterClauses = buildFilter(
-          tableFilterValues,
+          debouncedTableFilterValues,
           selectedRegionId,
           selectedParkId,
           protectedAreas,
         );
+
+        // When "All" is selected, first fetch the current total with
+        // the active filters applied, then request exactly that many rows
+        let pagination;
+
+        if (pageSize < 0) {
+          const countQuery = qs.stringify(
+            {
+              fields: ["id"],
+              filters: {
+                $and: [
+                  { isLatestRevision: true },
+                  advisoryFilter,
+                  ...columnFilterClauses,
+                ],
+              },
+              pagination: { page: 1, pageSize: 1 },
+            },
+            { encodeValuesOnly: true },
+          );
+          const countResult = await cmsGetRaw(
+            `/public-advisory-audits?${countQuery}`,
+          );
+          const allTotal =
+            countResult.meta?.pagination?.total ?? DEFAULT_PAGE_SIZE;
+
+          pagination = { page: 1, pageSize: Math.max(allTotal, 1) };
+        } else {
+          pagination = { page: currentPage, pageSize };
+        }
 
         const sort = buildSort(sortConfig);
 
@@ -391,7 +414,7 @@ export default function AdvisoryDashboard() {
     setError,
     showArchived,
     sortConfig,
-    tableFilterValues,
+    debouncedTableFilterValues,
   ]);
 
   const regionOptions = useMemo(

--- a/frontend/src/router/pages/advisories/parkAccessStatus/ParkAccessStatus.jsx
+++ b/frontend/src/router/pages/advisories/parkAccessStatus/ParkAccessStatus.jsx
@@ -78,24 +78,22 @@ export default function ParkAccessStatus() {
           <DataTable
             key={data.length}
             hover
-            options={{
-              filtering: true,
-              search: true,
-              exportMenu: [
-                {
-                  label: "Export CSV",
-                  exportFunc: (cols, datas) =>
-                    exportCsvFile(cols, datas, exportFilename),
-                },
-                {
-                  label: "Export PDF",
-                  exportFunc: (cols, datas) =>
-                    exportPdf(cols, datas, title, exportFilename),
-                },
-              ],
-              pageSize: 50,
-              pageSizeOptions: [25, 50, 100],
-            }}
+            filtering
+            search
+            exportMenu={[
+              {
+                label: "Export CSV",
+                exportFunc: (cols, datas) =>
+                  exportCsvFile(cols, datas, exportFilename),
+              },
+              {
+                label: "Export PDF",
+                exportFunc: (cols, datas) =>
+                  exportPdf(cols, datas, title, exportFilename),
+              },
+            ]}
+            pageSize={50}
+            pageSizeOptions={[25, 50, 100]}
             columns={[
               {
                 title: "ORCS",


### PR DESCRIPTION
### Jira Ticket

CMS-1616

### Description
<!-- What did you change, and why? -->
- Added server side pagination, filtering, and sorting to the advisory table (not park access status table)
- Created `AdvisoryDashboardQuery.js` for filters and sorts
- Please note that the region filter works only if advisories has a region
  - It doesn't get advisories with protectedAreas in a region
  - Note: I tried to get them using `$in` https://docs.strapi.io/cms/api/rest/filters#example-find-multiple-restaurants-with-ids-3-68 but it didn't work probably because the API post can be insanely long if a region has more than 100 protectedAreas ...