### PR TITLE
CMS-1228: Update tagging logic with fallback to any other source tag

### DIFF
--- a/.github/workflows/build-dev.yaml
+++ b/.github/workflows/build-dev.yaml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Set env
         run: |
-          echo "SHORT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+          echo "SHORT_SHA=$(git rev-parse --short=8 HEAD)" >> $GITHUB_ENV
           echo "REGISTRY_IMAGE=${{ vars.OPENSHIFT_EXTERNAL_REPOSITORY }}/${{ vars.OPENSHIFT_LICENSE_PLATE }}-tools/${{ env.IMAGE_NAME }}" >> $GITHUB_ENV
 
       - name: Install OpenShift CLI tools
@@ -65,7 +65,7 @@ jobs:
 
       - name: Set env
         run: |
-          echo "SHORT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+          echo "SHORT_SHA=$(git rev-parse --short=8 HEAD)" >> $GITHUB_ENV
           echo "REGISTRY_IMAGE=${{ vars.OPENSHIFT_EXTERNAL_REPOSITORY }}/${{ vars.OPENSHIFT_LICENSE_PLATE }}-tools/${{ env.IMAGE_NAME }}" >> $GITHUB_ENV
 
       - name: Login to OpenShift Container Repository

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Set env
         run: |
-          echo "SHORT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+          echo "SHORT_SHA=$(git rev-parse --short=8 HEAD)" >> $GITHUB_ENV
           echo "REGISTRY_IMAGE=${{ vars.OPENSHIFT_EXTERNAL_REPOSITORY }}/${{ vars.OPENSHIFT_LICENSE_PLATE }}-tools/${{ env.IMAGE_NAME }}" >> $GITHUB_ENV
 
       - name: Install OpenShift CLI tools
@@ -65,7 +65,7 @@ jobs:
 
       - name: Set env
         run: |
-          echo "SHORT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+          echo "SHORT_SHA=$(git rev-parse --short=8 HEAD)" >> $GITHUB_ENV
           echo "REGISTRY_IMAGE=${{ vars.OPENSHIFT_EXTERNAL_REPOSITORY }}/${{ vars.OPENSHIFT_LICENSE_PLATE }}-tools/${{ env.IMAGE_NAME }}" >> $GITHUB_ENV
 
       - name: Login to OpenShift Container Repository

--- a/.github/workflows/on-tag-push.yaml
+++ b/.github/workflows/on-tag-push.yaml
@@ -18,6 +18,12 @@ jobs:
           echo "SHORT_SHA=${GITHUB_SHA::7}" >> $GITHUB_ENV
           echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
 
+      # Check out the commit to access its git tags, if needed
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-tags: true
+
       - name: Install OpenShift CLI tools
         uses: redhat-actions/openshift-tools-installer@v1
         with:
@@ -30,11 +36,36 @@ jobs:
           openshift_token: ${{ secrets.OPENSHIFT_SERVICE_TOKEN }}
 
       - name: Tag images
+        # Determine the source tag: try SHORT_SHA first, and fall back to an existing Git tag on this commit
         run: |
-          oc -n ${{ env.TOOLS_NAMESPACE }} tag frontend-main:${{ env.SHORT_SHA }} frontend-main:${{ env.RELEASE_VERSION }}
-          oc -n ${{ env.TOOLS_NAMESPACE }} tag backend-main:${{ env.SHORT_SHA }} backend-main:${{ env.RELEASE_VERSION }}
+          SOURCE_TAG=""
 
