### PR TITLE
CMS-1614: Auto redirect to IDP and back to target page

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -195,6 +195,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2887,6 +2888,7 @@
       "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.2.0.tgz",
       "integrity": "sha512-YGdEUzYEd+82jeaVbSKKVp1jFZb8LwaNMIIzHFkihGvYdd/KKAr7KaJHdEdSYGredE3ssSravXIa0Jxg28Sv5w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -2955,6 +2957,7 @@
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
       "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -3607,6 +3610,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-2.1.13.tgz",
       "integrity": "sha512-cMC8bgTN63dj1Mv82iDeeLl6sa9kY0Pug8LSalxVEptRmyFVsVxGgu2/6Y3T+9aCYScxfS06EkA8SdzFMAwYTQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -3829,6 +3833,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-2.1.13.tgz",
       "integrity": "sha512-zNbA7muWsHuVg12GrTgN/j119rLePPq5M8dZgkKxUwdw8VmU3eUyBp1SihPEXJ2U0MGdZhNhFX7Y74g11u66sg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-changeset": "^2.2.0",
         "prosemirror-collab": "^1.3.0",
@@ -3909,14 +3914,14 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-3.0.0.tgz",
       "integrity": "sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@tiptap/starter-kit/node_modules/@tiptap/core": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-2.11.0.tgz",
       "integrity": "sha512-0S3AWx6E2QqwdQqb6z0/q6zq2u9lA9oL3BLyAaITGSC9zt8OwjloS2k1zN6wLa9hp2rO0c0vDnWsTPeFaEaMdw==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -4148,7 +4153,6 @@
       "resolved": "https://registry.npmjs.org/prosemirror-trailing-node/-/prosemirror-trailing-node-3.0.0.tgz",
       "integrity": "sha512-xiun5/3q0w5eRnGYfNlW1uU9W6x5MoFKWwq/0TIRgt09lv7Hcser2QYV8t4muXbEr+Fwo0geYn79Xs4GKywrRQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@remirror/core-constants": "3.0.0",
         "escape-string-regexp": "^4.0.0"
@@ -4261,6 +4265,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.18.tgz",
       "integrity": "sha512-t4yC+vtgnkYjNSKlFx1jkAhH8LgTo2N/7Qvi83kdEaUtMDiwpbLAktKDaAMlRcJ5eSxZkH74eEGt1ky31d7kfQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -4330,6 +4335,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4352,6 +4358,7 @@
       "resolved": "https://registry.npmjs.org/adminjs/-/adminjs-7.8.17.tgz",
       "integrity": "sha512-uTGZNMbNf0gsxzygEdQtPkFIdjkQh9Y47G7oeQ2Lmnvn2hUtArzgRnoLzBnyXBmk9pt0nmzEG4XVHG1tiY2sCA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@adminjs/design-system": "^4.1.0",
         "@babel/core": "^7.23.9",
@@ -4814,6 +4821,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001688",
         "electron-to-chromium": "^1.5.73",
@@ -5873,6 +5881,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6382,6 +6391,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
       "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -6434,6 +6444,7 @@
       "resolved": "https://registry.npmjs.org/express-formidable/-/express-formidable-1.2.0.tgz",
       "integrity": "sha512-w1vXjF3gb50UKTNkFaW8/4rqY4dUrKfZ1sAZzwAF9YxCAgj/29QZsycf71di0GkskrZOAkubk9pvGYfxyAMYiw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "formidable": "^1.0.17"
       },
@@ -6475,6 +6486,7 @@
       "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.19.0.tgz",
       "integrity": "sha512-0csaMkGq+vaiZTmSMMGkfdCOabYv192VbytFypcvI0MANrp+4i/7yEkJ0sbAEhycQjntaKGzYfjfXQyVb7BHMA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cookie": "~0.7.2",
         "cookie-signature": "~1.0.7",
@@ -7160,6 +7172,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.20.6"
       }
@@ -8794,6 +8807,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -8901,6 +8915,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9097,6 +9112,7 @@
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -9221,6 +9237,7 @@
       "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.24.1.tgz",
       "integrity": "sha512-YM053N+vTThzlWJ/AtPtF1j0ebO36nvbmDy4U7qA2XQB8JVaQp1FmB9Jhrps8s+z+uxhhVTny4m20ptUvhk0Mg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "orderedmap": "^2.0.0"
       }
