### PR TITLE
CMS-1667: Add group label to resource status display

### DIFF
--- a/frontend/src/lib/advisories/utils/AdvisoryDashboardQuery.js
+++ b/frontend/src/lib/advisories/utils/AdvisoryDashboardQuery.js
@@ -24,6 +24,7 @@ const COLUMN_FILTERS = [
     build: (value) => ({
       $or: [
         { accessStatus: { accessStatus: { $containsi: value } } },
+        { accessStatus: { groupLabel: { $containsi: value } } },
       ],
     }),
   },

--- a/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.jsx
+++ b/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.jsx
@@ -710,7 +710,7 @@ export default function AdvisoryDashboard() {
 
           if (!accessStatus) return "";
 
-          return groupLabel !== accessStatus
+          return groupLabel && groupLabel !== accessStatus
             ? `${groupLabel} - ${accessStatus}`
             : accessStatus;
         },

--- a/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.jsx
+++ b/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.jsx
@@ -373,7 +373,7 @@ export default function AdvisoryDashboard() {
               recreationResources: {
                 fields: ["recResourceId", "resourceName"],
               },
-              accessStatus: { fields: ["accessStatus"] },
+              accessStatus: { fields: ["accessStatus", "groupLabel"] },
               advisoryStatus: { fields: ["advisoryStatus", "code"] },
               eventType: { fields: ["eventType"] },
               urgency: { fields: ["urgency"] },
@@ -702,10 +702,17 @@ export default function AdvisoryDashboard() {
             status
           </>
         ),
-        headerStyle: { minWidth: 100 },
-        cellStyle: { minWidth: 100 },
+        headerStyle: { minWidth: 120 },
+        cellStyle: { minWidth: 120 },
         render(rowData) {
-          return rowData.accessStatus?.accessStatus || "";
+          const accessStatus = rowData.accessStatus?.accessStatus || "";
+          const groupLabel = rowData.accessStatus?.groupLabel || "";
+
+          if (!accessStatus) return "";
+
+          return groupLabel !== accessStatus
+            ? `${groupLabel} - ${accessStatus}`
+            : accessStatus;
         },
       },
       { field: "eventType.eventType", title: "Event type" },


### PR DESCRIPTION
### Jira Ticket

CMS-1667

### Description
<!-- What did you change, and why? -->
- Additional change on https://github.com/bcgov/bcparks-staff-portal/pull/538
- Displayed `groupLabel` + `accessStatus` in the "Resource status" column if `groupLabel` and `accessStatus` values are not the same
