### PR TITLE
CMS-1701: Rename advisory statuses

### DIFF
--- a/frontend/src/lib/advisories/utils/AdvisoryDataUtil.js
+++ b/frontend/src/lib/advisories/utils/AdvisoryDataUtil.js
@@ -34,7 +34,7 @@ export function updatePublicAdvisories(publicAdvisories, managementAreas) {
     }
 
     publicAdvisory.archived =
-      publicAdvisory.advisoryStatus.code === "INA" &&
+      publicAdvisory.advisoryStatus.code === "UNP" &&
       publicAdvisory.updatedAt < standardInactiveAdvisoryCutoffDate;
 
     return publicAdvisory;

--- a/frontend/src/lib/advisories/utils/AdvisoryUtil.js
+++ b/frontend/src/lib/advisories/utils/AdvisoryUtil.js
@@ -53,7 +53,7 @@ export function getSubmitterAdvisoryFields(
     setConfirmationText("Your advisory has been published successfully!");
     published = moment().tz("America/Vancouver");
   } else {
-    status = advisoryStatuses.filter((s) => s.code === "ARQ");
+    status = advisoryStatuses.filter((s) => s.code === "HQR");
     setConfirmationText("Your advisory has been sent for review successfully!");
   }
   return { status: status[0].value, published };

--- a/frontend/src/router/pages/advisories/advisory/Advisory.jsx
+++ b/frontend/src/router/pages/advisories/advisory/Advisory.jsx
@@ -556,8 +556,8 @@ export default function Advisory({ mode }) {
 
           setUrgencies([...newUrgencies]);
           const advisoryStatusData = res[11];
-          const restrictedAdvisoryStatusCodes = new Set(["INA", "APR"]);
-          const desiredOrder = ["PUB", "INA", "DFT", "APR", "ARQ"];
+          const restrictedAdvisoryStatusCodes = new Set(["UNP", "SCH"]);
+          const desiredOrder = ["PUB", "UNP", "DFT", "SCH", "HQR"];
           const tempAdvisoryStatuses = advisoryStatusData.map((s) => {
             let result = {};
 

--- a/frontend/src/router/pages/advisories/advisory/Advisory.jsx
+++ b/frontend/src/router/pages/advisories/advisory/Advisory.jsx
@@ -559,30 +559,31 @@ export default function Advisory({ mode }) {
           const restrictedAdvisoryStatusCodes = new Set(["UNP", "SCH"]);
           const desiredOrder = ["PUB", "UNP", "DFT", "SCH", "HQR"];
           const tempAdvisoryStatuses = advisoryStatusData.map((s) => {
-            let result = {};
-
             if (restrictedAdvisoryStatusCodes.has(s.code) && approver) {
-              result = {
-                code: s.code,
-                label: camelCaseToSentenceCase(s.advisoryStatus),
-                value: s.documentId,
-              };
-            } else if (!restrictedAdvisoryStatusCodes.has(s.code)) {
-              result = {
+              return {
                 code: s.code,
                 label: camelCaseToSentenceCase(s.advisoryStatus),
                 value: s.documentId,
               };
             }
-            return result;
+            if (!restrictedAdvisoryStatusCodes.has(s.code)) {
+              return {
+                code: s.code,
+                label: camelCaseToSentenceCase(s.advisoryStatus),
+                value: s.documentId,
+              };
+            }
+            return null;
           });
-          const sortedStatus = tempAdvisoryStatuses.sort(
+          const filteredStatuses = tempAdvisoryStatuses.filter(
+            (s) => s !== null,
+          );
+          const sortedStatus = filteredStatuses.sort(
             (a, b) =>
               desiredOrder.indexOf(a.code) - desiredOrder.indexOf(b.code),
           );
-          const newAdvisoryStatuses = sortedStatus.filter((s) => s !== null);
 
-          setAdvisoryStatuses([...newAdvisoryStatuses]);
+          setAdvisoryStatuses([...sortedStatus]);
           const linkTypeData = res[12];
           const newLinkTypes = linkTypeData.map((lt) => ({
             label: lt.type,

--- a/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.jsx
+++ b/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.jsx
@@ -284,13 +284,13 @@ export default function AdvisoryDashboard() {
         const advisoryFilter = showArchived
           ? {
               $or: [
-                { advisoryStatus: { code: { $ne: "INA" } } },
+                { advisoryStatus: { code: { $ne: "UNP" } } },
                 { updatedAt: { $gt: extendedCutoffDate } },
               ],
             }
           : {
               $or: [
-                { advisoryStatus: { code: { $ne: "INA" } } },
+                { advisoryStatus: { code: { $ne: "UNP" } } },
                 { updatedAt: { $gt: standardCutoffDate } },
               ],
             };
@@ -512,9 +512,9 @@ export default function AdvisoryDashboard() {
         render(rowData) {
           const statusIconMap = {
             DFT: { icon: faPencil, className: "draftIcon" },
-            INA: { icon: faClock, className: "inactiveIcon" },
-            APR: { icon: faThumbsUp, className: "approvedIcon" },
-            ARQ: { icon: faCircleInfo, className: "approvalRequestedIcon" },
+            UNP: { icon: faClock, className: "inactiveIcon" },
+            SCH: { icon: faThumbsUp, className: "approvedIcon" },
+            HQR: { icon: faCircleInfo, className: "approvalRequestedIcon" },
             PUB: { icon: faArrowUpToLine, className: "publishedIcon" },
           };
           const code = rowData.advisoryStatus?.code;


### PR DESCRIPTION
### Jira Ticket

CMS-1701

### Description

This change updates constants used in the BC Parks Staff Portal to refer to advisory statuses that have been changed in Strapi

| Old Status        | Old Code | New Status | New Code |
|-------------------------|----------|--------------------------|-----------|
| Inactive                | INA      | Unpublished | UNP        |
| Approval Requested      | ARQ      | HQ Review | HQR          |
| Approved                | APR      | Scheduled | SCH          |

This PR needs to be merged and deployed in conjunction with https://github.com/bcgov/bcparks.ca/pull/1780


