### PR TITLE
CMS-1665: Add recreation district filter

### DIFF
--- a/frontend/src/components/advisories/shared/multiSelect/MultiSelect.jsx
+++ b/frontend/src/components/advisories/shared/multiSelect/MultiSelect.jsx
@@ -1,0 +1,80 @@
+import PropTypes from "prop-types";
+import Form from "react-bootstrap/Form";
+import Select, { components } from "react-select";
+import "./MultiSelect.scss";
+
+function CheckboxOption(props) {
+  const { isSelected, label } = props;
+
+  return (
+    <components.Option {...props}>
+      <div className="multi-select-option">
+        <input
+          className="multi-select-option-checkbox"
+          type="checkbox"
+          checked={isSelected}
+          readOnly
+          tabIndex={-1}
+        />
+        <span>{label}</span>
+      </div>
+    </components.Option>
+  );
+}
+
+CheckboxOption.propTypes = {
+  isSelected: PropTypes.bool,
+  label: PropTypes.string,
+};
+
+export function MultiSelect({
+  label,
+  countLabel,
+  value,
+  options,
+  onChange,
+  placeholder,
+}) {
+  const displayPlaceholder =
+    value.length > 0 ? `${countLabel} (${value.length})` : placeholder;
+
+  return (
+    <>
+      {label && <Form.Label className="mb-1">{label}</Form.Label>}
+      <Select
+        value={value}
+        options={options}
+        components={{ Option: CheckboxOption }}
+        onChange={onChange}
+        placeholder={displayPlaceholder}
+        className="bcgov-select"
+        isMulti
+        isClearable
+        hideSelectedOptions={false}
+        controlShouldRenderValue={false}
+        closeMenuOnSelect={false}
+        styles={{
+          menu: (base) => ({ ...base, zIndex: 999 }),
+        }}
+      />
+    </>
+  );
+}
+
+MultiSelect.propTypes = {
+  label: PropTypes.string,
+  countLabel: PropTypes.string,
+  value: PropTypes.arrayOf(PropTypes.object),
+  options: PropTypes.arrayOf(PropTypes.object),
+  onChange: PropTypes.func,
+  placeholder: PropTypes.string,
+};
+
+MultiSelect.defaultProps = {
+  label: "",
+  countLabel: "",
+  value: [],
+  options: [],
+  onChange() {},
+  placeholder: "Select...",
+};

--- a/frontend/src/components/advisories/shared/multiSelect/MultiSelect.jsx
+++ b/frontend/src/components/advisories/shared/multiSelect/MultiSelect.jsx
@@ -1,3 +1,4 @@
+import { useId } from "react";
 import PropTypes from "prop-types";
 import Form from "react-bootstrap/Form";
 import Select, { components } from "react-select";