-      - name: Delete images tags with commit hash
-        run: |
-          oc -n ${{ env.TOOLS_NAMESPACE }} tag -d frontend-main:${{ env.SHORT_SHA }}
-          oc -n ${{ env.TOOLS_NAMESPACE }} tag -d backend-main:${{ env.SHORT_SHA }}
+          # Use the SHORT_SHA tag if it exists
+          if oc -n "$TOOLS_NAMESPACE" get istag "frontend-main:$SHORT_SHA" &>/dev/null; then
+            SOURCE_TAG="$SHORT_SHA"
+          else
+            # If the SHORT_SHA tag has been pruned, look for any other tag on this commit
+            # to use as the source. (like "v1.2.3-uat.5")
+            echo "SHORT_SHA tag not found, checking other Git tags on this commit..."
+            for candidate in $(git tag --points-at HEAD); do
+              # Skip the tag we're currently creating
+              if [ "$candidate" = "$RELEASE_VERSION" ]; then
+                continue
+              fi
+
+              # If this candidate tag exists as an imagestream tag in OpenShift, use it as the source tag
+              if oc -n "$TOOLS_NAMESPACE" get istag "frontend-main:$candidate" &>/dev/null; then
+                SOURCE_TAG="$candidate"
+                echo "Found existing imagestream tag: $candidate"
+                break
+              fi
+            done
+          fi
+
+          if [ -z "$SOURCE_TAG" ]; then
+            echo "::error::No source imagestream tag found for commit $SHORT_SHA. Cannot add release tag $RELEASE_VERSION."
+            exit 1
+          fi
+
+          oc -n "$TOOLS_NAMESPACE" tag "frontend-main:$SOURCE_TAG" "frontend-main:$RELEASE_VERSION"
+          oc -n "$TOOLS_NAMESPACE" tag "backend-main:$SOURCE_TAG" "backend-main:$RELEASE_VERSION"

--- a/.github/workflows/on-tag-push.yaml
+++ b/.github/workflows/on-tag-push.yaml
@@ -13,16 +13,16 @@ jobs:
   tag:
     runs-on: ubuntu-24.04
     steps:
-      - name: Set env
-        run: |
-          echo "SHORT_SHA=${GITHUB_SHA::7}" >> $GITHUB_ENV
-          echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
-
-      # Check out the commit to access its git tags, if needed
+      # Check out the commit to access its SHA hash and tags
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-tags: true
+
+      - name: Set env
+        run: |
+          echo "SHORT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+          echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
 
       - name: Install OpenShift CLI tools
         uses: redhat-actions/openshift-tools-installer@v1

--- a/.github/workflows/on-tag-push.yaml
+++ b/.github/workflows/on-tag-push.yaml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-tags: true
+          ref: ${{ github.ref }}
 
       - name: Set env
         run: |

--- a/.github/workflows/on-tag-push.yaml
+++ b/.github/workflows/on-tag-push.yaml
@@ -40,23 +40,25 @@ jobs:
         run: |
           SOURCE_TAG=""
 
-          # Use the SHORT_SHA tag if it exists
-          if oc -n "$TOOLS_NAMESPACE" get istag "frontend-main:$SHORT_SHA" &>/dev/null; then
+          # Use the SHORT_SHA tag if it exists for both imagestreams
+          if oc -n "$TOOLS_NAMESPACE" get istag "frontend-main:$SHORT_SHA" &>/dev/null && \
+             oc -n "$TOOLS_NAMESPACE" get istag "backend-main:$SHORT_SHA" &>/dev/null; then
             SOURCE_TAG="$SHORT_SHA"
           else
-            # If the SHORT_SHA tag has been pruned, look for any other tag on this commit
+            # If the SHORT_SHA tags have been pruned, look for any other tag on this commit
             # to use as the source. (like "v1.2.3-uat.5")
-            echo "SHORT_SHA tag not found, checking other Git tags on this commit..."
+            echo "SHORT_SHA tag not found in both imagestreams, checking other Git tags on this commit..."
             for candidate in $(git tag --points-at HEAD); do
               # Skip the tag we're currently creating
               if [ "$candidate" = "$RELEASE_VERSION" ]; then
                 continue
               fi
 
-              # If this candidate tag exists as an imagestream tag in OpenShift, use it as the source tag
-              if oc -n "$TOOLS_NAMESPACE" get istag "frontend-main:$candidate" &>/dev/null; then
+              # Use this candidate if it exists as a tag for both imagestreams in OpenShift
+              if oc -n "$TOOLS_NAMESPACE" get istag "frontend-main:$candidate" &>/dev/null && \
+                 oc -n "$TOOLS_NAMESPACE" get istag "backend-main:$candidate" &>/dev/null; then
                 SOURCE_TAG="$candidate"
-                echo "Found existing imagestream tag: $candidate"
+                echo "Found existing tags for both imagestreams: $candidate"
                 break
               fi
             done

--- a/.github/workflows/on-tag-push.yaml
+++ b/.github/workflows/on-tag-push.yaml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Set env
         run: |
-          echo "SHORT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+          echo "SHORT_SHA=$(git rev-parse --short=8 HEAD)" >> $GITHUB_ENV
           echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
 
       - name: Install OpenShift CLI tools