@@ -9250,6 +9267,7 @@
       "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.3.tgz",
       "integrity": "sha512-goFKORVbvPuAQaXhpbemJFRKJ2aixr+AZMGiquiqKxaucC6hlpHNZHWgz5R7dS4roHiwq9vDctE//CZ++o0W1Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-transform": "^1.0.0",
@@ -9298,6 +9316,7 @@
       "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.37.1.tgz",
       "integrity": "sha512-MEAnjOdXU1InxEmhjgmEzQAikaS6lF3hD64MveTPpjOGNTl87iRLA1HupC/DEV6YuK7m4Q9DHFNTjwIVtqz5NA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.20.0",
         "prosemirror-state": "^1.0.0",
@@ -9445,6 +9464,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -9500,6 +9520,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -9866,6 +9887,7 @@
       "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
       "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.9.2"
       }
@@ -10057,6 +10079,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
       "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -10232,6 +10255,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/debug": "^4.1.8",
         "@types/validator": "^13.7.17",
@@ -10989,7 +11013,8 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/frontend/src/config/keycloak.js
+++ b/frontend/src/config/keycloak.js
@@ -24,7 +24,31 @@ export const oidcConfig = {
   monitorSession: true,
 };
 
-// Strips OIDC parameters from the URL after redirecting back to the app
+/**
+ * Strips OIDC callback params from the URL after sign-in,
+ * preserving any other query params and hash that were on the redirect_uri.
+ * Removes: code, state, session_state, iss, error, error_description, error_uri (per OIDC spec and RFC 9207).
+ * @returns {void}
+ */
 export function onSigninCallback() {
-  window.history.replaceState({}, document.title, window.location.pathname);
+  const url = new URL(window.location.href);
+
+  // Standard OIDC authorization response params
+  for (const param of [
+    "code",
+    "state",
+    "session_state",
+    "iss",
+    "error",
+    "error_description",
+    "error_uri",
+  ]) {
+    url.searchParams.delete(param);
+  }
+
+  window.history.replaceState(
+    {},
+    document.title,
+    `${url.pathname}${url.search}${url.hash}`,
+  );
 }

--- a/frontend/src/constants/allowedIdps.js
+++ b/frontend/src/constants/allowedIdps.js
@@ -1,0 +1,4 @@
+// List of allowed IDP (Identity Provider) hints for authentication flows for Keycloak.
+// Used to validate IDP hints in login and protected route logic.
+
+export default new Set(["idir", "bceid", "bcsc"]);

--- a/frontend/src/router/ProtectedRoute.jsx
+++ b/frontend/src/router/ProtectedRoute.jsx
@@ -1,8 +1,45 @@
-import { useEffect, useMemo, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useEffect, useState } from "react";
+import { useNavigate, useLocation } from "react-router-dom";
 import { hasAuthParams, useAuth } from "react-oidc-context";
+import { useSessionStorage } from "usehooks-ts";
 import PropTypes from "prop-types";
 import AccessProvider from "@/router/AccessProvider";
+import getEnv from "@/config/getEnv";
+import ALLOWED_IDPS from "@/constants/allowedIdps";
+
+const frontendBaseUrl = getEnv("VITE_FRONTEND_BASE_URL");
+
+/**
+ * Returns the original destination URL after login, removing the temporary idp helper param.
+ * @param {Object} location The location object from react-router, containing pathname, search, and hash
+ * @returns {string} The cleaned absolute URL for post-login redirect
+ */
+function getPostLoginRedirectUrl(location) {
+  const query = new URLSearchParams(location.search);
+
+  query.delete("idp");
+  const cleanedSearch = query.toString();
+
+  return new URL(
+    `${location.pathname}${cleanedSearch ? `?${cleanedSearch}` : ""}${location.hash}`,
+    frontendBaseUrl,
+  ).toString();
+}
+
+/**
+ * Returns the login path, forwarding a valid idp hint if present in the query string.
+ * @param {Object} location The location object from react-router, containing search params
+ * @returns {string} The login path, with idp param if valid, otherwise "/login"
+ */
+function getLoginPath(location) {
+  const idp = new URLSearchParams(location.search).get("idp");
+
+  if (idp && ALLOWED_IDPS.has(idp)) {
+    return `/login?idp=${encodeURIComponent(idp)}`;
+  }
+
+  return "/login";
+}
 
 // Higher-order component that wraps a route component for authentication
 // Wrap a "layout" component in this component to protect all of its children
