### PR TITLE
CMS-1673: Sort the DOOT table by rank

### DIFF
--- a/backend/routes/api/filter-options.js
+++ b/backend/routes/api/filter-options.js
@@ -5,6 +5,7 @@ import {
   FeatureType,
   ManagementArea,
   Section,
+  ParkAreaType,
 } from "../../models/index.js";
 import asyncHandler from "express-async-handler";
 import * as DATE_TYPE from "../../constants/dateType.js";
@@ -15,7 +16,7 @@ router.get(
   "/",
   asyncHandler(async (req, res) => {
     // Run all queries concurrently
-    const [sections, managementAreas, dateTypes, featureTypes, accessGroups] =
+    const [sections, managementAreas, dateTypes, featureTypes, accessGroups, parkAreaTypes] =
       await Promise.all([
         Section.findAll({
           attributes: ["id", "sectionNumber", "name"],
@@ -30,11 +31,15 @@ router.get(
           order: [["strapiDateTypeId", "ASC"]],
         }),
         FeatureType.findAll({
-          attributes: ["id", "name"],
+          attributes: ["id", "strapiFeatureTypeId", "rank", "name"],
           order: [["name", "ASC"]],
         }),
         AccessGroup.findAll({
           attributes: ["id", "name"],
+          order: [["name", "ASC"]],
+        }),
+        ParkAreaType.findAll({
+          attributes: ["id", "parkAreaTypeNumber", "rank", "name"],
           order: [["name", "ASC"]],
         }),
       ]);
@@ -70,6 +75,7 @@ router.get(
       dateTypes: groupedDateTypes,
       featureTypes,
       accessGroups,
+      parkAreaTypes,
     };
 
     if (!filterOptions) {

--- a/backend/routes/api/parks.js
+++ b/backend/routes/api/parks.js
@@ -5,6 +5,7 @@ import {
   Park,
   Season,
   FeatureType,
+  ParkAreaType,
   DateRange,
   DateType,
   Feature,
@@ -265,6 +266,7 @@ function buildParkAreaOutput(parkArea) {
       buildFeatureOutput(feature, parkArea.seasons, false),
     ),
     featureTypes,
+    parkAreaType: parkArea.parkAreaType,
     seasons: parkArea.seasons,
     currentSeason,
     groupedDateRanges: groupDateRangesByTypeAndYear(parkAreaDateRanges),
@@ -317,6 +319,13 @@ router.get(
             },
             // Publishable Seasons for the ParkArea
             seasonModel(currentYear),
+            // ParkAreaType for the ParkArea
+            {
+              model: ParkAreaType,
+              as: "parkAreaType",
+              attributes: ["id", "parkAreaTypeNumber", "name"],
+              required: true,
+            },
           ],
         },
 
@@ -356,6 +365,13 @@ router.get(
         ["name", "ASC"],
         [{ model: ParkArea, as: "parkAreas" }, "name", "ASC"],
         // For Features that ARE part of a ParkArea
+        [
+          { model: ParkArea, as: "parkAreas" },
+          { model: Feature, as: "features" },
+          { model: FeatureType, as: "featureType" },
+          "rank",
+          "ASC",
+        ],
         [
           { model: ParkArea, as: "parkAreas" },
           { model: Feature, as: "features" },

--- a/frontend/src/components/EditAndReviewTable.jsx
+++ b/frontend/src/components/EditAndReviewTable.jsx
@@ -297,26 +297,14 @@ StatusTableRow.propTypes = {
   color: PropTypes.string,
 };
 
-function FeaturesByFeatureTypeWithAreas({
-  featureTypeId,
-  park,
-  parkAreas,
-  formPanelHandler,
-  featureTypeFilter,
-}) {
+function FeaturesByFeatureTypeWithAreas({ park, parkAreas, formPanelHandler }) {
   return (
     <>
       {/* 2 - park area level */}
       {parkAreas.map((parkArea) => {
         const regularSeason = parkArea.currentSeason.regular;
 
-        const featuresInCurrentGroup = parkArea.features.filter((feature) =>
-          featureTypeFilter(
-            feature.featureType.strapiFeatureTypeId,
-            featureTypeId,
-          ),
-        );
-        const featureTypeGroup = featuresInCurrentGroup[0]?.featureType;
+        const featuresInCurrentGroup = parkArea.features;
 
         return (
           featuresInCurrentGroup.length > 0 && (
@@ -325,7 +313,7 @@ function FeaturesByFeatureTypeWithAreas({
                 id={parkArea.id}
                 level="park-area"
                 name={`${park.name} - ${parkArea.name}`}
-                typeName={featureTypeGroup?.name || ""}
+                typeName={parkArea?.parkAreaType?.name || ""}
                 season={regularSeason}
                 formPanelHandler={() =>
                   formPanelHandler({ ...parkArea, level: "park-area" })
@@ -359,11 +347,9 @@ function FeaturesByFeatureTypeWithAreas({
 }
 
 FeaturesByFeatureTypeWithAreas.propTypes = {
-  featureTypeId: PropTypes.number.isRequired,
   park: PropTypes.object.isRequired,
   parkAreas: PropTypes.array.isRequired,
   formPanelHandler: PropTypes.func.isRequired,
-  featureTypeFilter: PropTypes.func.isRequired,
 };
 
 function FeaturesByFeatureTypeNoAreas({ park, features, formPanelHandler }) {
@@ -406,19 +392,14 @@ FeaturesByFeatureTypeNoAreas.propTypes = {
   formPanelHandler: PropTypes.func.isRequired,
 };
 
-function Table({ park, formPanelHandler }) {
+function Table({ park, formPanelHandler, sortOrder }) {
   // Constants
   const parkAreas = park.parkAreas || [];
   const features = park.features || [];
   const regularSeason = park.currentSeason.regular;
   const winterSeason = park?.currentSeason.winter || {};
 
-  // Filter function to determine if feature matches current feature type group
-  function matchesFeatureTypeGroup(featureTypeId, groupFeatureType) {
-    return groupFeatureType === FEATURE_TYPE.UNKNOWN
-      ? !FEATURE_TYPE.SORT_ORDER.includes(featureTypeId)
-      : featureTypeId === groupFeatureType;
-  }
+  if (!sortOrder?.length) return <></>;
 
   return (
     <table key={park.id} className="table has-header-row mb-0">
@@ -496,25 +477,32 @@ function Table({ park, formPanelHandler }) {
           </>
         )}
 
-        {FEATURE_TYPE.SORT_ORDER.map((featureTypeId) => (
-          <React.Fragment key={`feature-type-${featureTypeId}`}>
-            <FeaturesByFeatureTypeWithAreas
-              featureTypeId={featureTypeId}
-              park={park}
-              parkAreas={parkAreas}
-              formPanelHandler={formPanelHandler}
-              featureTypeFilter={matchesFeatureTypeGroup}
-            />
-            <FeaturesByFeatureTypeNoAreas
-              park={park}
-              features={features.filter((f) =>
-                matchesFeatureTypeGroup(
-                  f.featureType.strapiFeatureTypeId,
-                  featureTypeId,
-                ),
-              )}
-              formPanelHandler={formPanelHandler}
-            />
+        {sortOrder.map((groupingType) => (
+          <React.Fragment
+            key={`${groupingType.type}-${groupingType.parkAreaTypeNumber || groupingType.strapiFeatureTypeId}`}
+          >
+            {groupingType.type === "ParkAreaType" && (
+              <FeaturesByFeatureTypeWithAreas
+                park={park}
+                parkAreas={parkAreas.filter(
+                  (pa) =>
+                    pa.parkAreaType?.parkAreaTypeNumber ===
+                    groupingType.parkAreaTypeNumber,
+                )}
+                formPanelHandler={formPanelHandler}
+              />
+            )}
+            {groupingType.type === "FeatureType" && (
+              <FeaturesByFeatureTypeNoAreas
+                park={park}
+                features={features.filter(
+                  (f) =>
+                    f.featureType.strapiFeatureTypeId ===
+                    groupingType.strapiFeatureTypeId,
+                )}
+                formPanelHandler={formPanelHandler}
+              />
+            )}
           </React.Fragment>
         ))}
       </tbody>
@@ -577,17 +565,24 @@ Table.propTypes = {
   }),
   formPanelHandler: PropTypes.func.isRequired,
   inReservationSystemFilter: PropTypes.bool,
+  sortOrder: PropTypes.arrayOf(PropTypes.object),
 };
 
 export default function EditAndReviewTable({
   data,
   onResetFilters,
   formPanelHandler,
+  sortOrder,
 }) {
   return (
     <div className="table-responsive">
       {data.map((park) => (
-        <Table key={park.id} park={park} formPanelHandler={formPanelHandler} />
+        <Table
+          key={park.id}
+          park={park}
+          formPanelHandler={formPanelHandler}
+          sortOrder={sortOrder}
+        />
       ))}
 
       {data.length === 0 && (
@@ -615,4 +610,5 @@ EditAndReviewTable.propTypes = {
   ),
   onResetFilters: PropTypes.func,
   formPanelHandler: PropTypes.func,
+  sortOrder: PropTypes.arrayOf(PropTypes.object),
 };

--- a/frontend/src/constants/featureType.js
+++ b/frontend/src/constants/featureType.js
@@ -21,27 +21,4 @@ export const TRAIL = 16;
 export const WALK_IN_CAMPING = 17;
 export const WILDERNESS_CAMPING = 18;
 export const WINTER_CAMPING = 19;
-export const UNKNOWN = -1; // New feature types are sorted last by default.
-
-export const SORT_ORDER = [
-  FRONTCOUNTRY_CAMPGROUND,
-  CABIN,
-  WALK_IN_CAMPING,
-  WINTER_CAMPING,
-  GROUP_CAMPGROUND,
-  RESORT,
-  BACKCOUNTRY,
-  MARINE_ACCESSIBLE_CAMPING,
-  HUT,
-  SHELTER,
-  WILDERNESS_CAMPING,
-  PICNIC_AREA,
-  PICNIC_SHELTER,
-  BOAT_LAUNCH,
-  HOT_SPRING,
-  DOCK,
-  MOORING_BUOY,
-  ANCHORAGE,
-  TRAIL,
-  UNKNOWN,
-];
+export const YURT = 21;

--- a/frontend/src/router/pages/EditAndReview.jsx
+++ b/frontend/src/router/pages/EditAndReview.jsx
@@ -31,7 +31,11 @@ function EditAndReview() {
     error: filterOptionsError,
   } = useApiGet("/filter-options");
   const parks = useMemo(() => data ?? [], [data]);
-  const filterOptions = filterOptionsData ?? {};
+
+  const filterOptions = useMemo(
+    () => filterOptionsData ?? {},
+    [filterOptionsData],
+  );
 
   const statusOptions = [
     { value: STATUS.REQUESTED.value, label: STATUS.REQUESTED.label },
@@ -39,6 +43,23 @@ function EditAndReview() {
     { value: STATUS.APPROVED.value, label: STATUS.APPROVED.label },
     { value: STATUS.PUBLISHED.value, label: STATUS.PUBLISHED.label },
   ];
+
+  const tableSortOrder = useMemo(
+    () =>
+      [
+        ...(filterOptions?.parkAreaTypes ?? []).map((p) => ({
+          rank: p.rank,
+          parkAreaTypeNumber: p.parkAreaTypeNumber,
+          type: "ParkAreaType",
+        })),
+        ...(filterOptions?.featureTypes ?? []).map((f) => ({
+          rank: f.rank,
+          strapiFeatureTypeId: f.strapiFeatureTypeId,
+          type: "FeatureType",
+        })),
+      ].sort((a, b) => a.rank - b.rank),
+    [filterOptions],
+  );
 
   // table pagination
   const [page, setPage] = useState(1);
@@ -325,6 +346,7 @@ function EditAndReview() {
               data={pageData}
               onResetFilters={resetFilters}
               formPanelHandler={formPanelHandler}
+              sortOrder={tableSortOrder}
             />
           </RefreshTableContext.Provider>
         </div>


### PR DESCRIPTION
### Jira Ticket

CMS-1673

### Description
This PR changes the main DOOT table to sort by both `ParkAreaType.rank` and `FeatureType.rank` instead of the previous hardcoded FeatureType-only order. As part of this, Park Areas are no longer split up by FeatureType. All features belonging to a Park Area are now rendered together under their ParkAreaType and sorted by FeatureType.rank within the Park Area. 

