### PR TITLE
CMS-1572: Update winter & tier validation logic

### DIFF
--- a/backend/routes/api/seasons.js
+++ b/backend/routes/api/seasons.js
@@ -310,7 +310,7 @@ async function getFrontcountryFeatureReservationDates(park, operatingYear) {
         [Op.in]: featureSeasonIds,
       },
 
-      // Filter out blank date ranges (null startDate and endDate) and return
+      // Filter out blank date ranges (null startDate and endDate)
       startDate: {
         [Op.ne]: null,
       },

--- a/backend/routes/api/seasons.js
+++ b/backend/routes/api/seasons.js
@@ -6,6 +6,7 @@ import sequelize from "../../db/connection.js";
 import * as STATUS from "../../constants/seasonStatus.js";
 import * as DATE_TYPE from "../../constants/dateType.js";
 import * as SEASON_TYPE from "../../constants/seasonType.js";
+import * as FEATURE_TYPE from "../../constants/featureType.js";
 import {
   getAllDateTypes,
   getDateTypesForFeature,
@@ -264,25 +265,16 @@ const SEASON_ATTRIBUTES = [
 ];
 
 /**
- * Returns all reservation feature dates for a specific park and operating year.
+ * Returns all Frontcountry Campground feature reservation dates for a park and operating year.
  * @param {Object} park Park model with features and parkAreas
  * @param {number} operatingYear Operating year for the Seasons
- * @returns {Promise<Array>} - Array of reservation feature dates
+ * @returns {Promise<Array>} - Array of Frontcountry Campground feature reservation dates
  */
-async function getFeatureReservationDates(park, operatingYear) {
+async function getFrontcountryFeatureReservationDates(park, operatingYear) {
   // Only fetch dates if the park has Winter fee dates or either Tier 1 or Tier 2 dates.
   // This data is needed for Winter/Tier date validation.
   if (!(park.hasWinterFeeDates || park.hasTier1Dates || park.hasTier2Dates))
     return [];
-
-  // Get the ID of the applicable Reservation date type
-  const reservationDateType = await DateType.findOne({
-    attributes: ["id"],
-
-    where: {
-      name: "Reservation",
-    },
-  });
 
   const featurePublishableIds = park.features
     // Filter out any park features without Publishable IDs
@@ -310,20 +302,63 @@ async function getFeatureReservationDates(park, operatingYear) {
 
   const featureSeasonIds = featureSeasons.map((season) => season.id);
 
-  // Get all Reservation DateRanges for these Seasons
-  const reservationDateRanges = await DateRange.findAll({
+  // Get all Frontcountry Campground Reservation DateRanges for these Seasons
+  return DateRange.findAll({
+    attributes: ["id", "startDate", "endDate", "dateTypeId", "seasonId"],
     where: {
       seasonId: {
         [Op.in]: featureSeasonIds,
       },
-      dateTypeId: reservationDateType.id,
-    },
-  });
 
-  // Filter out blank date ranges (null startDate and endDate) and return
-  return reservationDateRanges.filter(
-    (dateRange) => dateRange.startDate && dateRange.endDate,
-  );
+      // Filter out blank date ranges (null startDate and endDate) and return
+      startDate: {
+        [Op.ne]: null,
+      },
+      endDate: {
+        [Op.ne]: null,
+      },
+    },
+
+    include: [
+      // Only include DateRanges with the Reservation DateType
+      {
+        model: DateType,
+        as: "dateType",
+        attributes: ["id"],
+        where: {
+          strapiDateTypeId: DATE_TYPE.RESERVATION,
+        },
+        required: true,
+      },
+
+      // Only include DateRanges that are associated with a Frontcountry Campground feature
+      {
+        model: Dateable,
+        as: "dateable",
+        attributes: ["id"],
+        required: true,
+        include: [
+          {
+            model: Feature,
+            as: "feature",
+            required: true,
+            attributes: ["id"],
+            include: [
+              {
+                model: FeatureType,
+                as: "featureType",
+                attributes: ["id"],
+                where: {
+                  strapiFeatureTypeId: FEATURE_TYPE.FRONTCOUNTRY_CAMPGROUND,
+                },
+                required: true,
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  });
 }
 
 /**
@@ -947,12 +982,10 @@ router.get(
 
     const { park } = seasonModel;
 
-    // Add the parkArea- and feature-level reservation dates to the payload
-    // (for Tier 1 and Tier 2 validation rules)
-    const featureReservationDates = getFeatureReservationDates(
-      park,
-      seasonModel.operatingYear,
-    );
+    // Add the parkArea- and feature-level Frontcountry Campground reservation dates
+    // to the payload (for Tier 1 and Tier 2 validation rules)
+    const frontcountryFeatureReservationDates =
+      getFrontcountryFeatureReservationDates(park, seasonModel.operatingYear);
 
     // Get the previous year's Season Dates for this Feature
     const previousSeason = await getPreviousSeasonDates(seasonModel, {
@@ -1019,7 +1052,8 @@ router.get(
       icon: null,
       featureTypeName: null,
       name: seasonModel.park.name,
-      featureReservationDates: await featureReservationDates,
+      frontcountryFeatureReservationDates:
+        await frontcountryFeatureReservationDates,
     };
 
     res.json(output);

--- a/backend/routes/api/seasons.js
+++ b/backend/routes/api/seasons.js
@@ -249,7 +249,7 @@ function featureTypeQueryPart() {
   return {
     model: FeatureType,
     as: "featureType",
-    attributes: ["id", "name", "icon"],
+    attributes: ["id", "name", "icon", "strapiFeatureTypeId"],
   };
 }
 

--- a/frontend/src/hooks/useValidation/rules/reservationAndWinterNoOverlap.js
+++ b/frontend/src/hooks/useValidation/rules/reservationAndWinterNoOverlap.js
@@ -2,9 +2,10 @@ import { areIntervalsOverlapping } from "date-fns";
 import { groupBy } from "lodash-es";
 
 import consolidateRanges from "@/lib/consolidateDateRanges";
+import * as FEATURE_TYPE from "@/constants/featureType";
 
 /**
- * Validates that Feature/Area Reservation dates do not overlap with Park-level Winter fee dates.
+ * Validates that Frontcountry Campground Feature Reservation dates do not overlap with Park-level Winter fee dates.
  * @param {Object} seasonData The season form data to validate
  * @param {Object} context Validation context with errors array
  * @returns {void}
@@ -15,16 +16,20 @@ export default function reservationAndWinterNoOverlap(seasonData, context) {
   // This rule applies to the Feature and ParkArea level. Skip for Parks
   if (context.level === "park") return;
 
-  // Get a list of the populated Reservation dates on this form
-  const allReservationDates = dateRanges.filter(
+  // Get a list of the populated Frontcountry Campground Feature Reservation dates on this form
+  const frontcountryReservationDates = dateRanges.filter(
     (dateRange) =>
       dateRange.dateType.name === "Reservation" &&
+      dateRange.strapiFeatureTypeId === FEATURE_TYPE.FRONTCOUNTRY_CAMPGROUND &&
       dateRange.startDate &&
       dateRange.endDate,
   );
 
   // Group reservation dateRanges by dateableId so we can test each dateable feature
-  const reservationDatesByFeature = groupBy(allReservationDates, "dateableId");
+  const reservationDatesByFeature = groupBy(
+    frontcountryReservationDates,
+    "dateableId",
+  );
 
   // Consolidate Park-level winter dates for comparison
   const consolidatedWinterDates = consolidateRanges(parkWinterDates);

--- a/frontend/src/hooks/useValidation/rules/reservationSameAsTier1And2.js
+++ b/frontend/src/hooks/useValidation/rules/reservationSameAsTier1And2.js
@@ -2,9 +2,10 @@ import { isEqual } from "date-fns";
 import { groupBy } from "lodash-es";
 
 import consolidateRanges from "@/lib/consolidateDateRanges";
+import * as FEATURE_TYPE from "@/constants/featureType";
 
 /**
- * Validates that the Feature/Area-level reservation dates match the Park-level Tier 1 and 2 dates.
+ * Validates that the Feature/Area-level Frontcountry Campground reservation dates match the Park-level Tier 1 and 2 dates.
  * Each feature's dates must be the same as the Park's combined Tier 1 and Tier 2 dates.
  * @param {Object} seasonData The season form data to validate
  * @param {Object} context Validation context with errors array
@@ -19,16 +20,20 @@ export default function reservationSameAsTier1And2(seasonData, context) {
   // Skip if the Park doesn't have Tier 1 dates
   if (parkTier1Dates.length === 0) return;
 
-  // Get a list of the populated Reservation dates on this form
-  const allReservationDates = dateRanges.filter(
+  // Get a list of the populated Frontcountry Campground Feature Reservation dates on this form
+  const frontcountryReservationDates = dateRanges.filter(
     (dateRange) =>
       dateRange.dateType.name === "Reservation" &&
+      dateRange.strapiFeatureTypeId === FEATURE_TYPE.FRONTCOUNTRY_CAMPGROUND &&
       dateRange.startDate &&
       dateRange.endDate,
   );
 
   // Group reservation dates by dateableId
-  const reservationDatesByFeature = groupBy(allReservationDates, "dateableId");
+  const reservationDatesByFeature = groupBy(
+    frontcountryReservationDates,
+    "dateableId",
+  );
 
   // Consolidate Tier 1 + 2 ranges for comparison
   const consolidatedTierDates = consolidateRanges([

--- a/frontend/src/hooks/useValidation/rules/reservationSameAsTier1And2.js
+++ b/frontend/src/hooks/useValidation/rules/reservationSameAsTier1And2.js
@@ -5,7 +5,7 @@ import consolidateRanges from "@/lib/consolidateDateRanges";
 import * as FEATURE_TYPE from "@/constants/featureType";
 
 /**
- * Validates that the Feature/Area-level Frontcountry Campground reservation dates match the Park-level Tier 1 and 2 dates.
+ * Validates that Frontcountry Campground Feature Reservation dates match the Park-level Tier 1 and 2 dates.
  * Each feature's dates must be the same as the Park's combined Tier 1 and Tier 2 dates.
  * @param {Object} seasonData The season form data to validate
  * @param {Object} context Validation context with errors array

--- a/frontend/src/hooks/useValidation/rules/tier1And2SameAsReservation.js
+++ b/frontend/src/hooks/useValidation/rules/tier1And2SameAsReservation.js
@@ -3,13 +3,13 @@ import { isEqual } from "date-fns";
 import consolidateRanges from "@/lib/consolidateDateRanges";
 
 /**
- * Validates that the Park-level Tier 1 and 2 dates match the reservation dates.
+ * Validates that the Park-level Tier 1 and 2 dates match the Frontcountry Campground Feature Reservation dates.
  * @param {Object} seasonData The season form data to validate
  * @param {Object} context Validation context with errors array
  * @returns {void}
  */
 export default function tier1And2SameAsReservation(seasonData, context) {
-  const { dateRanges, elements, featureReservationDates } = context;
+  const { dateRanges, elements, frontcountryFeatureReservationDates } = context;
   const { current } = seasonData;
 
   // This rule applies to the Park level. Skip for other levels
@@ -18,7 +18,6 @@ export default function tier1And2SameAsReservation(seasonData, context) {
   // Skip if the Park doesn't have Tier 1 or Tier 2 dates
   if (!(current.park.hasTier1Dates || current.park.hasTier2Dates)) return;
 
-  // Skip if Tier 1 and Reservation dates are not provided
   const tier1Dates = dateRanges.filter(
     (dateRange) =>
       dateRange.dateType.name === "Tier 1" &&
@@ -38,12 +37,12 @@ export default function tier1And2SameAsReservation(seasonData, context) {
     ...tier2Dates,
   ]);
 
-  // Consolidate Reservation dates for comparison
+  // Consolidate Frontcountry Campground Feature Reservation dates for comparison
   const consolidatedReservationDates = consolidateRanges(
-    featureReservationDates,
+    frontcountryFeatureReservationDates,
   );
 
-  // Skip if there are no reservation dates, or if the Park doesn't have Tier 1 dates
+  // Skip if there are no applicable reservation dates, or if the Park doesn't have Tier 1 dates
   if (consolidatedReservationDates.length === 0 || tier1Dates.length === 0)
     return;
 

--- a/frontend/src/hooks/useValidation/rules/tier1And2SameAsReservation.js
+++ b/frontend/src/hooks/useValidation/rules/tier1And2SameAsReservation.js
@@ -61,7 +61,7 @@ export default function tier1And2SameAsReservation(seasonData, context) {
 
   if (!sameDates) {
     const errorText =
-      "The tier 1 and tier 2 dates must include all reservation dates. (To change reservation dates, edit the park’s reservable features)";
+      "The tier 1 and tier 2 dates must include all reservation dates. (To change reservation dates, edit the park's frontcountry campsite reservation dates)";
 
     // Show the error below the Tier 1 and Tier 2 date range sections
     context.addError(

--- a/frontend/src/hooks/useValidation/rules/tier1And2SameAsReservation.js
+++ b/frontend/src/hooks/useValidation/rules/tier1And2SameAsReservation.js
@@ -61,7 +61,7 @@ export default function tier1And2SameAsReservation(seasonData, context) {
 
   if (!sameDates) {
     const errorText =
-      "The tier 1 and tier 2 dates must include all reservation dates. (To change reservation dates, edit the park's frontcountry campsite reservation dates)";
+      "The tier 1 and tier 2 dates must include all reservation dates. (To change reservation dates, edit the park's frontcountry campground reservation dates)";
 
     // Show the error below the Tier 1 and Tier 2 date range sections
     context.addError(

--- a/frontend/src/hooks/useValidation/rules/winterAndReservationNoOverlap.js
+++ b/frontend/src/hooks/useValidation/rules/winterAndReservationNoOverlap.js
@@ -59,7 +59,7 @@ export default function winterAndReservationNoOverlap(seasonData, context) {
     // Show the error below the Winter fee date range section
     context.addError(
       elements.dateableDateType(current.park.dateableId, "Winter fee"),
-      "Winter dates must not overlap with reservation dates. (To change reservation dates, edit the park's frontcountry campsite reservation dates)",
+      "Winter dates must not overlap with reservation dates. (To change reservation dates, edit the park's frontcountry campground reservation dates)",
     );
   }
 }

--- a/frontend/src/hooks/useValidation/rules/winterAndReservationNoOverlap.js
+++ b/frontend/src/hooks/useValidation/rules/winterAndReservationNoOverlap.js
@@ -3,13 +3,13 @@ import { areIntervalsOverlapping } from "date-fns";
 import consolidateRanges from "@/lib/consolidateDateRanges";
 
 /**
- * Validates that Park-level Winter fee dates do not overlap with Feature/Area Reservation dates.
+ * Validates that Park-level Winter fee dates do not overlap with Frontcountry Campground Feature Reservation dates.
  * @param {Object} seasonData The season form data to validate
  * @param {Object} context Validation context with errors array
  * @returns {void}
  */
 export default function winterAndReservationNoOverlap(seasonData, context) {
-  const { dateRanges, elements, featureReservationDates } = context;
+  const { dateRanges, elements, frontcountryFeatureReservationDates } = context;
   const { current } = seasonData;
 
   // This rule applies to the Park level. Skip for other levels
@@ -26,12 +26,12 @@ export default function winterAndReservationNoOverlap(seasonData, context) {
   // Consolidate Park-level winter dates for comparison
   const consolidatedWinterDates = consolidateRanges(winterDates);
 
-  // Consolidate Feature reservation dates for comparison
+  // Consolidate Frontcountry Feature reservation dates for comparison
   const consolidatedReservationDates = consolidateRanges(
-    featureReservationDates,
+    frontcountryFeatureReservationDates,
   );
 
-  // Check every winter date range for overlaps with reservation dates
+  // Check every winter date range for overlaps with frontcountry campground reservation dates
   const hasOverlaps = consolidatedWinterDates.some((winterDateRange) =>
     // Check for overlaps with any reservation date range
     consolidatedReservationDates.some((reservationDateRange) =>

--- a/frontend/src/hooks/useValidation/rules/winterAndReservationNoOverlap.js
+++ b/frontend/src/hooks/useValidation/rules/winterAndReservationNoOverlap.js
@@ -1,6 +1,8 @@
 import { areIntervalsOverlapping } from "date-fns";
 
 import consolidateRanges from "@/lib/consolidateDateRanges";
+import * as SEASON_TYPE from "@/constants/seasonType";
+import * as DATE_TYPE from "@/constants/dateType";
 
 /**
  * Validates that Park-level Winter fee dates do not overlap with Frontcountry Campground Feature Reservation dates.
@@ -12,13 +14,16 @@ export default function winterAndReservationNoOverlap(seasonData, context) {
   const { dateRanges, elements, frontcountryFeatureReservationDates } = context;
   const { current } = seasonData;
 
+  // This rule applies to winter seasons only. Skip for regular seasons
+  if (current.seasonType !== SEASON_TYPE.WINTER) return;
+
   // This rule applies to the Park level. Skip for other levels
   if (context.level !== "park") return;
 
   // Get a list of Park-level winter dates
   const winterDates = dateRanges.filter(
     (dateRange) =>
-      dateRange.dateType.name === "Winter fee" &&
+      dateRange.dateType.strapiDateTypeId === DATE_TYPE.WINTER_FEE &&
       dateRange.startDate &&
       dateRange.endDate,
   );

--- a/frontend/src/hooks/useValidation/rules/winterAndReservationNoOverlap.js
+++ b/frontend/src/hooks/useValidation/rules/winterAndReservationNoOverlap.js
@@ -59,7 +59,7 @@ export default function winterAndReservationNoOverlap(seasonData, context) {
     // Show the error below the Winter fee date range section
     context.addError(
       elements.dateableDateType(current.park.dateableId, "Winter fee"),
-      "Winter dates must not overlap with reservation dates. (To change reservation dates, edit campground)",
+      "Winter dates must not overlap with reservation dates. (To change reservation dates, edit the park's frontcountry campsite reservation dates)",
     );
   }
 }

--- a/frontend/src/hooks/useValidation/useValidation.js
+++ b/frontend/src/hooks/useValidation/useValidation.js
@@ -43,6 +43,16 @@ const elements = {
 };
 
 /**
+ * Adds the Strapi Feature Type ID to a date range object as `strapiFeatureTypeId`
+ * @param {number} strapiFeatureTypeId The Strapi Feature Type ID to add to the date range
+ * @param {Object} dateRange The date range object
+ * @returns {Object} The date range object with the added `strapiFeatureTypeId` property
+ */
+function addFeatureTypeToDateRange(strapiFeatureTypeId, dateRange) {
+  return { ...dateRange, strapiFeatureTypeId };
+}
+
+/**
  * Synchronously validates the form data.
  * Called automatically by the useValidate hook, or manually by the validateForm method.
  * @param {Object} seasonData The season form data to validate
@@ -92,13 +102,30 @@ function validate(seasonData, seasonContext) {
   } else if (level === "park-area") {
     // For parkArea-level forms, don't include any parkArea-level dates,
     // just include all feature-level dates within the parkArea.
-    const featureDateRanges = current.parkArea.features.flatMap(
-      (feature) => feature.dateable.dateRanges,
+    const featureDateRanges = current.parkArea.features.flatMap((feature) =>
+      feature.dateable.dateRanges.map((dateRange) =>
+        // Add feature type for validation rules that need it (Winter fee/Tier 1 and 2 rules)
+        addFeatureTypeToDateRange(
+          feature.featureType.strapiFeatureTypeId,
+          dateRange,
+        ),
+      ),
     );
 
     dateRanges.push(...featureDateRanges);
   } else if (level === "feature") {
-    dateRanges.push(...current.feature.dateable.dateRanges);
+    const { feature } = current;
+
+    // Add feature type for validation rules that need it (Winter fee/Tier 1 and 2 rules)
+    const dateRangesWithFeatureType = feature.dateable.dateRanges.map(
+      (dateRange) =>
+        addFeatureTypeToDateRange(
+          feature.featureType.strapiFeatureTypeId,
+          dateRange,
+        ),
+    );
+
+    dateRanges.push(...dateRangesWithFeatureType);
   }
 
   validationContext.dateRanges = dateRanges;

--- a/frontend/src/hooks/useValidation/useValidation.js
+++ b/frontend/src/hooks/useValidation/useValidation.js
@@ -71,9 +71,10 @@ function validate(seasonData, seasonContext) {
     errors.push({ element, message });
   };
 
-  // Provide the flat array of Feature Reservation dates in the context, for Park-level validation
-  validationContext.featureReservationDates =
-    seasonData.featureReservationDates ?? [];
+  // Provide the flat array of Frontcountry Campground Feature Reservation dates in the context,
+  // for Park-level validation
+  validationContext.frontcountryFeatureReservationDates =
+    seasonData.frontcountryFeatureReservationDates ?? [];
 
   // Provide flat arrays of some Park-level dates in the context, for Feature/Area Reservation validation
   validationContext.parkTier1Dates = seasonData.parkTier1Dates ?? [];


### PR DESCRIPTION
### Jira Ticket

CMS-1572

### Description
<!-- What did you change, and why? -->

Updates the Winter fee and Tier 1 & 2 validation rules to only consider **Frontcountry Campground** feature reservation dates in its comparisons. Previously, it used feature reservation dates of **all** types.

I had to update a few endpoints to send the necessary featureType values for the validation functions.