@@ -11,8 +48,13 @@ import AccessProvider from "@/router/AccessProvider";
 export default function ProtectedRoute({ children }) {
   const auth = useAuth();
   const navigate = useNavigate();
-  // Get the query params from the URL
-  const params = useMemo(() => new URLSearchParams(window.location.search), []);
+  const location = useLocation();
+
+  // Store the path to redirect to after login in session storage so it persists through the redirect flow
+  const [, setPostLoginRedirectPath] = useSessionStorage(
+    "post_login_redirect_path",
+    "",
+  );
 
   // Track if a redirect has happened to prevent redirect loops
   const [hasTriedSignin, setHasTriedSignin] = useState(false);
@@ -26,28 +68,27 @@ export default function ProtectedRoute({ children }) {
   useEffect(() => {
     const unsubscribeSignedOut = auth.events.addUserSignedOut(() => {
       auth.removeUser();
-      navigate("/login", { replace: true });
+      setPostLoginRedirectPath(getPostLoginRedirectUrl(location));
+      navigate(getLoginPath(location), { replace: true });
     });
 
     const unsubscribeRenewError = auth.events.addSilentRenewError(() => {
       auth.removeUser();
-      navigate("/login", { replace: true });
+      setPostLoginRedirectPath(getPostLoginRedirectUrl(location));
+      navigate(getLoginPath(location), { replace: true });
     });
 
     return () => {
       unsubscribeSignedOut();
       unsubscribeRenewError();
     };
-  }, [auth, navigate]);
+  }, [auth, navigate, setPostLoginRedirectPath, location]);
 
   /**
    * Attempt to automatically sign in
    * See {@link https://github.com/authts/react-oidc-context?tab=readme-ov-file#automatic-sign-in}
    */
   useEffect(() => {
-    // If the URL has the "logged-out" query param, do not redirect
-    if (params.has("logged-out")) return;
-
     if (
       !(
         hasAuthParams() ||
@@ -61,13 +102,15 @@ export default function ProtectedRoute({ children }) {
       auth.clearStaleState();
       setHasTriedSignin(true);
 
-      // Only redirect if not already on the login page
-      if (!auth.isAuthenticated && window.location.pathname !== "/login") {
-        navigate("/login", { replace: true });
+      // Navigate to the login page, which will trigger the sign-in flow and redirect to Keycloak as needed
+      if (!auth.isAuthenticated) {
+        setPostLoginRedirectPath(getPostLoginRedirectUrl(location));
+        navigate(getLoginPath(location), { replace: true });
       }
     }
-  }, [auth, hasTriedSignin, params, navigate]);
+  }, [auth, hasTriedSignin, navigate, setPostLoginRedirectPath, location]);
 
+  // Clear broken auth state by sending the user through a fresh sign-out flow
   useEffect(() => {
     if (auth.error) {
       // If there's an error, redirect to the sign-in page
@@ -84,11 +127,6 @@ export default function ProtectedRoute({ children }) {
 
   if (auth.isLoading && auth.activeNavigator !== "signinSilent") {
     return <div>Checking authentication...</div>;
-  }
-
-  // If the URL has the "logged-out" query param, display a message
-  if (params.has("logged-out")) {
-    return <div>Logged out.</div>;
   }
 
   if (!auth.isAuthenticated) {

--- a/frontend/src/router/ProtectedRoute.jsx
+++ b/frontend/src/router/ProtectedRoute.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
 import { hasAuthParams, useAuth } from "react-oidc-context";
 import { useSessionStorage } from "usehooks-ts";
@@ -59,6 +59,12 @@ export default function ProtectedRoute({ children }) {
   // Track if a redirect has happened to prevent redirect loops
   const [hasTriedSignin, setHasTriedSignin] = useState(false);
 
+  // Keep a ref to the latest location so event handlers always use the current page
+  // without needing `location` in dependency arrays (which would re-subscribe on every navigation)
+  const locationRef = useRef(location);
+
+  locationRef.current = location;
+
   /**
    * Immediately redirect to /login when the library detects the Keycloak
    * session has ended (e.g. killed from the admin panel) or silent renew fails.
@@ -68,21 +74,21 @@ export default function ProtectedRoute({ children }) {
   useEffect(() => {
     const unsubscribeSignedOut = auth.events.addUserSignedOut(() => {
       auth.removeUser();
-      setPostLoginRedirectPath(getPostLoginRedirectUrl(location));
-      navigate(getLoginPath(location), { replace: true });
+      setPostLoginRedirectPath(getPostLoginRedirectUrl(locationRef.current));
+      navigate(getLoginPath(locationRef.current), { replace: true });
     });
 
     const unsubscribeRenewError = auth.events.addSilentRenewError(() => {
       auth.removeUser();
-      setPostLoginRedirectPath(getPostLoginRedirectUrl(location));
-      navigate(getLoginPath(location), { replace: true });
+      setPostLoginRedirectPath(getPostLoginRedirectUrl(locationRef.current));
+      navigate(getLoginPath(locationRef.current), { replace: true });
     });
 
     return () => {
       unsubscribeSignedOut();
       unsubscribeRenewError();
     };
-  }, [auth, navigate, setPostLoginRedirectPath, location]);
+  }, [auth, navigate, setPostLoginRedirectPath]);
 
   /**
    * Attempt to automatically sign in
@@ -104,11 +110,11 @@ export default function ProtectedRoute({ children }) {
 
       // Navigate to the login page, which will trigger the sign-in flow and redirect to Keycloak as needed
       if (!auth.isAuthenticated) {
-        setPostLoginRedirectPath(getPostLoginRedirectUrl(location));
-        navigate(getLoginPath(location), { replace: true });
+        setPostLoginRedirectPath(getPostLoginRedirectUrl(locationRef.current));
+        navigate(getLoginPath(locationRef.current), { replace: true });
       }
     }
-  }, [auth, hasTriedSignin, navigate, setPostLoginRedirectPath, location]);
+  }, [auth, hasTriedSignin, navigate, setPostLoginRedirectPath]);
 
   // Clear broken auth state by sending the user through a fresh sign-out flow
   useEffect(() => {

--- a/frontend/src/router/pages/LoginPage.jsx
+++ b/frontend/src/router/pages/LoginPage.jsx
@@ -1,44 +1,95 @@
-import { useEffect, useCallback } from "react";
-import { Navigate } from "react-router-dom";
-import { useAuth } from "react-oidc-context";
+import { useEffect, useCallback, useRef } from "react";
+import { Navigate, useLocation } from "react-router-dom";
+import { hasAuthParams, useAuth } from "react-oidc-context";
+import { useSessionStorage } from "usehooks-ts";
 import getEnv from "@/config/getEnv";
 import "./LoginPage.scss";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faArrowUpRightFromSquare } from "@fa-kit/icons/classic/regular";
+import ALLOWED_IDPS from "@/constants/allowedIdps";
+
+const frontendBaseUrl = getEnv("VITE_FRONTEND_BASE_URL");
 
 export default function LoginPage() {
   const auth = useAuth();
+  const location = useLocation();
 
-  // function to redirect to Keycloak for the selected login provider
+  // Track auto sign-in attempts to prevent multiple redirects
+  const autoSigninAttempted = useRef(false);
+
+  // Store the path to redirect to after login. Use session storage to persist through the redirect flow
+  const [postLoginRedirectPath, , removePostLoginRedirectPath] =
+    useSessionStorage("post_login_redirect_path", "");
+
+  // Redirects to Keycloak with the selected login provider
   const handleLogin = useCallback(
     (idp) => {
       auth.signinRedirect({
         // eslint-disable-next-line camelcase -- 'redirect_uri' is required by Keycloak
-        redirect_uri: new URL("/", getEnv("VITE_FRONTEND_BASE_URL")).toString(),
+        redirect_uri:
+          postLoginRedirectPath || new URL("/", frontendBaseUrl).toString(),
         extraQueryParams: {
           // eslint-disable-next-line camelcase -- 'kc_idp_hint' is required by Keycloak
           kc_idp_hint: idp,
         },
       });
     },
-    [auth],
+    [auth, postLoginRedirectPath],
   );
 
+  // Try to automatically sign in when an `idp` query param is provided
   useEffect(() => {
-    // if the login_idp is already set in session storage, use that to log in automatically
-    const savedIdp = sessionStorage.getItem("login_idp");
-
-    if (savedIdp) {
-      // delete the saved IDP to avoid infinite redirects
-      sessionStorage.removeItem("login_idp");
-      handleLogin(savedIdp);
+    // If auth is already in progress or completed, do nothing
+    if (auth.isAuthenticated || auth.activeNavigator || auth.isLoading) {
+      return;
     }
-  }, [handleLogin]);
 
-  // if already authenticated, don't show the login page
+    if (autoSigninAttempted.current) return;
+
+    const params = new URLSearchParams(location.search);
+
+    // Don't sign in automatically in after explicit logout or after auth errors
+    if (params.has("logged-out") || params.has("error") || hasAuthParams()) {
+      return;
+    }
+
+    // Auto sign-in only when an `idp` query param is provided
+    const queryIdp = params.get("idp");
+
+    if (!queryIdp || !ALLOWED_IDPS.has(queryIdp)) return;
+
+    autoSigninAttempted.current = true;
+    handleLogin(queryIdp);
+  }, [
+    auth.isAuthenticated,
+    auth.activeNavigator,
+    auth.isLoading,
+    handleLogin,
+    location.search,
+  ]);
+
+  // Clear the stored login redirect destination after authentication succeeds
+  useEffect(() => {
+    if (auth.isAuthenticated && postLoginRedirectPath) {
+      removePostLoginRedirectPath();
+    }
+  }, [
+    auth.isAuthenticated,
+    postLoginRedirectPath,
+    removePostLoginRedirectPath,
+  ]);
+
+  // Redirect authenticated users to their original destination, or fallback to "/"
   if (auth.isAuthenticated) {
-    // Redirect to "/" (which will redirect to a dashboard)
-    return <Navigate to="/" replace />;
+    let redirectPath = "/";
+
+    if (postLoginRedirectPath) {
+      const url = new URL(postLoginRedirectPath);
+
+      redirectPath = `${url.pathname}${url.search}${url.hash}`;
+    }
+
+    return <Navigate to={redirectPath} replace />;
   }
 
   return (

--- a/frontend/src/router/pages/LoginPage.jsx
+++ b/frontend/src/router/pages/LoginPage.jsx
@@ -68,6 +68,16 @@ export default function LoginPage() {
     location.search,
   ]);
 
+  // Clear the stored redirect destination on explicit logout or auth error,
+  // so a subsequent manual login defaults to "/"
+  useEffect(() => {
+    const params = new URLSearchParams(location.search);
+
+    if (params.has("logged-out") || params.has("error")) {
+      removePostLoginRedirectPath();
+    }
+  }, [location.search, removePostLoginRedirectPath]);
+
   // Clear the stored login redirect destination after authentication succeeds
   useEffect(() => {
     if (auth.isAuthenticated && postLoginRedirectPath) {


### PR DESCRIPTION
### Jira Ticket

CMS-1614

### Description
<!-- What did you change, and why? -->

Updated the login flow to allow cross-realm authentication when following links from RecSpace 

If the link has `?idp=idir` (or `bceid` or some other supported IDP defined in ALLOWED_IDPS):
1. Remember the URL to redirect back to after logging in, but strip the `idp` query param (uses sessionStorage)
2. Redirect to the login page with the `idp` query parameter (`/login?idp=idir`)
3. Login page sees the IDP and tries to automatically log in with that `kc_idp_hint` 
4. The Azure AD "Entra" IDIR bridge will see you're already logged in with IDIR and send you back to your original destination URL without prompting you for an IDIR or password.

If you navigate straight to the app or the link has no `idp` query param:
1. Remember the URL to redirect back to after logging in, but strip the `idp` query param (uses sessionStorage)
2. Redirects to the login page
3. User clicks the button for their ID provider (IDIR, in this case)
4. The Azure AD "Entra" IDIR bridge will see you're already logged in with IDIR and send you back to your original destination URL without prompting you for an IDIR or password.
5. (If you don't already have an IDIR session, obviously it will prompt you to log in)

Saving the redirect URL is new in this branch, and passing the `idp` between redirects was added to allow a hands-free login flow. The rest is basically the same as before.

---

## To test:
Go to the RecSpace test environment in an incognito window and use devtools to add an outbound link somewhere on the page to point to your local dev server: `<a href="http://localhost:3000/park-access-status?idp=idir">Staff Portal</a>`. Click that, and the Staff Portal app should show the login page, then automatically log you in and redirect you to the `/park-access-status` route.
