### PR TITLE
CMS-1701: Fix advisory status casing in dropdown

### DIFF
--- a/frontend/src/lib/advisories/utils/AppUtil.js
+++ b/frontend/src/lib/advisories/utils/AppUtil.js
@@ -28,10 +28,3 @@ export function dateCompare(a, b) {
   }
   return 0;
 }
-
-export function camelCaseToSentenceCase(input) {
-  if (!input) {
-    return "";
-  }
-  return input[0].toUpperCase() + input.slice(1).toLowerCase();
-}

--- a/frontend/src/router/pages/advisories/advisory/Advisory.jsx
+++ b/frontend/src/router/pages/advisories/advisory/Advisory.jsx
@@ -12,10 +12,7 @@ import {
 } from "@/lib/advisories/utils/AdvisoryUtil";
 import AdvisoryForm from "@/components/advisories/composite/advisoryForm/AdvisoryForm";
 import { Loader } from "@/components/advisories/shared/loader/Loader";
-import {
-  labelCompare,
-  camelCaseToSentenceCase,
-} from "@/lib/advisories/utils/AppUtil";
+import { labelCompare } from "@/lib/advisories/utils/AppUtil";
 import getEnv from "@/config/getEnv";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faArrowLeft } from "@fa-kit/icons/classic/solid";
@@ -562,14 +559,14 @@ export default function Advisory({ mode }) {
             if (restrictedAdvisoryStatusCodes.has(s.code) && approver) {
               return {
                 code: s.code,
-                label: camelCaseToSentenceCase(s.advisoryStatus),
+                label: s.advisoryStatus,
                 value: s.documentId,
               };
             }
             if (!restrictedAdvisoryStatusCodes.has(s.code)) {
               return {
                 code: s.code,
-                label: camelCaseToSentenceCase(s.advisoryStatus),
+                label: s.advisoryStatus,
                 value: s.documentId,
               };
             }


### PR DESCRIPTION
### Jira Ticket

CMS-1701

### Description
This change fixes incorrect advisory status casing in the dropdown.  It was appearing as `Hq review` instead of `HQ review`. 

The `camelCaseToSentenceCase` function was not needed by any of the advisory statuses in the current list. It may have been a remnant from bad data in the past.  