@@ -13,6 +14,7 @@ function CheckboxOption(props) {
           className="multi-select-option-checkbox"
           type="checkbox"
           checked={isSelected}
+          aria-hidden="true"
           readOnly
           tabIndex={-1}
         />
@@ -35,13 +37,20 @@ export function MultiSelect({
   onChange,
   placeholder,
 }) {
+  const generatedId = useId();
   const displayPlaceholder =
     value.length > 0 ? `${countLabel} (${value.length})` : placeholder;
 
   return (
     <>
-      {label && <Form.Label className="mb-1">{label}</Form.Label>}
+      {label && (
+        <Form.Label htmlFor={generatedId} className="mb-1">
+          {label}
+        </Form.Label>
+      )}
       <Select
+        inputId={generatedId}
+        instanceId={generatedId}
         value={value}
         options={options}
         components={{ Option: CheckboxOption }}

--- a/frontend/src/components/advisories/shared/multiSelect/MultiSelect.scss
+++ b/frontend/src/components/advisories/shared/multiSelect/MultiSelect.scss
@@ -1,0 +1,5 @@
+.multi-select-option {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}

--- a/frontend/src/hooks/useCms.js
+++ b/frontend/src/hooks/useCms.js
@@ -213,6 +213,15 @@ export default function useCms() {
     [fetchCached],
   );
 
+  const getRecreationDistricts = useCallback(
+    () =>
+      fetchCached(
+        "recreationDistricts",
+        `/recreation-districts?${querySort("district")}&populate=*`,
+      ),
+    [fetchCached],
+  );
+
   const getEventTypes = useCallback(
     () => fetchCached("eventTypes", `/event-types?${querySort("eventType")}`),
     [fetchCached],
@@ -290,6 +299,7 @@ export default function useCms() {
     getFireCentres,
     getFireZones,
     getNaturalResourceDistricts,
+    getRecreationDistricts,
     getEventTypes,
     getAccessStatuses,
     getUrgencies,

--- a/frontend/src/lib/advisories/utils/AdvisoryDashboardQuery.js
+++ b/frontend/src/lib/advisories/utils/AdvisoryDashboardQuery.js
@@ -82,7 +82,9 @@ export function buildFilter(
 
   if (selectedDistrictIds.length > 0) {
     filters.push({
-      recreationDistricts: { documentId: { $in: selectedDistrictIds } },
+      recreationResources: {
+        recreationDistrict: { documentId: { $in: selectedDistrictIds } },
+      },
     });
   }
 

--- a/frontend/src/lib/advisories/utils/AdvisoryDashboardQuery.js
+++ b/frontend/src/lib/advisories/utils/AdvisoryDashboardQuery.js
@@ -56,15 +56,13 @@ const COLUMN_FILTERS = [
  * Builds an array of filters
  * @param {Object} tableFilterValues Column filter values keyed by column field name
  * @param {number} selectedRegionId Selected region id (0 = none)
- * @param {string|number} selectedParkId Selected park documentId (0 = none)
- * @param {Array} protectedAreas Full list of protected areas (used to resolve orcs from documentId)
+ * @param {string} selectedDistrictId Selected district id ("" = none)
  * @returns {Array} Array of Strapi filters
  */
 export function buildFilter(
   tableFilterValues,
   selectedRegionId,
-  selectedParkId,
-  protectedAreas,
+  selectedDistrictId,
 ) {
   const filters = [];
 
@@ -80,16 +78,10 @@ export function buildFilter(
     });
   }
 
-  if (selectedParkId && selectedParkId !== -1) {
-    const park = protectedAreas.find(
-      (protectedArea) => protectedArea.documentId === selectedParkId,
-    );
-
-    if (park) {
-      filters.push({
-        protectedAreas: { orcs: { $eq: park.orcs } },
-      });
-    }
+  if (selectedDistrictId) {
+    filters.push({
+      resourceDistricts: { documentId: { $eq: selectedDistrictId } },
+    });
   }
 
   return filters;

--- a/frontend/src/lib/advisories/utils/AdvisoryDashboardQuery.js
+++ b/frontend/src/lib/advisories/utils/AdvisoryDashboardQuery.js
@@ -55,14 +55,14 @@ const COLUMN_FILTERS = [
 /**
  * Builds an array of filters
  * @param {Object} tableFilterValues Column filter values keyed by column field name
- * @param {number} selectedRegionId Selected region id (0 = none)
- * @param {string} selectedDistrictId Selected district id ("" = none)
+ * @param {number[]} selectedRegionIds Selected region ids ([] = none)
+ * @param {string[]} selectedDistrictIds Selected district documentIds ([] = none)
  * @returns {Array} Array of Strapi filters
  */
 export function buildFilter(
   tableFilterValues,
-  selectedRegionId,
-  selectedDistrictId,
+  selectedRegionIds,
+  selectedDistrictIds,
 ) {
   const filters = [];
 
@@ -72,15 +72,15 @@ export function buildFilter(
     }
   }
 
-  if (selectedRegionId) {
+  if (selectedRegionIds.length > 0) {
     filters.push({
-      regions: { id: { $eq: selectedRegionId } },
+      regions: { id: { $in: selectedRegionIds } },
     });
   }
 
-  if (selectedDistrictId) {
+  if (selectedDistrictIds.length > 0) {
     filters.push({
-      resourceDistricts: { documentId: { $eq: selectedDistrictId } },
+      recreationDistricts: { documentId: { $in: selectedDistrictIds } },
     });
   }
 

--- a/frontend/src/lib/advisories/utils/AdvisoryDashboardQuery.js
+++ b/frontend/src/lib/advisories/utils/AdvisoryDashboardQuery.js
@@ -55,14 +55,16 @@ const COLUMN_FILTERS = [
 /**
  * Builds an array of filters
  * @param {Object} tableFilterValues Column filter values keyed by column field name
- * @param {number[]} selectedRegionIds Selected region ids ([] = none)
+ * @param {string[]} selectedRegionIds Selected region documentIds ([] = none)
  * @param {string[]} selectedDistrictIds Selected district documentIds ([] = none)
+ * @param {string[]} selectedParkIds Selected park documentIds ([] = none)
  * @returns {Array} Array of Strapi filters
  */
 export function buildFilter(
   tableFilterValues,
   selectedRegionIds,
   selectedDistrictIds,
+  selectedParkIds,
 ) {
   const filters = [];
 
@@ -74,13 +76,19 @@ export function buildFilter(
 
   if (selectedRegionIds.length > 0) {
     filters.push({
-      regions: { id: { $in: selectedRegionIds } },
+      regions: { documentId: { $in: selectedRegionIds } },
     });
   }
 
   if (selectedDistrictIds.length > 0) {
     filters.push({
       recreationDistricts: { documentId: { $in: selectedDistrictIds } },
+    });
+  }
+
+  if (selectedParkIds.length > 0) {
+    filters.push({
+      protectedAreas: { documentId: { $in: selectedParkIds } },
     });
   }
 

--- a/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.jsx
+++ b/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.jsx
@@ -61,7 +61,7 @@ export default function AdvisoryDashboard() {
   const {
     getRegions,
     getManagementAreas,
-    getProtectedAreas,
+    getRecreationDistricts,
     getAdvisoryStatuses,
     getUrgencies,
     cmsGet,
@@ -71,15 +71,15 @@ export default function AdvisoryDashboard() {
   const [toCreate, setToCreate] = useState(false);
   const [selectedRegionId, setSelectedRegionId] = useState(0);
   const [selectedRegion, setSelectedRegion] = useState(null);
-  const [selectedParkId, setSelectedParkId] = useState(0);
-  const [selectedPark, setSelectedPark] = useState(null);
+  const [selectedDistrictId, setSelectedDistrictId] = useState("");
+  const [selectedDistrict, setSelectedDistrict] = useState(null);
   const [publishedAdvisories, setPublishedAdvisories] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
   const [hasErrors, setHasErrors] = useState(false);
   const [publicAdvisories, setPublicAdvisories] = useState([]);
   const [regions, setRegions] = useState([]);
   const [managementAreas, setManagementAreas] = useState([]);
-  const [protectedAreas, setProtectedAreas] = useState([]);
+  const [districts, setDistricts] = useState([]);
   const [advisoryStatuses, setAdvisoryStatuses] = useState([]);
   const [urgencies, setUrgencies] = useState([]);
   const [currentPage, setCurrentPage] = useState(1);
@@ -90,12 +90,16 @@ export default function AdvisoryDashboard() {
   const [isCmsDataLoaded, setIsCmsDataLoaded] = useState(false);
   const [sortConfig, setSortConfig] = useState(null);
 
+  console.log("districts", districts);
+  console.log("selectedDistrict", selectedDistrict);
+  console.log("selectedDistrictId", selectedDistrictId);
+
   const defaultPageFilters = [
     { filterName: "region", filterValue: "", type: "page" },
-    { filterName: "park", filterValue: "", type: "page" },
+    { filterName: "district", filterValue: "", type: "page" },
   ];
 
-  // Persisted filter state for the dashboard (region, park, and table filters)
+  // Persisted filter state for the dashboard (region, district, and table filters)
   // Saved to localStorage as an array of { type: "page"|"table", filterName/fieldName, filterValue/fieldValue }
   const [storedFilters, setStoredFilters] = useLocalStorage(
     "advisoryFilters",
@@ -126,7 +130,7 @@ export default function AdvisoryDashboard() {
   // Called by DataTable after user stops typing
   const persistTableFilterValues = useDebounceCallback((values) => {
     setStoredFilters((currentFilters) => {
-      // Keep page-level filters (region, park)
+      // Keep page-level filters (region, district)
       const pageFilters = currentFilters.filter((f) => f.type === "page");
       // Convert { [fieldName]: value } to array of { fieldName, fieldValue, type: "table" }
       const tableFilters = Object.entries(values)
@@ -165,13 +169,13 @@ export default function AdvisoryDashboard() {
         const [
           regionsData,
           managementAreasData,
-          protectedAreasData,
+          districtsData,
           fetchedAdvisoryStatuses,
           fetchedUrgencies,
         ] = await Promise.all([
           getRegions(),
           getManagementAreas(),
-          getProtectedAreas(),
+          getRecreationDistricts(),
           getAdvisoryStatuses(),
           getUrgencies(),
         ]);
@@ -180,7 +184,7 @@ export default function AdvisoryDashboard() {
 
         setRegions(regionsData);
         setManagementAreas(managementAreasData);
-        setProtectedAreas(protectedAreasData);
+        setDistricts(districtsData);
 
         // Fetch advisory statuses and urgencies for filter options and table icons
         setAdvisoryStatuses(fetchedAdvisoryStatuses);
@@ -225,18 +229,21 @@ export default function AdvisoryDashboard() {
             }
           }
 
-          const parkId = getPageFilterValue(initialStoredFilters, "park");
+          const districtId = getPageFilterValue(
+            initialStoredFilters,
+            "district",
+          );
 
-          if (parkId) {
-            const park = protectedAreasData.find(
-              (p) => p.documentId === parkId,
+          if (districtId) {
+            const district = districtsData.find(
+              (d) => d.documentId === districtId,
             );
 
-            if (park) {
-              setSelectedParkId(parkId);
-              setSelectedPark({
-                label: park.protectedAreaName,
-                value: park.documentId,
+            if (district) {
+              setSelectedDistrictId(districtId);
+              setSelectedDistrict({
+                label: district.district,
+                value: district.documentId,
               });
             }
           }
@@ -258,7 +265,7 @@ export default function AdvisoryDashboard() {
     cmsGet,
     getAdvisoryStatuses,
     getManagementAreas,
-    getProtectedAreas,
+    getRecreationDistricts,
     getRegions,
     getUrgencies,
     initialStoredFilters,
@@ -299,8 +306,7 @@ export default function AdvisoryDashboard() {
         const columnFilterClauses = buildFilter(
           debouncedTableFilterValues,
           selectedRegionId,
-          selectedParkId,
-          protectedAreas,
+          selectedDistrictId,
         );
 
         // When "All" is selected, first fetch the current total with
@@ -409,8 +415,7 @@ export default function AdvisoryDashboard() {
     isCmsDataLoaded,
     managementAreas,
     pageSize,
-    protectedAreas,
-    selectedParkId,
+    selectedDistrictId,
     selectedRegionId,
     setError,
     showArchived,
@@ -427,13 +432,13 @@ export default function AdvisoryDashboard() {
     [regions],
   );
 
-  const parkOptions = useMemo(
+  const districtOptions = useMemo(
     () =>
-      (protectedAreas || []).map((p) => ({
-        label: p.protectedAreaName,
-        value: p.documentId,
+      (districts || []).map((district) => ({
+        label: district.district,
+        value: district.documentId,
       })),
-    [protectedAreas],
+    [districts],
   );
 
   const tableColumns = useMemo(
@@ -801,24 +806,22 @@ export default function AdvisoryDashboard() {
               onChange={(e) => {
                 setSelectedRegion(e);
                 setSelectedRegionId(e ? e.value : 0);
-
-                setSelectedPark(null);
-                setSelectedParkId(0);
+                setSelectedDistrict(null);
+                setSelectedDistrictId("");
                 setCurrentPage(1);
 
                 setStoredFilters((currentFilters) => {
-                  const nonPageFilters = currentFilters.filter(
-                    (o) => o.type !== "page",
+                  const nonRegionPageFilters = currentFilters.filter(
+                    (o) => !(o.type === "page" && o.filterName === "region"),
                   );
 
                   return [
-                    ...nonPageFilters,
+                    ...nonRegionPageFilters,
                     {
                       type: "page",
                       filterName: "region",
                       filterValue: e ? e.value : 0,
                     },
-                    { type: "page", filterName: "park", filterValue: 0 }, // Reset park filter
                   ];
                 });
               }}
@@ -832,30 +835,29 @@ export default function AdvisoryDashboard() {
           </div>
           <div className="col-xl-5 col-md-4 col-sm-12">
             <Select
-              value={selectedPark}
-              options={parkOptions}
+              value={selectedDistrict}
+              options={districtOptions}
               onChange={(e) => {
-                setSelectedPark(e);
-                setSelectedParkId(e ? e.value : 0);
+                setSelectedDistrict(e);
+                setSelectedDistrictId(e ? e.value : "");
                 setCurrentPage(1);
 
                 setStoredFilters((currentFilters) => {
-                  // Remove any existing "park" page filter
-                  const nonParkPageFilters = currentFilters.filter(
-                    (o) => !(o.type === "page" && o.filterName === "park"),
+                  const nonDistrictPageFilters = currentFilters.filter(
+                    (o) => !(o.type === "page" && o.filterName === "district"),
                   );
 
                   return [
-                    ...nonParkPageFilters,
+                    ...nonDistrictPageFilters,
                     {
                       type: "page",
-                      filterName: "park",
-                      filterValue: e ? e.value : 0,
+                      filterName: "district",
+                      filterValue: e ? e.value : "",
                     },
                   ];
                 });
               }}
-              placeholder="Select a Park..."
+              placeholder="Select a district..."
               className="bcgov-select"
               isClearable
               styles={{

--- a/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.jsx
+++ b/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.jsx
@@ -77,6 +77,7 @@ export default function AdvisoryDashboard() {
   const navigate = useNavigate();
   const {
     getRegions,
+    getProtectedAreas,
     getManagementAreas,
     getRecreationDistricts,
     getAdvisoryStatuses,
@@ -90,11 +91,14 @@ export default function AdvisoryDashboard() {
   const [selectedRegion, setSelectedRegion] = useState([]);
   const [selectedDistrictId, setSelectedDistrictId] = useState([]);
   const [selectedDistrict, setSelectedDistrict] = useState([]);
+  const [selectedParkId, setSelectedParkId] = useState([]);
+  const [selectedPark, setSelectedPark] = useState([]);
   const [publishedAdvisories, setPublishedAdvisories] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
   const [hasErrors, setHasErrors] = useState(false);
   const [publicAdvisories, setPublicAdvisories] = useState([]);
   const [regions, setRegions] = useState([]);
+  const [protectedAreas, setProtectedAreas] = useState([]);
   const [managementAreas, setManagementAreas] = useState([]);
   const [districts, setDistricts] = useState([]);
   const [advisoryStatuses, setAdvisoryStatuses] = useState([]);
@@ -110,6 +114,7 @@ export default function AdvisoryDashboard() {
   const defaultPageFilters = [
     { filterName: "region", filterValue: [], type: "page" },
     { filterName: "district", filterValue: [], type: "page" },
+    { filterName: "park", filterValue: [], type: "page" },
   ];
 
   // Persisted filter state for the dashboard (region, district, and table filters)
@@ -181,12 +186,14 @@ export default function AdvisoryDashboard() {
       try {
         const [
           regionsData,
+          protectedAreasData,
           managementAreasData,
           districtsData,
           fetchedAdvisoryStatuses,
           fetchedUrgencies,
         ] = await Promise.all([
           getRegions(),
+          getProtectedAreas(),
           getManagementAreas(),
           getRecreationDistricts(),
           getAdvisoryStatuses(),
@@ -196,6 +203,7 @@ export default function AdvisoryDashboard() {
         if (!isMounted) return;
 
         setRegions(regionsData);
+        setProtectedAreas(protectedAreasData);
         setManagementAreas(managementAreasData);
         setDistricts(districtsData);
 
@@ -234,10 +242,10 @@ export default function AdvisoryDashboard() {
 
           if (regionIds.length > 0) {
             const selectedRegions = regionsData
-              .filter((region) => regionIds.includes(region.id))
+              .filter((region) => regionIds.includes(region.documentId))
               .map((region) => ({
                 label: `${region.regionName} Region`,
-                value: region.id,
+                value: region.documentId,
               }));
 
             if (selectedRegions.length > 0) {
@@ -263,6 +271,24 @@ export default function AdvisoryDashboard() {
               setSelectedDistrict(selectedDistricts);
             }
           }
+
+          const parkIds = normalizePageFilterValues(
+            getPageFilterValue(initialStoredFilters, "park", []),
+          );
+
+          if (parkIds.length > 0) {
+            const selectedParks = protectedAreasData
+              .filter((park) => parkIds.includes(park.documentId))
+              .map((park) => ({
+                label: park.protectedAreaName,
+                value: park.documentId,
+              }));
+
+            if (selectedParks.length > 0) {
+              setSelectedParkId(parkIds);
+              setSelectedPark(selectedParks);
+            }
+          }
           setIsCmsDataLoaded(true);
         }
       } catch (error) {
@@ -281,6 +307,7 @@ export default function AdvisoryDashboard() {
     cmsGet,
     getAdvisoryStatuses,
     getManagementAreas,
+    getProtectedAreas,
     getRecreationDistricts,
     getRegions,
     getUrgencies,
@@ -323,6 +350,7 @@ export default function AdvisoryDashboard() {
           debouncedTableFilterValues,
           selectedRegionId,
           selectedDistrictId,
+          selectedParkId,
         );
 
         // When "All" is selected, first fetch the current total with
@@ -432,6 +460,7 @@ export default function AdvisoryDashboard() {
     managementAreas,
     pageSize,
     selectedDistrictId,
+    selectedParkId,
     selectedRegionId,
     setError,
     showArchived,
@@ -441,9 +470,9 @@ export default function AdvisoryDashboard() {
 
   const regionOptions = useMemo(
     () =>
-      (regions || []).map((r) => ({
-        label: `${r.regionName} Region`,
-        value: r.id,
+      (regions || []).map((region) => ({
+        label: `${region.regionName} Region`,
+        value: region.documentId,
       })),
     [regions],
   );
@@ -455,6 +484,15 @@ export default function AdvisoryDashboard() {
         value: district.documentId,
       })),
     [districts],
+  );
+
+  const parkOptions = useMemo(
+    () =>
+      (protectedAreas || []).map((park) => ({
+        label: park.protectedAreaName,
+        value: park.documentId,
+      })),
+    [protectedAreas],
   );
 
   const tableColumns = useMemo(
@@ -815,53 +853,8 @@ export default function AdvisoryDashboard() {
           </div>
         </div>
         <div className="row ad-row">
-          <div className="col-xl-4 col-md-4 col-sm-12">
-            <Form.Label className="mb-1">BC Parks region</Form.Label>
-            <Select
-              value={selectedRegion}
-              options={regionOptions}
-              onChange={(e) => {
-                const selectedRegions = e || [];
-                const selectedRegionIds = selectedRegions.map((region) => region.value);
-
-                setSelectedRegion(selectedRegions);
-                setSelectedRegionId(selectedRegionIds);
-                setSelectedDistrict([]);
-                setSelectedDistrictId([]);
-                setCurrentPage(1);
-
-                setStoredFilters((currentFilters) => {
-                  const nonPageFilters = currentFilters.filter(
-                    (o) => o.type !== "page",
-                  );
-
-                  return [
-                    ...nonPageFilters,
-                    {
-                      type: "page",
-                      filterName: "region",
-                      filterValue: selectedRegionIds,
-                    },
-                    {
-                      type: "page",
-                      filterName: "district",
-                      filterValue: [],
-                    },
-                  ];
-                });
-              }}
-              placeholder="Select a Region..."
-              className="bcgov-select"
-              isMulti
-              isClearable
-              closeMenuOnSelect={false}
-              styles={{
-                menu: (base) => ({ ...base, zIndex: 999 }),
-              }}
-            />
-          </div>
-          <div className="col-xl-5 col-md-4 col-sm-12">
-            <Form.Label className="mb-1">RST Recreation district</Form.Label>
+          <div className="col-xl-3 col-md-6 col-sm-12">
+            <Form.Label className="mb-1">RST rRecreation district</Form.Label>
             <Select
               value={selectedDistrict}
               options={districtOptions}
@@ -900,7 +893,85 @@ export default function AdvisoryDashboard() {
               }}
             />
           </div>
-          <div className="col-xl-3 col-md-4 col-sm-12">
+          <div className="col-xl-3 col-md-6 col-sm-12">
+            <Form.Label className="mb-1">BC Parks region</Form.Label>
+            <Select
+              value={selectedRegion}
+              options={regionOptions}
+              onChange={(e) => {
+                const selectedRegions = e || [];
+                const selectedRegionIds = selectedRegions.map(
+                  (region) => region.value,
+                );
+
+                setSelectedRegion(selectedRegions);
+                setSelectedRegionId(selectedRegionIds);
+                setCurrentPage(1);
+
+                setStoredFilters((currentFilters) => {
+                  const nonRegionPageFilters = currentFilters.filter(
+                    (o) => !(o.type === "page" && o.filterName === "region"),
+                  );
+
+                  return [
+                    ...nonRegionPageFilters,
+                    {
+                      type: "page",
+                      filterName: "region",
+                      filterValue: selectedRegionIds,
+                    },
+                  ];
+                });
+              }}
+              placeholder="Select a Region..."
+              className="bcgov-select"
+              isMulti
+              isClearable
+              closeMenuOnSelect={false}
+              styles={{
+                menu: (base) => ({ ...base, zIndex: 999 }),
+              }}
+            />
+          </div>
+          <div className="col-xl-3 col-md-6 col-sm-12">
+            <Form.Label className="mb-1">BC Parks park</Form.Label>
+            <Select
+              value={selectedPark}
+              options={parkOptions}
+              onChange={(e) => {
+                const selectedParks = e || [];
+                const selectedParkIds = selectedParks.map((park) => park.value);
+
+                setSelectedPark(selectedParks);
+                setSelectedParkId(selectedParkIds);
+                setCurrentPage(1);
+
+                setStoredFilters((currentFilters) => {
+                  const nonParkPageFilters = currentFilters.filter(
+                    (o) => !(o.type === "page" && o.filterName === "park"),
+                  );
+
+                  return [
+                    ...nonParkPageFilters,
+                    {
+                      type: "page",
+                      filterName: "park",
+                      filterValue: selectedParkIds,
+                    },
+                  ];
+                });
+              }}
+              placeholder="Select a park..."
+              className="bcgov-select"
+              isMulti
+              isClearable
+              closeMenuOnSelect={false}
+              styles={{
+                menu: (base) => ({ ...base, zIndex: 999 }),
+              }}
+            />
+          </div>
+          <div className="col-xl-3 col-md-6 col-sm-12">
             <Form.Check
               className="ms-1 advisory-archived-toggle"
               type="checkbox"

--- a/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.jsx
+++ b/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useMemo, useContext, useRef } from "react";
+import PropTypes from "prop-types";
 import {
   useLocalStorage,
   useSessionStorage,
@@ -12,7 +13,7 @@ import useCms from "@/hooks/useCms";
 import "./AdvisoryDashboard.scss";
 import { Button } from "@/components/advisories/shared/button/Button";
 import DataTable from "@/components/advisories/composite/dataTable/DataTable";
-import Select from "react-select";
+import Select, { components } from "react-select";
 import moment from "moment";
 import { Loader } from "@/components/advisories/shared/loader/Loader";
 import Badge from "react-bootstrap/Badge";
@@ -71,6 +72,38 @@ function normalizePageFilterValues(filterValue) {
 
   return [filterValue];
 }
+
+function getSelectionPlaceholder(label, selectedOptions, defaultLabel) {
+  if ((selectedOptions || []).length > 0) {
+    return `${label}(${selectedOptions.length})`;
+  }
+
+  return defaultLabel;
+}
+
+function CheckboxOption(props) {
+  const { isSelected, label } = props;
+
+  return (
+    <components.Option {...props}>
+      <div className="multi-select-option">
+        <input
+          className="multi-select-option-checkbox"
+          type="checkbox"
+          checked={isSelected}
+          readOnly
+          tabIndex={-1}
+        />
+        <span>{label}</span>
+      </div>
+    </components.Option>
+  );
+}
+
+CheckboxOption.propTypes = {
+  isSelected: PropTypes.bool,
+  label: PropTypes.string,
+};
 
 export default function AdvisoryDashboard() {
   const { setError } = useContext(ErrorContext);
@@ -858,6 +891,7 @@ export default function AdvisoryDashboard() {
             <Select
               value={selectedDistrict}
               options={districtOptions}
+              components={{ Option: CheckboxOption }}
               onChange={(e) => {
                 const selectedDistricts = e || [];
                 const selectedDistrictIds = selectedDistricts.map(
@@ -883,10 +917,16 @@ export default function AdvisoryDashboard() {
                   ];
                 });
               }}
-              placeholder="Select a district..."
+              placeholder={getSelectionPlaceholder(
+                "RST Recreation district",
+                selectedDistrict,
+                "Select a district...",
+              )}
               className="bcgov-select"
               isMulti
               isClearable
+              hideSelectedOptions={false}
+              controlShouldRenderValue={false}
               closeMenuOnSelect={false}
               styles={{
                 menu: (base) => ({ ...base, zIndex: 999 }),
@@ -898,6 +938,7 @@ export default function AdvisoryDashboard() {
             <Select
               value={selectedRegion}
               options={regionOptions}
+              components={{ Option: CheckboxOption }}
               onChange={(e) => {
                 const selectedRegions = e || [];
                 const selectedRegionIds = selectedRegions.map(
@@ -923,10 +964,16 @@ export default function AdvisoryDashboard() {
                   ];
                 });
               }}
-              placeholder="Select a Region..."
+              placeholder={getSelectionPlaceholder(
+                "BC Parks region",
+                selectedRegion,
+                "Select a Region...",
+              )}
               className="bcgov-select"
               isMulti
               isClearable
+              hideSelectedOptions={false}
+              controlShouldRenderValue={false}
               closeMenuOnSelect={false}
               styles={{
                 menu: (base) => ({ ...base, zIndex: 999 }),
@@ -938,6 +985,7 @@ export default function AdvisoryDashboard() {
             <Select
               value={selectedPark}
               options={parkOptions}
+              components={{ Option: CheckboxOption }}
               onChange={(e) => {
                 const selectedParks = e || [];
                 const selectedParkIds = selectedParks.map((park) => park.value);
@@ -961,19 +1009,25 @@ export default function AdvisoryDashboard() {
                   ];
                 });
               }}
-              placeholder="Select a park..."
+              placeholder={getSelectionPlaceholder(
+                "BC Parks park",
+                selectedPark,
+                "Select a park...",
+              )}
               className="bcgov-select"
               isMulti
               isClearable
+              hideSelectedOptions={false}
+              controlShouldRenderValue={false}
               closeMenuOnSelect={false}
               styles={{
                 menu: (base) => ({ ...base, zIndex: 999 }),
               }}
             />
           </div>
-          <div className="col-xl-3 col-md-6 col-sm-12">
+          <div className="col-12">
             <Form.Check
-              className="ms-1 advisory-archived-toggle"
+              className="mt-4 mb-0 advisory-archived-toggle"
               type="checkbox"
               id="show-archived"
               checked={showArchived}
@@ -983,7 +1037,8 @@ export default function AdvisoryDashboard() {
               }}
               label={
                 <span>
-                  <small>Show archived</small>
+                  Show advisories and closures that have not been updated in 30
+                  days
                   <LightTooltip
                     arrow
                     title="By default, inactive advisories that have not been modified in the past 30 days are hidden. Check this

--- a/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.jsx
+++ b/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.jsx
@@ -77,8 +77,8 @@ export default function AdvisoryDashboard() {
   const navigate = useNavigate();
   const {
     getRegions,
-    getProtectedAreas,
     getManagementAreas,
+    getProtectedAreas,
     getRecreationDistricts,
     getAdvisoryStatuses,
     getUrgencies,
@@ -98,8 +98,8 @@ export default function AdvisoryDashboard() {
   const [hasErrors, setHasErrors] = useState(false);
   const [publicAdvisories, setPublicAdvisories] = useState([]);
   const [regions, setRegions] = useState([]);
-  const [protectedAreas, setProtectedAreas] = useState([]);
   const [managementAreas, setManagementAreas] = useState([]);
+  const [protectedAreas, setProtectedAreas] = useState([]);
   const [districts, setDistricts] = useState([]);
   const [advisoryStatuses, setAdvisoryStatuses] = useState([]);
   const [urgencies, setUrgencies] = useState([]);
@@ -117,7 +117,7 @@ export default function AdvisoryDashboard() {
     { filterName: "park", filterValue: [], type: "page" },
   ];
 
-  // Persisted filter state for the dashboard (region, district, and table filters)
+  // Persisted filter state for the dashboard (region, district, park, and table filters)
   // Saved to localStorage as an array of { type: "page"|"table", filterName/fieldName, filterValue/fieldValue }
   const [storedFilters, setStoredFilters] = useLocalStorage(
     "advisoryFilters",
@@ -148,7 +148,7 @@ export default function AdvisoryDashboard() {
   // Called by DataTable after user stops typing
   const persistTableFilterValues = useDebounceCallback((values) => {
     setStoredFilters((currentFilters) => {
-      // Keep page-level filters (region, district)
+      // Keep page-level filters (region, district, park)
       const pageFilters = currentFilters.filter((f) => f.type === "page");
       // Convert { [fieldName]: value } to array of { fieldName, fieldValue, type: "table" }
       const tableFilters = Object.entries(values)
@@ -186,15 +186,15 @@ export default function AdvisoryDashboard() {
       try {
         const [
           regionsData,
-          protectedAreasData,
           managementAreasData,
+          protectedAreasData,
           districtsData,
           fetchedAdvisoryStatuses,
           fetchedUrgencies,
         ] = await Promise.all([
           getRegions(),
-          getProtectedAreas(),
           getManagementAreas(),
+          getProtectedAreas(),
           getRecreationDistricts(),
           getAdvisoryStatuses(),
           getUrgencies(),
@@ -203,8 +203,8 @@ export default function AdvisoryDashboard() {
         if (!isMounted) return;
 
         setRegions(regionsData);
-        setProtectedAreas(protectedAreasData);
         setManagementAreas(managementAreasData);
+        setProtectedAreas(protectedAreasData);
         setDistricts(districtsData);
 
         // Fetch advisory statuses and urgencies for filter options and table icons
@@ -854,7 +854,7 @@ export default function AdvisoryDashboard() {
         </div>
         <div className="row ad-row">
           <div className="col-xl-3 col-md-6 col-sm-12">
-            <Form.Label className="mb-1">RST rRecreation district</Form.Label>
+            <Form.Label className="mb-1">RST Recreation district</Form.Label>
             <Select
               value={selectedDistrict}
               options={districtOptions}

--- a/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.jsx
+++ b/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.jsx
@@ -1,5 +1,4 @@
 import { useState, useEffect, useMemo, useContext, useRef } from "react";
-import PropTypes from "prop-types";
 import {
   useLocalStorage,
   useSessionStorage,
@@ -12,8 +11,8 @@ import ErrorContext from "@/contexts/ErrorContext";
 import useCms from "@/hooks/useCms";
 import "./AdvisoryDashboard.scss";
 import { Button } from "@/components/advisories/shared/button/Button";
+import { MultiSelect } from "@/components/advisories/shared/multiSelect/MultiSelect";
 import DataTable from "@/components/advisories/composite/dataTable/DataTable";
-import Select, { components } from "react-select";
 import moment from "moment";
 import { Loader } from "@/components/advisories/shared/loader/Loader";
 import Badge from "react-bootstrap/Badge";
@@ -72,38 +71,6 @@ function normalizePageFilterValues(filterValue) {
 
   return [filterValue];
 }
-
-function getSelectionPlaceholder(label, selectedOptions, defaultLabel) {
-  if ((selectedOptions || []).length > 0) {
-    return `${label}(${selectedOptions.length})`;
-  }
-
-  return defaultLabel;
-}
-
-function CheckboxOption(props) {
-  const { isSelected, label } = props;
-
-  return (
-    <components.Option {...props}>
-      <div className="multi-select-option">
-        <input
-          className="multi-select-option-checkbox"
-          type="checkbox"
-          checked={isSelected}
-          readOnly
-          tabIndex={-1}
-        />
-        <span>{label}</span>
-      </div>
-    </components.Option>
-  );
-}
-
-CheckboxOption.propTypes = {
-  isSelected: PropTypes.bool,
-  label: PropTypes.string,
-};
 
 export default function AdvisoryDashboard() {
   const { setError } = useContext(ErrorContext);
@@ -887,11 +854,12 @@ export default function AdvisoryDashboard() {
         </div>
         <div className="row ad-row">
           <div className="col-xl-3 col-md-6 col-sm-12">
-            <Form.Label className="mb-1">RST Recreation district</Form.Label>
-            <Select
+            <MultiSelect
+              label="RST Recreation district"
+              countLabel="RST Recreation district"
+              placeholder="Select a district"
               value={selectedDistrict}
               options={districtOptions}
-              components={{ Option: CheckboxOption }}
               onChange={(e) => {
                 const selectedDistricts = e || [];
                 const selectedDistrictIds = selectedDistricts.map(
@@ -917,28 +885,15 @@ export default function AdvisoryDashboard() {
                   ];
                 });
               }}
-              placeholder={getSelectionPlaceholder(
-                "RST Recreation district",
-                selectedDistrict,
-                "Select a district...",
-              )}
-              className="bcgov-select"
-              isMulti
-              isClearable
-              hideSelectedOptions={false}
-              controlShouldRenderValue={false}
-              closeMenuOnSelect={false}
-              styles={{
-                menu: (base) => ({ ...base, zIndex: 999 }),
-              }}
             />
           </div>
           <div className="col-xl-3 col-md-6 col-sm-12">
-            <Form.Label className="mb-1">BC Parks region</Form.Label>
-            <Select
+            <MultiSelect
+              label="BC Parks region"
+              countLabel="BC Parks region"
+              placeholder="Select a region"
               value={selectedRegion}
               options={regionOptions}
-              components={{ Option: CheckboxOption }}
               onChange={(e) => {
                 const selectedRegions = e || [];
                 const selectedRegionIds = selectedRegions.map(
@@ -964,28 +919,15 @@ export default function AdvisoryDashboard() {
                   ];
                 });
               }}
-              placeholder={getSelectionPlaceholder(
-                "BC Parks region",
-                selectedRegion,
-                "Select a Region...",
-              )}
-              className="bcgov-select"
-              isMulti
-              isClearable
-              hideSelectedOptions={false}
-              controlShouldRenderValue={false}
-              closeMenuOnSelect={false}
-              styles={{
-                menu: (base) => ({ ...base, zIndex: 999 }),
-              }}
             />
           </div>
           <div className="col-xl-3 col-md-6 col-sm-12">
-            <Form.Label className="mb-1">BC Parks park</Form.Label>
-            <Select
+            <MultiSelect
+              label="BC Parks park"
+              countLabel="BC Parks park"
+              placeholder="Select a park"
               value={selectedPark}
               options={parkOptions}
-              components={{ Option: CheckboxOption }}
               onChange={(e) => {
                 const selectedParks = e || [];
                 const selectedParkIds = selectedParks.map((park) => park.value);
@@ -1008,20 +950,6 @@ export default function AdvisoryDashboard() {
                     },
                   ];
                 });
-              }}
-              placeholder={getSelectionPlaceholder(
-                "BC Parks park",
-                selectedPark,
-                "Select a park...",
-              )}
-              className="bcgov-select"
-              isMulti
-              isClearable
-              hideSelectedOptions={false}
-              controlShouldRenderValue={false}
-              closeMenuOnSelect={false}
-              styles={{
-                menu: (base) => ({ ...base, zIndex: 999 }),
               }}
             />
           </div>

--- a/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.jsx
+++ b/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.jsx
@@ -55,6 +55,23 @@ function getPageFilterValue(storedFilters, filterName, defaultValue = 0) {
   );
 }
 
+function normalizePageFilterValues(filterValue) {
+  if (Array.isArray(filterValue)) {
+    return filterValue;
+  }
+
+  if (
+    filterValue === "" ||
+    filterValue === 0 ||
+    filterValue === null ||
+    typeof filterValue === "undefined"
+  ) {
+    return [];
+  }
+
+  return [filterValue];
+}
+
 export default function AdvisoryDashboard() {
   const { setError } = useContext(ErrorContext);
   const navigate = useNavigate();
@@ -69,10 +86,10 @@ export default function AdvisoryDashboard() {
 
   const [toError, setToError] = useState(false);
   const [toCreate, setToCreate] = useState(false);
-  const [selectedRegionId, setSelectedRegionId] = useState(0);
-  const [selectedRegion, setSelectedRegion] = useState(null);
-  const [selectedDistrictId, setSelectedDistrictId] = useState("");
-  const [selectedDistrict, setSelectedDistrict] = useState(null);
+  const [selectedRegionId, setSelectedRegionId] = useState([]);
+  const [selectedRegion, setSelectedRegion] = useState([]);
+  const [selectedDistrictId, setSelectedDistrictId] = useState([]);
+  const [selectedDistrict, setSelectedDistrict] = useState([]);
   const [publishedAdvisories, setPublishedAdvisories] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
   const [hasErrors, setHasErrors] = useState(false);
@@ -90,13 +107,9 @@ export default function AdvisoryDashboard() {
   const [isCmsDataLoaded, setIsCmsDataLoaded] = useState(false);
   const [sortConfig, setSortConfig] = useState(null);
 
-  console.log("districts", districts);
-  console.log("selectedDistrict", selectedDistrict);
-  console.log("selectedDistrictId", selectedDistrictId);
-
   const defaultPageFilters = [
-    { filterName: "region", filterValue: "", type: "page" },
-    { filterName: "district", filterValue: "", type: "page" },
+    { filterName: "region", filterValue: [], type: "page" },
+    { filterName: "district", filterValue: [], type: "page" },
   ];
 
   // Persisted filter state for the dashboard (region, district, and table filters)
@@ -215,36 +228,39 @@ export default function AdvisoryDashboard() {
 
         if (isMounted) {
           // Preserve filters
-          const regionId = getPageFilterValue(initialStoredFilters, "region");
+          const regionIds = normalizePageFilterValues(
+            getPageFilterValue(initialStoredFilters, "region", []),
+          );
 
-          if (regionId) {
-            const region = regionsData.find((r) => r.id === regionId);
-
-            if (region) {
-              setSelectedRegionId(regionId);
-              setSelectedRegion({
+          if (regionIds.length > 0) {
+            const selectedRegions = regionsData
+              .filter((region) => regionIds.includes(region.id))
+              .map((region) => ({
                 label: `${region.regionName} Region`,
                 value: region.id,
-              });
+              }));
+
+            if (selectedRegions.length > 0) {
+              setSelectedRegionId(regionIds);
+              setSelectedRegion(selectedRegions);
             }
           }
 
-          const districtId = getPageFilterValue(
-            initialStoredFilters,
-            "district",
+          const districtIds = normalizePageFilterValues(
+            getPageFilterValue(initialStoredFilters, "district", []),
           );
 
-          if (districtId) {
-            const district = districtsData.find(
-              (d) => d.documentId === districtId,
-            );
-
-            if (district) {
-              setSelectedDistrictId(districtId);
-              setSelectedDistrict({
+          if (districtIds.length > 0) {
+            const selectedDistricts = districtsData
+              .filter((district) => districtIds.includes(district.documentId))
+              .map((district) => ({
                 label: district.district,
                 value: district.documentId,
-              });
+              }));
+
+            if (selectedDistricts.length > 0) {
+              setSelectedDistrictId(districtIds);
+              setSelectedDistrict(selectedDistricts);
             }
           }
           setIsCmsDataLoaded(true);
@@ -800,46 +816,63 @@ export default function AdvisoryDashboard() {
         </div>
         <div className="row ad-row">
           <div className="col-xl-4 col-md-4 col-sm-12">
+            <Form.Label className="mb-1">BC Parks region</Form.Label>
             <Select
               value={selectedRegion}
               options={regionOptions}
               onChange={(e) => {
-                setSelectedRegion(e);
-                setSelectedRegionId(e ? e.value : 0);
-                setSelectedDistrict(null);
-                setSelectedDistrictId("");
+                const selectedRegions = e || [];
+                const selectedRegionIds = selectedRegions.map((region) => region.value);
+
+                setSelectedRegion(selectedRegions);
+                setSelectedRegionId(selectedRegionIds);
+                setSelectedDistrict([]);
+                setSelectedDistrictId([]);
                 setCurrentPage(1);
 
                 setStoredFilters((currentFilters) => {
-                  const nonRegionPageFilters = currentFilters.filter(
-                    (o) => !(o.type === "page" && o.filterName === "region"),
+                  const nonPageFilters = currentFilters.filter(
+                    (o) => o.type !== "page",
                   );
 
                   return [
-                    ...nonRegionPageFilters,
+                    ...nonPageFilters,
                     {
                       type: "page",
                       filterName: "region",
-                      filterValue: e ? e.value : 0,
+                      filterValue: selectedRegionIds,
+                    },
+                    {
+                      type: "page",
+                      filterName: "district",
+                      filterValue: [],
                     },
                   ];
                 });
               }}
               placeholder="Select a Region..."
               className="bcgov-select"
+              isMulti
               isClearable
+              closeMenuOnSelect={false}
               styles={{
                 menu: (base) => ({ ...base, zIndex: 999 }),
               }}
             />
           </div>
           <div className="col-xl-5 col-md-4 col-sm-12">
+            <Form.Label className="mb-1">RST Recreation district</Form.Label>
             <Select
               value={selectedDistrict}
               options={districtOptions}
               onChange={(e) => {
-                setSelectedDistrict(e);
-                setSelectedDistrictId(e ? e.value : "");
+                const selectedDistricts = e || [];
+                const selectedDistrictIds = selectedDistricts.map(
+                  (district) => district.value,
+                );
+
+                setSelectedDistrict(selectedDistricts);
+                setSelectedDistrictId(selectedDistrictIds);
                 setCurrentPage(1);
 
                 setStoredFilters((currentFilters) => {
@@ -852,14 +885,16 @@ export default function AdvisoryDashboard() {
                     {
                       type: "page",
                       filterName: "district",
-                      filterValue: e ? e.value : "",
+                      filterValue: selectedDistrictIds,
                     },
                   ];
                 });
               }}
               placeholder="Select a district..."
               className="bcgov-select"
+              isMulti
               isClearable
+              closeMenuOnSelect={false}
               styles={{
                 menu: (base) => ({ ...base, zIndex: 999 }),
               }}

--- a/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.scss
+++ b/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.scss
@@ -126,10 +126,4 @@
   .advisory-dashboard-padding {
     padding: 16px;
   }
-
-  .multi-select-option {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-  }
 }

--- a/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.scss
+++ b/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.scss
@@ -126,4 +126,10 @@
   .advisory-dashboard-padding {
     padding: 16px;
   }
+
+  .multi-select-option {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
 }


### PR DESCRIPTION
### Jira Ticket

CMS-1665

### Description
<!-- What did you change, and why? -->
- Added the RST district filter to the Advisory dashboard
- Updated the filters to the multi-select filters
- Added a reusable MultiSelect component for advisories so we don’t repeat the same code in multiple places
- Styled dropdown options to look like checkbox items and showed selected counts in the field label text
