### PR TITLE
CMS-1696: Add hasDates to park operation populate fields

### DIFF
--- a/backend/strapi-sync/strapi-data-service.js
+++ b/backend/strapi-sync/strapi-data-service.js
@@ -58,6 +58,7 @@ const MODEL_CONFIG = {
             "hasWinterFeeDates",
             "hasTier1Dates",
             "hasTier2Dates",
+            "hasDates",
           ],
         },
         managementAreas: {


### PR DESCRIPTION
### Jira Ticket

CMS-1696

### Description
<!-- What did you change, and why? -->
- Added `hasDates` to park operation populate fields so that the sync script can import `hasDates` value