--- a/tools/imagetag-prune/index.js
+++ b/tools/imagetag-prune/index.js
@@ -8,9 +8,9 @@ const OPENSHIFT_API_URL =
   "https://api.silver.devops.gov.bc.ca:6443/apis/image.openshift.io/v1";
 const TOOLS_NAMESPACE = process.env.TOOLS_NAMESPACE || "a7dd13-tools";
 
-// Regex pattern used to match git sha hash abcd345
+// Regex pattern used to match git sha hash abcd3456
 const GIT_SHA_HASH_REGEX =
-  process.env.GIT_SHA_HASH_REGEX || "\\b[0-9a-f]{7}\\b";
+  process.env.GIT_SHA_HASH_REGEX || "\\b[0-9a-f]{8}\\b";
 
 // Regex pattern used to match release tags, e.g., v1.12.3
 const RELEASE_TAG_REGEX =


### PR DESCRIPTION
### Jira Ticket

CMS-1228

### Description
<!-- What did you change, and why? -->

To tag an image in openshift with `oc tag`, we need to identify the image with an existing tag ("source tag"):
```sh
oc tag image-name:existing-tag image-name:new-tag
```
We were using the git commit hash `SHORT_SHA` value for this and then deleting it immediately, so it would fail if we tried to add another tag later. (For example, adding `v2.3.0` on a commit that was already tagged with `v2.3.0-uat.3`)
The SHA tags also get pruned by the ImageTag Pruner script, so we can't rely on them being there.

This branch updates the logic in the "On tag push" Github action script:

- Updated all scripts to use 8-digit SHORT_SHA instead of 7, because my local version seems to use 8 by default and I'm guessing the server is using an older version.
- Don't delete SHORT_SHA tags in this script. They will be cleaned up eventually by the ImageTag Pruner script.
- Check out the commit being tagged so we can look at its other git tags
- Try using the SHORT_SHA tag as usual
- If the SHORT_SHA tag has been pruned, use `git tag --points-at <commit>` to find any other tags on this commit. If we're promoting a UAT tag to a production release, it will find the last UAT tag, for example. 
- Check if that git tag is also an imagestream tag in OpenShift, and use it as the source tag for the tagging operation
- If no suitable tags are found, it will fail like before. But now much less likely to happen with our normal workflows.

It could still fail if we add a tag to a very old commit where all of the other tags have been pruned. This seems pretty unlikely, but we can always manually tag stuff in OpenShift for edge cases like that. Or we could increase the number of tags to retain in the pruner script.

```sh
# You can try:

git tag --points-at a87276c13c7276906a61777c29b1880a2a943f99
# prints v2.3.0 and v2.3.0-uat.3

git tag --points-at c2210c
# prints v2.2.0 and v2.2.0-uat.6
```

# Testing on this PR branch
I got the 8-digit short SHA hash of the latest commit on this branch:
```sh
git rev-parse --short=8 HEAD

# prints: 338081dc
```
Created a git tag locally and pushed it to Github:
```sh
git tag duncan-testing
git push origin duncan-testing
```
It ran this action and succeeded:
https://github.com/bcgov/bcparks-staff-portal/actions/runs/24589512604

Confirmed that the tags exist in openshift:
```sh
oc get is frontend-main -n a7dd13-tools -o yaml | grep tag:

# prints:
    tag: 338081dc ⬅️ the short SHA tag
    tag: duncan-testing ⬅️ the git tag I pushed
    tag: latest
[...etc]
```
Confirmed that both tags point to the same image:
```sh
oc -n a7dd13-tools get istag frontend-main:338081dc

# prints an sha256 hash starting with sha256:307536764b...

oc -n a7dd13-tools get istag frontend-main:duncan-testing

# prints the same sha256 hash as above: sha256:307536764b...
```

I also tried deleting the short sha tag and [pushing another tag](https://github.com/bcgov/bcparks-staff-portal/actions/runs/24588864595/job/71905031072)

> SHORT_SHA tag not found in both imagestreams, checking other Git tags on this commit...
Found existing tags for both imagestreams: dm-push-test-2
Tag frontend-main:dm-push-test-5 set to frontend-main@sha256:307536764b47de7db90b447f26b62f4c1c914ff626f9b979c457f205e1dc039f.

(Note the same sha256 hash mentioned above 👍)

Then I tried deleting all tags and pushing one to [test the failure state](https://github.com/bcgov/bcparks-staff-portal/actions/runs/24589068501). Everything is working as expected now ✅ 