### PR TITLE
CMS-1666: Add resource id to search

### DIFF
--- a/frontend/src/lib/advisories/utils/AdvisoryDashboardQuery.js
+++ b/frontend/src/lib/advisories/utils/AdvisoryDashboardQuery.js
@@ -42,11 +42,12 @@ const COLUMN_FILTERS = [
     build: (value) => ({ eventType: { eventType: { $containsi: value } } }),
   },
   {
-    key: "associatedParks",
+    key: "associatedResources",
     build: (value) => ({
       $or: [
         { protectedAreas: { protectedAreaName: { $containsi: value } } },
         { recreationResources: { resourceName: { $containsi: value } } },
+        { recreationResources: { recResourceId: { $containsi: value } } },
       ],
     }),
   },
@@ -102,7 +103,7 @@ export function buildFilter(
  */
 const SORT_FIELD_MAP = {
   "urgency.urgency": "urgency.sequence",
-  associatedParks: [
+  associatedResources: [
     "protectedAreas.protectedAreaName",
     "recreationResources.resourceName",
   ],

--- a/frontend/src/lib/advisories/utils/AdvisoryDashboardQuery.js
+++ b/frontend/src/lib/advisories/utils/AdvisoryDashboardQuery.js
@@ -26,10 +26,6 @@ const COLUMN_FILTERS = [
     }),
   },
   {
-    key: "endDate",
-    build: (value) => ({ endDate: { $containsi: toIsoDateFilter(value) } }),
-  },
-  {
     key: "expiryDate",
     build: (value) => ({ expiryDate: { $containsi: toIsoDateFilter(value) } }),
   },

--- a/frontend/src/lib/advisories/utils/AdvisoryDataUtil.js
+++ b/frontend/src/lib/advisories/utils/AdvisoryDataUtil.js
@@ -21,7 +21,8 @@ export function updatePublicAdvisories(publicAdvisories, managementAreas) {
     publicAdvisory.associatedResources =
       publicAdvisory.protectedAreas.map((p) => p.protectedAreaName).join(", ") +
         publicAdvisory.regions.map((r) => r.regionName).join(", ") ||
-      publicAdvisory.recreationResources.map((r) => r.resourceName).join(", ");
+      publicAdvisory.recreationResources.map((r) => r.resourceName).join(", ") +
+        publicAdvisory.recreationResources.map((r) => r.district).join(", ");
 
     let regionsWithParkCount = [];
 

--- a/frontend/src/lib/advisories/utils/AdvisoryDataUtil.js
+++ b/frontend/src/lib/advisories/utils/AdvisoryDataUtil.js
@@ -18,7 +18,7 @@ export function updatePublicAdvisories(publicAdvisories, managementAreas) {
   return publicAdvisories.map((publicAdvisory) => {
     publicAdvisory.expired = publicAdvisory.expiryDate < today ? "Y" : "N";
     // Display associated parks/regions, or rec resource name if no parks/regions
-    publicAdvisory.associatedParks =
+    publicAdvisory.associatedResources =
       publicAdvisory.protectedAreas.map((p) => p.protectedAreaName).join(", ") +
         publicAdvisory.regions.map((r) => r.regionName).join(", ") ||
       publicAdvisory.recreationResources.map((r) => r.resourceName).join(", ");

--- a/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.jsx
+++ b/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.jsx
@@ -344,7 +344,6 @@ export default function AdvisoryDashboard() {
               "advisoryDate",
               "title",
               "effectiveDate",
-              "endDate",
               "expiryDate",
               "updatedAt",
             ],
@@ -357,6 +356,7 @@ export default function AdvisoryDashboard() {
               eventType: { fields: ["eventType"] },
               urgency: { fields: ["urgency"] },
               regions: { fields: ["regionName"] },
+              recreationDistricts: { fields: ["district"] },
             },
             filters: {
               $and: [

--- a/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.jsx
+++ b/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.jsx
@@ -585,53 +585,8 @@ export default function AdvisoryDashboard() {
         },
       },
       {
-        field: "advisoryDate",
-        title: "Posting date",
-        render(rowData) {
-          if (rowData.advisoryDate) {
-            return moment(rowData.advisoryDate).format("YYYY/MM/DD");
-          }
-
-          return null;
-        },
-      },
-      {
-        field: "endDate",
-        title: "End date",
-        render(rowData) {
-          if (rowData.endDate) {
-            return moment(rowData.endDate).format("YYYY/MM/DD");
-          }
-
-          return null;
-        },
-      },
-      {
-        field: "expiryDate",
-        title: "Expiry date",
-        render(rowData) {
-          if (rowData.expiryDate) {
-            return moment(rowData.expiryDate).format("YYYY/MM/DD");
-          }
-
-          return null;
-        },
-      },
-      {
-        field: "title",
-        title: "Headline",
-        headerStyle: { width: 400 },
-        cellStyle: { width: 400 },
-        render(rowData) {
-          return (
-            <div dangerouslySetInnerHTML={{ __html: rowData.title }}></div>
-          );
-        },
-      },
-      { field: "eventType.eventType", title: "Event type" },
-      {
-        field: "associatedParks",
-        title: "Associated Park(s)",
+        field: "associatedResources",
+        title: "Associated Resource(s)",
         headerStyle: { width: 400 },
         cellStyle: { width: 400 },
         render(rowData) {
@@ -716,7 +671,7 @@ export default function AdvisoryDashboard() {
             <div>
               {displayedResources.map((r, i) => (
                 <span key={i}>
-                  {r.resourceName}
+                  {r.resourceName} {`(${r.recResourceId})`}
                   {displayedResources.length - 1 > i && ", "}
                 </span>
               ))}
@@ -738,6 +693,40 @@ export default function AdvisoryDashboard() {
               )}
             </div>
           );
+        },
+      },
+      { field: "eventType.eventType", title: "Event type" },
+      {
+        field: "title",
+        title: "Headline",
+        headerStyle: { width: 400 },
+        cellStyle: { width: 400 },
+        render(rowData) {
+          return (
+            <div dangerouslySetInnerHTML={{ __html: rowData.title }}></div>
+          );
+        },
+      },
+      {
+        field: "advisoryDate",
+        title: "Posting date",
+        render(rowData) {
+          if (rowData.advisoryDate) {
+            return moment(rowData.advisoryDate).format("YYYY/MM/DD");
+          }
+
+          return null;
+        },
+      },
+      {
+        field: "expiryDate",
+        title: "Expiry date",
+        render(rowData) {
+          if (rowData.expiryDate) {
+            return moment(rowData.expiryDate).format("YYYY/MM/DD");
+          }
+
+          return null;
         },
       },
       {


### PR DESCRIPTION
### Jira Ticket

CMS-1666

### Description
<!-- What did you change, and why? -->
- Displayed `recResourceId` next to `resourceName` in the Advisory table
- Added `recResourceId` to the Advisory table search
- Changed the column name from "Associated parks" to "Associated resources" 
- Reordered some columns