### PR TITLE
CMS-1572: Fix stale state in updateDateRange

### DIFF
--- a/frontend/src/components/DateRangeFields.jsx
+++ b/frontend/src/components/DateRangeFields.jsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useMemo, useCallback } from "react";
 import PropTypes from "prop-types";
 import classNames from "classnames";
 import { sortBy } from "lodash-es";
@@ -29,15 +29,18 @@ function DateRange({
   const { elements } = useValidationContext();
 
   // Call the update method from the parent
-  function onSelect(dateField, dateObj) {
-    // Existing ranges have an ID
-    if (dateRange.id) {
-      return updateDateRange(dateRange.id, dateField, dateObj);
-    }
+  const onSelect = useCallback(
+    (dateField, dateObj) => {
+      // Existing ranges have an ID
+      if (dateRange.id) {
+        return updateDateRange(dateRange.id, dateField, dateObj);
+      }
 
-    // New ranges have a tempId
-    return updateDateRange(dateRange.tempId, dateField, dateObj, true);
-  }
+      // New ranges have a tempId
+      return updateDateRange(dateRange.tempId, dateField, dateObj, true);
+    },
+    [dateRange.id, dateRange.tempId, updateDateRange],
+  );
 
   return (
     <div className="mb-2">

--- a/frontend/src/components/SeasonForms/ParkSeasonForm.jsx
+++ b/frontend/src/components/SeasonForms/ParkSeasonForm.jsx
@@ -6,7 +6,7 @@ import {
   get as lodashGet,
   cloneDeep,
 } from "lodash-es";
-import { useMemo, useContext } from "react";
+import { useMemo, useContext, useCallback } from "react";
 import PropTypes from "prop-types";
 import { isEqual } from "date-fns";
 
@@ -154,47 +154,62 @@ export default function ParkSeasonForm({
   );
 
   // Updates the date range in the parent component
-  function updateDateRange(id, dateField, dateObj, tempId = false) {
-    const { dateRanges } = season.park.dateable;
-    // Find the dateRanges array index from the dateRange id or tempId
-    const dateRangeIndex = dateRanges.findIndex((range) => {
-      if (tempId) {
-        return range.tempId === id;
-      }
+  const updateDateRange = useCallback(
+    (id, dateField, dateObj, tempId = false) => {
+      setData((prevData) => {
+        const dateRanges = lodashGet(
+          prevData,
+          ["current", "park", "dateable", "dateRanges"],
+          [],
+        );
 
-      return range.id === id;
-    });
+        // Find the dateRanges array index from the dateRange id or tempId
+        const dateRangeIndex = dateRanges.findIndex((range) => {
+          if (tempId) {
+            return range.tempId === id;
+          }
 
-    // Path to access the date range in the season data object
-    const dateRangePath = ["park", "dateable", "dateRanges", dateRangeIndex];
+          return range.id === id;
+        });
 
-    // The DateRange input component fires onSelect even if the date didn't change,
-    // so check if the value actually changed to avoid unnecessary updates.
-    // Get the original value of the date field (startDate or endDate) in the season data object
-    const existingDate = lodashGet(season, [...dateRangePath, dateField], null);
+        // If the date range was removed, don't attempt to update
+        if (dateRangeIndex === -1) return prevData;
 
-    // If the value in the form hasn't changed since it loaded from the API, don't call setData
-    if (isEqual(existingDate, dateObj)) return;
+        // Path to access the date range in the season data object
+        const dateRangePath = [
+          "current",
+          "park",
+          "dateable",
+          "dateRanges",
+          dateRangeIndex,
+        ];
 
-    // Update the local state (in the FormPanel component)
-    setData((prevData) => {
-      let updatedData = cloneDeep(prevData);
+        // The DateRange input component fires onSelect even if the date didn't change,
+        // so check if the value actually changed to avoid unnecessary updates.
+        const existingDate = lodashGet(
+          prevData,
+          [...dateRangePath, dateField],
+          null,
+        );
 
-      // Update the start or end date field in the current season data object
-      updatedData = lodashSet(
-        updatedData,
-        ["current", ...dateRangePath, dateField],
-        dateObj,
-      );
+        // If the value in the form hasn't changed, keep the previous state.
+        if (isEqual(existingDate, dateObj)) return prevData;
 
-      // Set the changed flag for the date range in the current season data object
-      return lodashSet(
-        updatedData,
-        ["current", ...dateRangePath, "changed"],
-        true,
-      );
-    });
-  }
+        let updatedData = cloneDeep(prevData);
+
+        // Update the start or end date field in the current season data object
+        updatedData = lodashSet(
+          updatedData,
+          [...dateRangePath, dateField],
+          dateObj,
+        );
+
+        // Set the changed flag for the date range in the current season data object
+        return lodashSet(updatedData, [...dateRangePath, "changed"], true);
+      });
+    },
+    [setData],
+  );
 
   // Adds a new date range to the Park's dateable.dateRanges
   function addDateRange(dateType) {


### PR DESCRIPTION
### Jira Ticket

CMS-1572

### Description
<!-- What did you change, and why? -->

Fixing a bug that can happen when you update a date range after deleting another date range in the same dateable:

`updateDateRange` sometimes used stale state, so date edits could be applied incorrectly. This change moves the logic into `setData`, so checks and updates always use the correct state from the `prevData` parameter.

I also wrapped `onSelect` in useCallback to reduce potential edge cases with stale callback state. DatePicker.jsx is memoized but it doesn't check if onSelect changes.