### PR TITLE
CMS-1540: Clean up DOOT CrunchyDB helm files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,11 +132,6 @@ dist
 .yarn/install-state.gz
 .pnp.*
 
-# crunchy-postgres helm files (from https://github.com/bcgov/crunchy-postgres/tree/main/charts/crunchy-postgres)
-helm/crunchy-postgres/.helmignore
-helm/crunchy-postgres/Chart.yaml
-helm/crunchy-postgres/values.yaml
-
 bcparks-staff-portal.code-workspace
 
 # Ignore Park AccessGroup data because it has user email addresses

--- a/helm/README.md
+++ b/helm/README.md
@@ -82,19 +82,6 @@ helm -n a7dd13-test install alpha . -f values-alpha-test.yaml
 helm -n a7dd13-test install training . -f values-training.yaml
 ```
 
-### Create the Postgres user and db
-
-If this is the first time deploying the app then you will also need to create a Postgres user and an empty database.
-
-1. Go into the terminal on one of the `crunchy-postgres-ha-*` pods. _(choose the one using the most memory)_
-2. Run `patronictl list` at the command prompt to make sure you are in the leader. Switch to the leader pod if you aren't on the leader.
-3. Get the password from `main-postgres-secret` or `alpha-postgres-secret`
-4. Run the `psql` command and enter the following commands in the sql console. Replace `<password>` with the password from step 3, and replace `main` with `alpha` for alpha deployments.
-   ```sql
-   CREATE USER "bcparks-main" WITH PASSWORD '<password>';
-   CREATE DATABASE "staff-portal-main" OWNER "bcparks-main";
-   ```
-
 #### Create additional Routes
 
 Some additional Openshift routes must also be manually created. Use the bcparks.ca wildcard certificate for these routes. DNS updates may also be needed.
@@ -151,9 +138,9 @@ helm -n a7dd13-test upgrade training . -f values-training.yaml
 
 ## Teardown
 
-The `uninstall` command ca be used to remove all resources defined by the Helm chart. Please note that secrets and PVCs created by the Helm chart are not automatically removed.
+The `uninstall` command can be used to remove all resources defined by the Helm chart. Please note that secrets and PVCs created by the Helm chart are not automatically removed.
 
-Run the following commands from the `infrastructure/helm/bcparks` directory.
+Run the following commands from the `helm/deployment` directory.
 
 NOTE: This wil not remove the secrets.
 

--- a/helm/crunchy-postgres/.helmignore
+++ b/helm/crunchy-postgres/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm/crunchy-postgres/Chart.yaml
+++ b/helm/crunchy-postgres/Chart.yaml
@@ -1,0 +1,26 @@
+apiVersion: v2
+name: crunchy-postgres
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.6.5
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+
+# Crunchy Postgres Operator version
+appVersion: "5.5.1"

--- a/helm/crunchy-postgres/README.md
+++ b/helm/crunchy-postgres/README.md
@@ -95,13 +95,24 @@ Don't run `uninstall crunchy` unless you really want to lose all your data!
 ### Dev
 
 ```sh
+# dev:
 helm -n a7dd13-dev uninstall crunchy
+
+# alpha-dev:
+helm -n a7dd13-dev uninstall crunchy-alpha
 ```
 
 ### Test
 
 ```sh
+# test:
 helm -n a7dd13-test uninstall crunchy
+
+# alpha-test:
+helm -n a7dd13-test uninstall crunchy-alpha
+
+# training: (a third test environment, for RSOs and POs)
+helm -n a7dd13-test uninstall crunchy-training
 ```
 
 ### Prod

--- a/helm/crunchy-postgres/README.md
+++ b/helm/crunchy-postgres/README.md
@@ -1,6 +1,6 @@
 # Crunchy Postgres Installation
 
-## Prerequesites
+## Prerequisites
 
 - Install `helm` CLI from https://helm.sh/docs/intro/install/
 
@@ -133,7 +133,7 @@ A chart to provision a [Crunchy Postgres](https://www.crunchydata.com/) cluster.
 | ------------------ | ---------------------- | ------------------ |
 | `fullnameOverride` | Override release name  | `crunchy-postgres` |
 | `crunchyImage`     | Crunchy Postgres image |                    |
-| `postgresVersion`  | Postgres version       | `14`               |
+| `postgresVersion`  | Postgres version       | `15`               |
 
 ---
 

--- a/helm/crunchy-postgres/UPSTREAM.md
+++ b/helm/crunchy-postgres/UPSTREAM.md
@@ -1,0 +1,29 @@
+# Upstream Source
+
+This directory contains a copy of the upstream Helm chart so it can be versioned and maintained alongside this project:
+
+- Repository: https://github.com/bcgov/crunchy-postgres
+- Source path: charts/crunchy-postgres
+- Source URL: https://github.com/bcgov/crunchy-postgres/tree/main/charts/crunchy-postgres
+- Imported commit: `ec73314008b283fb66eb72dd196d6f266492bd5e`
+- Imported branch: `main`
+
+## Editing Guidelines
+
+To keep upstream updates simple, **all local customizations must be confined to specific files**.
+
+### ✅ Allowed edits
+
+- `values-alpha-dev.yaml`
+- `values-alpha-test.yaml`
+- `values-dev.yaml`
+- `values-prod.yaml`
+- `values-test.yaml`
+- `values-training.yaml`
+- Documentation files:
+  - `README.md`
+  - `UPSTREAM.md`
+
+### 🚫 Do not edit
+
+All other files come directly from upstream and should be treated as read‑only. Keeping changes limited to the files above makes it easy to refresh from upstream, reduce merge conflicts, and clearly separate local configuration from upstream source.

--- a/helm/crunchy-postgres/templates/PostgresCluster.yaml
+++ b/helm/crunchy-postgres/templates/PostgresCluster.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "crunchy-postgres.fullname" . }}
   labels: {{ include "crunchy-postgres.labels" . | nindent 4 }}
 spec:
-  openshift: true
+  openshift: {{ .Values.openshift }}
   metadata:
     labels: {{ include "crunchy-postgres.labels" . | nindent 6 }}
   {{ if .Values.crunchyImage }}
@@ -29,9 +29,11 @@ spec:
           requests:
             cpu: {{ .Values.pgmonitor.exporter.requests.cpu }}
             memory: {{ .Values.pgmonitor.exporter.requests.memory }}
+          {{ if .Values.pgmonitor.exporter.limits }}
           limits:
             cpu: {{ .Values.pgmonitor.exporter.limits.cpu }}
             memory: {{ .Values.pgmonitor.exporter.limits.memory }}
+          {{ end }}
 
   {{ end }}
 
@@ -42,18 +44,22 @@ spec:
         requests:
           cpu: {{ .Values.instances.requests.cpu }}
           memory: {{ .Values.instances.requests.memory }}
+        {{ if .Values.instances.limits }}
         limits:
           cpu: {{ .Values.instances.limits.cpu }}
           memory: {{ .Values.instances.limits.memory }}
+        {{ end }}
       sidecars:
         replicaCertCopy:
           resources:
             requests:
               cpu: {{ .Values.instances.replicaCertCopy.requests.cpu }}
               memory: {{ .Values.instances.replicaCertCopy.requests.memory }}
+            {{ if .Values.instances.replicaCertCopy.limits }}
             limits:
               cpu: {{ .Values.instances.replicaCertCopy.limits.cpu }}
               memory: {{ .Values.instances.replicaCertCopy.limits.memory }}
+            {{ end }}
       dataVolumeClaimSpec:
         accessModes:
           - "ReadWriteOnce"
@@ -111,8 +117,10 @@ spec:
       {{- end }}
       global:
         # Support both PVC and s3 backups
+        {{- if .Values.pgBackRest.repo1.enabled }}
         repo1-retention-full: {{ .Values.pgBackRest.retention | quote }}
         repo1-retention-full-type: {{ .Values.pgBackRest.retentionFullType }}
+        {{- end }}
         {{- if .Values.pgBackRest.s3.enabled }}
         repo2-retention-full: {{ .Values.pgBackRest.retention | quote }}
         repo2-retention-full-type: {{ .Values.pgBackRest.retentionFullType }}
@@ -121,6 +129,7 @@ spec:
         {{- end }}
       repos:
         # hardcoding repo1 until we solution allowing multiple repos
+        {{- if .Values.pgBackRest.repo1.enabled }}
         - name: repo1
           schedules:
             full: {{ .Values.pgBackRest.repos.schedules.full }}
@@ -133,6 +142,7 @@ spec:
                 requests:
                   storage: {{ .Values.pgBackRest.repos.volume.storage }}
               storageClassName: {{ .Values.pgBackRest.repos.volume.storageClassName }}
+        {{- end }}
         {{- if .Values.pgBackRest.s3.enabled }}
         - name: repo2
           schedules:
@@ -143,31 +153,17 @@ spec:
             endpoint: {{ .Values.pgBackRest.s3.endpoint }}
             region: {{ .Values.pgBackRest.s3.region }}
         {{- end }}
-
-      # Backup and recovery options
-      {{- if and .Values.pgBackRest.restore .Values.pgBackRest.restore.enabled }}
-      restore:
-        enabled: {{ .Values.pgBackRest.restore.enabled }}
-        repoName: {{ .Values.pgBackRest.restore.repoName }}
-        options:
-          - --type=time
-          - --target="{{ .Values.pgBackRest.restore.target }}"
-      {{- end }}
-
-      manual:
-        options:
-          - --type=full
-        repoName: {{ .Values.pgBackRest.manual.repoName }}
-
       # this stuff is for the "pgbackrest" container (the only non-init container) in the "postgres-crunchy-repo-host" pod
       repoHost:
         resources:
           requests:
             cpu: {{ .Values.pgBackRest.repoHost.requests.cpu }}
             memory: {{ .Values.pgBackRest.repoHost.requests.memory }}
+          {{- if .Values.pgBackRest.repoHost.limits }}
           limits:
             cpu: {{ .Values.pgBackRest.repoHost.limits.cpu }}
             memory: {{ .Values.pgBackRest.repoHost.limits.memory }}
+          {{- end }}
       sidecars:
         # this stuff is for the "pgbackrest" container in the "postgres-crunchy-ha" set of pods
         pgbackrest:
@@ -175,17 +171,21 @@ spec:
             requests:
               cpu: {{ .Values.pgBackRest.sidecars.requests.cpu }}
               memory: {{ .Values.pgBackRest.sidecars.requests.memory }}
+            {{- if .Values.pgBackRest.sidecars.limits }}
             limits:
               cpu: {{ .Values.pgBackRest.sidecars.limits.cpu }}
               memory: {{ .Values.pgBackRest.sidecars.limits.memory }}
+            {{- end }}
         pgbackrestConfig:
           resources:
             requests:
               cpu: {{ .Values.pgBackRest.sidecars.requests.cpu }}
               memory: {{ .Values.pgBackRest.sidecars.requests.memory }}
+            {{- if .Values.pgBackRest.sidecars.limits }}
             limits:
               cpu: {{ .Values.pgBackRest.sidecars.limits.cpu }}
               memory: {{ .Values.pgBackRest.sidecars.limits.memory }}
+            {{- end }}
   standby:
     enabled: {{ .Values.standby.enabled }}
     repoName: {{ .Values.standby.repoName }}
@@ -217,9 +217,11 @@ spec:
         requests:
           cpu: {{ .Values.proxy.pgBouncer.requests.cpu }}
           memory: {{ .Values.proxy.pgBouncer.requests.memory }}
+        {{ if .Values.proxy.pgBouncer.limits }}
         limits:
           cpu: {{ .Values.proxy.pgBouncer.limits.cpu }}
           memory: {{ .Values.proxy.pgBouncer.limits.memory }}
+        {{ end }}
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/helm/crunchy-postgres/values-alpha-dev.yaml
+++ b/helm/crunchy-postgres/values-alpha-dev.yaml
@@ -1,149 +1,22 @@
 fullnameOverride: crunchy-postgres-alpha
 
-crunchyImage: # it's not necessary to specify an image as the images specified in the Crunchy Postgres Operator will be pulled by default
-#crunchyImage: artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-postgres-gis:ubi8-15.2-3.3-0 # use this image for POSTGIS
 postgresVersion: 17
-#postGISVersion: '3.3' # use this version of POSTGIS. both crunchyImage and this property needs to have valid values for POSTGIS to be enabled.
-imagePullPolicy: IfNotPresent
-
-# enable to bootstrap a standby cluster from backup. Then disable to promote this standby to primary
-standby:
-  enabled: false
-  # If you want to recover from PVC, use repo1. If you want to recover from S3, use repo2
-  repoName: repo2
 
 instances:
-  name: ha # high availability
   replicas: 1
   dataVolumeClaimSpec:
     storage: 2Gi
-    storageClassName: netapp-block-standard
   requests:
     cpu: 100m
-    memory: 256Mi
-  limits:
-    cpu: 400m
-    memory: 512Mi
-  replicaCertCopy:
-    requests:
-      cpu: 1m
-      memory: 32Mi
-    limits:
-      cpu: 50m
-      memory: 64Mi
-
-# If we need to restore the cluster from a backup, we need to set the following values
-# assuming restore from repo2 (s3), adjust as needed if your S3 repo is different
-dataSource:
-  enabled: false
-  # should have the same name and contain the same keys as the pgbackrest secret
-  secretName: s3-pgbackrest
-  repo:
-    name: repo2
-    path: "/habackup"
-    s3:
-      bucket: "bucketName"
-      endpoint: "s3.ca-central-1.amazonaws.com"
-      region: "ca-central-1"
-    stanza: db
 
 pgBackRest:
-  image: # it's not necessary to specify an image as the images specified in the Crunchy Postgres Operator will be pulled by default
-  retention: "2" # Ideally a larger number such as 30 backups/days
-  # If retention-full-type set to 'count' then the oldest backups will expire when the number of backups reach the number defined in retention
-  # If retention-full-type set to 'time' then the number defined in retention will take that many days worth of full backups before expiration
-  retentionFullType: count
   repos:
-    schedules:
-      full: 0 8 * * *
-      incremental: 0 0,4,12,16,20 * * *
     volume:
-      accessModes: "ReadWriteOnce"
       storage: 1Gi
-      storageClassName: netapp-file-backup
-  repoHost:
-    requests:
-      cpu: 1m
-      memory: 64Mi
-    limits:
-      cpu: 50m
-      memory: 128Mi
-  sidecars:
-    requests:
-      cpu: 1m
-      memory: 64Mi
-    limits:
-      cpu: 50m
-      memory: 128Mi
-  s3:
-    enabled: false
-    createS3Secret: true
-    # the s3 secret name
-    s3Secret: s3-pgbackrest
-    # the path start with /, it will be created under bucket if it doesn't exist
-    s3Path: "/habackup"
-    # s3UriStyle is host or path
-    s3UriStyle: path
-    # bucket specifies the S3 bucket to use,
-    bucket: "bucketName"
-    # endpoint specifies the S3 endpoint to use.
-    endpoint: "endpointName"
-    # region specifies the S3 region to use. If your S3 storage system does not
-    # use "region", fill this in with a random value.
-    region: "ca-central-1"
-    # key is the S3 key. This is stored in a Secret.
-    # Please DO NOT push this value to GitHub
-    key: "s3keyValue"
-    # keySecret is the S3 key secret. This is stored in a Secret.
-    # Please DO NOT push this value to GitHub
-    keySecret: "s3SecretValue"
-    # setting the below to be one plus of the default schedule
-    # to avoid conflicts
-    fullSchedule: "0 9 * * *"
-    incrementalSchedule: "0 1,5,13,17,21 * * *"
-
-  # Restore from backup
-  restore:
-    enabled: false
-    # PVC=repo1 / S3=repo2
-    repoName: ~ # provide repo name
-    target: ~ # 2024-03-24 17:16:00-07 this is the target timestamp to go back to in current cluster
-
-  # Specify the repo to use for manual full backups
-  # PVC=repo1 / S3=repo2
-  manual:
-    repoName: repo1
-
-patroni:
-  postgresql:
-    pg_hba: "host all all 0.0.0.0/0 md5"
-    parameters:
-      shared_buffers: 16MB # default is 128MB; a good tuned default for shared_buffers is 25% of the memory allocated to the pod
-      wal_buffers: "64kB" # this can be set to -1 to automatically set as 1/32 of shared_buffers or 64kB, whichever is larger
-      min_wal_size: 32MB
-      max_wal_size: 64MB # default is 1GB
-      max_slot_wal_keep_size: 128MB # default is -1, allowing unlimited wal growth when replicas fall behind
 
 proxy:
   pgBouncer:
-    image: # it's not necessary to specify an image as the images specified in the Crunchy Postgres Operator will be pulled by default
     replicas: 1
-    requests:
-      cpu: 1m
-      memory: 64Mi
-    limits:
-      cpu: 50m
-      memory: 128Mi
 
-# Postgres Cluster resource values:
 pgmonitor:
-  enabled: false
   namespace: a7dd13 #The high level namespace of your project without the -tools -dev, etc part.
-  exporter:
-    image: # it's not necessary to specify an image as the images specified in the Crunchy Postgres Operator will be pulled by default
-    requests:
-      cpu: 1m
-      memory: 64Mi
-    limits:
-      cpu: 50m
-      memory: 128Mi

--- a/helm/crunchy-postgres/values-alpha-test.yaml
+++ b/helm/crunchy-postgres/values-alpha-test.yaml
@@ -1,149 +1,22 @@
 fullnameOverride: crunchy-postgres-alpha
 
-crunchyImage: # it's not necessary to specify an image as the images specified in the Crunchy Postgres Operator will be pulled by default
-#crunchyImage: artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-postgres-gis:ubi8-15.2-3.3-0 # use this image for POSTGIS
 postgresVersion: 17
-#postGISVersion: '3.3' # use this version of POSTGIS. both crunchyImage and this property needs to have valid values for POSTGIS to be enabled.
-imagePullPolicy: IfNotPresent
-
-# enable to bootstrap a standby cluster from backup. Then disable to promote this standby to primary
-standby:
-  enabled: false
-  # If you want to recover from PVC, use repo1. If you want to recover from S3, use repo2
-  repoName: repo2
 
 instances:
-  name: ha # high availability
   replicas: 1
   dataVolumeClaimSpec:
     storage: 2Gi
-    storageClassName: netapp-block-standard
   requests:
     cpu: 100m
-    memory: 256Mi
-  limits:
-    cpu: 400m
-    memory: 512Mi
-  replicaCertCopy:
-    requests:
-      cpu: 1m
-      memory: 32Mi
-    limits:
-      cpu: 50m
-      memory: 64Mi
-
-# If we need to restore the cluster from a backup, we need to set the following values
-# assuming restore from repo2 (s3), adjust as needed if your S3 repo is different
-dataSource:
-  enabled: false
-  # should have the same name and contain the same keys as the pgbackrest secret
-  secretName: s3-pgbackrest
-  repo:
-    name: repo2
-    path: "/habackup"
-    s3:
-      bucket: "bucketName"
-      endpoint: "s3.ca-central-1.amazonaws.com"
-      region: "ca-central-1"
-    stanza: db
 
 pgBackRest:
-  image: # it's not necessary to specify an image as the images specified in the Crunchy Postgres Operator will be pulled by default
-  retention: "2" # Ideally a larger number such as 30 backups/days
-  # If retention-full-type set to 'count' then the oldest backups will expire when the number of backups reach the number defined in retention
-  # If retention-full-type set to 'time' then the number defined in retention will take that many days worth of full backups before expiration
-  retentionFullType: count
   repos:
-    schedules:
-      full: 0 8 * * *
-      incremental: 0 0,4,12,16,20 * * *
     volume:
-      accessModes: "ReadWriteOnce"
       storage: 1Gi
-      storageClassName: netapp-file-backup
-  repoHost:
-    requests:
-      cpu: 1m
-      memory: 64Mi
-    limits:
-      cpu: 50m
-      memory: 128Mi
-  sidecars:
-    requests:
-      cpu: 1m
-      memory: 64Mi
-    limits:
-      cpu: 50m
-      memory: 128Mi
-  s3:
-    enabled: false
-    createS3Secret: true
-    # the s3 secret name
-    s3Secret: s3-pgbackrest
-    # the path start with /, it will be created under bucket if it doesn't exist
-    s3Path: "/habackup"
-    # s3UriStyle is host or path
-    s3UriStyle: path
-    # bucket specifies the S3 bucket to use,
-    bucket: "bucketName"
-    # endpoint specifies the S3 endpoint to use.
-    endpoint: "endpointName"
-    # region specifies the S3 region to use. If your S3 storage system does not
-    # use "region", fill this in with a random value.
-    region: "ca-central-1"
-    # key is the S3 key. This is stored in a Secret.
-    # Please DO NOT push this value to GitHub
-    key: "s3keyValue"
-    # keySecret is the S3 key secret. This is stored in a Secret.
-    # Please DO NOT push this value to GitHub
-    keySecret: "s3SecretValue"
-    # setting the below to be one plus of the default schedule
-    # to avoid conflicts
-    fullSchedule: "0 9 * * *"
-    incrementalSchedule: "0 1,5,13,17,21 * * *"
-
-  # Restore from backup
-  restore:
-    enabled: false
-    # PVC=repo1 / S3=repo2
-    repoName: ~ # provide repo name
-    target: ~ # 2024-03-24 17:16:00-07 this is the target timestamp to go back to in current cluster
-
-  # Specify the repo to use for manual full backups
-  # PVC=repo1 / S3=repo2
-  manual:
-    repoName: repo1
-
-patroni:
-  postgresql:
-    pg_hba: "host all all 0.0.0.0/0 md5"
-    parameters:
-      shared_buffers: 16MB # default is 128MB; a good tuned default for shared_buffers is 25% of the memory allocated to the pod
-      wal_buffers: "64kB" # this can be set to -1 to automatically set as 1/32 of shared_buffers or 64kB, whichever is larger
-      min_wal_size: 32MB
-      max_wal_size: 64MB # default is 1GB
-      max_slot_wal_keep_size: 128MB # default is -1, allowing unlimited wal growth when replicas fall behind
 
 proxy:
   pgBouncer:
-    image: # it's not necessary to specify an image as the images specified in the Crunchy Postgres Operator will be pulled by default
     replicas: 1
-    requests:
-      cpu: 1m
-      memory: 64Mi
-    limits:
-      cpu: 50m
-      memory: 128Mi
 
-# Postgres Cluster resource values:
 pgmonitor:
-  enabled: false
   namespace: a7dd13 #The high level namespace of your project without the -tools -dev, etc part.
-  exporter:
-    image: # it's not necessary to specify an image as the images specified in the Crunchy Postgres Operator will be pulled by default
-    requests:
-      cpu: 1m
-      memory: 64Mi
-    limits:
-      cpu: 50m
-      memory: 128Mi

--- a/helm/crunchy-postgres/values-dev.yaml
+++ b/helm/crunchy-postgres/values-dev.yaml
@@ -1,149 +1,22 @@
 fullnameOverride: crunchy-postgres
 
-crunchyImage: # it's not necessary to specify an image as the images specified in the Crunchy Postgres Operator will be pulled by default
-#crunchyImage: artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-postgres-gis:ubi8-15.2-3.3-0 # use this image for POSTGIS
 postgresVersion: 17
-#postGISVersion: '3.3' # use this version of POSTGIS. both crunchyImage and this property needs to have valid values for POSTGIS to be enabled.
-imagePullPolicy: IfNotPresent
-
-# enable to bootstrap a standby cluster from backup. Then disable to promote this standby to primary
-standby:
-  enabled: false
-  # If you want to recover from PVC, use repo1. If you want to recover from S3, use repo2
-  repoName: repo2
 
 instances:
-  name: ha # high availability
   replicas: 1
   dataVolumeClaimSpec:
     storage: 2Gi
-    storageClassName: netapp-block-standard
   requests:
     cpu: 100m
-    memory: 256Mi
-  limits:
-    cpu: 400m
-    memory: 512Mi
-  replicaCertCopy:
-    requests:
-      cpu: 1m
-      memory: 32Mi
-    limits:
-      cpu: 50m
-      memory: 64Mi
-
-# If we need to restore the cluster from a backup, we need to set the following values
-# assuming restore from repo2 (s3), adjust as needed if your S3 repo is different
-dataSource:
-  enabled: false
-  # should have the same name and contain the same keys as the pgbackrest secret
-  secretName: s3-pgbackrest
-  repo:
-    name: repo2
-    path: "/habackup"
-    s3:
-      bucket: "bucketName"
-      endpoint: "s3.ca-central-1.amazonaws.com"
-      region: "ca-central-1"
-    stanza: db
 
 pgBackRest:
-  image: # it's not necessary to specify an image as the images specified in the Crunchy Postgres Operator will be pulled by default
-  retention: "2" # Ideally a larger number such as 30 backups/days
-  # If retention-full-type set to 'count' then the oldest backups will expire when the number of backups reach the number defined in retention
-  # If retention-full-type set to 'time' then the number defined in retention will take that many days worth of full backups before expiration
-  retentionFullType: count
   repos:
-    schedules:
-      full: 0 8 * * *
-      incremental: 0 0,4,12,16,20 * * *
     volume:
-      accessModes: "ReadWriteOnce"
       storage: 1Gi
-      storageClassName: netapp-file-backup
-  repoHost:
-    requests:
-      cpu: 1m
-      memory: 64Mi
-    limits:
-      cpu: 50m
-      memory: 128Mi
-  sidecars:
-    requests:
-      cpu: 1m
-      memory: 64Mi
-    limits:
-      cpu: 50m
-      memory: 128Mi
-  s3:
-    enabled: false
-    createS3Secret: true
-    # the s3 secret name
-    s3Secret: s3-pgbackrest
-    # the path start with /, it will be created under bucket if it doesn't exist
-    s3Path: "/habackup"
-    # s3UriStyle is host or path
-    s3UriStyle: path
-    # bucket specifies the S3 bucket to use,
-    bucket: "bucketName"
-    # endpoint specifies the S3 endpoint to use.
-    endpoint: "endpointName"
-    # region specifies the S3 region to use. If your S3 storage system does not
-    # use "region", fill this in with a random value.
-    region: "ca-central-1"
-    # key is the S3 key. This is stored in a Secret.
-    # Please DO NOT push this value to GitHub
-    key: "s3keyValue"
-    # keySecret is the S3 key secret. This is stored in a Secret.
-    # Please DO NOT push this value to GitHub
-    keySecret: "s3SecretValue"
-    # setting the below to be one plus of the default schedule
-    # to avoid conflicts
-    fullSchedule: "0 9 * * *"
-    incrementalSchedule: "0 1,5,13,17,21 * * *"
-
-  # Restore from backup
-  restore:
-    enabled: false
-    # PVC=repo1 / S3=repo2
-    repoName: ~ # provide repo name
-    target: ~ # 2024-03-24 17:16:00-07 this is the target timestamp to go back to in current cluster
-
-  # Specify the repo to use for manual full backups
-  # PVC=repo1 / S3=repo2
-  manual:
-    repoName: repo1
-
-patroni:
-  postgresql:
-    pg_hba: "host all all 0.0.0.0/0 md5"
-    parameters:
-      shared_buffers: 16MB # default is 128MB; a good tuned default for shared_buffers is 25% of the memory allocated to the pod
-      wal_buffers: "64kB" # this can be set to -1 to automatically set as 1/32 of shared_buffers or 64kB, whichever is larger
-      min_wal_size: 32MB
-      max_wal_size: 64MB # default is 1GB
-      max_slot_wal_keep_size: 128MB # default is -1, allowing unlimited wal growth when replicas fall behind
 
 proxy:
   pgBouncer:
-    image: # it's not necessary to specify an image as the images specified in the Crunchy Postgres Operator will be pulled by default
     replicas: 1
-    requests:
-      cpu: 1m
-      memory: 64Mi
-    limits:
-      cpu: 50m
-      memory: 128Mi
 
-# Postgres Cluster resource values:
 pgmonitor:
-  enabled: false
   namespace: a7dd13 #The high level namespace of your project without the -tools -dev, etc part.
-  exporter:
-    image: # it's not necessary to specify an image as the images specified in the Crunchy Postgres Operator will be pulled by default
-    requests:
-      cpu: 1m
-      memory: 64Mi
-    limits:
-      cpu: 50m
-      memory: 128Mi

--- a/helm/crunchy-postgres/values-prod.yaml
+++ b/helm/crunchy-postgres/values-prod.yaml
@@ -1,149 +1,27 @@
 fullnameOverride: crunchy-postgres
 
-crunchyImage: # it's not necessary to specify an image as the images specified in the Crunchy Postgres Operator will be pulled by default
-#crunchyImage: artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-postgres-gis:ubi8-15.2-3.3-0 # use this image for POSTGIS
 postgresVersion: 17
-#postGISVersion: '3.3' # use this version of POSTGIS. both crunchyImage and this property needs to have valid values for POSTGIS to be enabled.
-imagePullPolicy: IfNotPresent
-
-# enable to bootstrap a standby cluster from backup. Then disable to promote this standby to primary
-standby:
-  enabled: false
-  # If you want to recover from PVC, use repo1. If you want to recover from S3, use repo2
-  repoName: repo2
 
 instances:
-  name: ha # high availability
   replicas: 2
   dataVolumeClaimSpec:
     storage: 2Gi
-    storageClassName: netapp-block-standard
   requests:
     cpu: 100m
-    memory: 256Mi
-  limits:
-    cpu: 400m
-    memory: 512Mi
-  replicaCertCopy:
-    requests:
-      cpu: 1m
-      memory: 32Mi
-    limits:
-      cpu: 50m
-      memory: 64Mi
-
-# If we need to restore the cluster from a backup, we need to set the following values
-# assuming restore from repo2 (s3), adjust as needed if your S3 repo is different
-dataSource:
-  enabled: false
-  # should have the same name and contain the same keys as the pgbackrest secret
-  secretName: s3-pgbackrest
-  repo:
-    name: repo2
-    path: "/habackup"
-    s3:
-      bucket: "bucketName"
-      endpoint: "s3.ca-central-1.amazonaws.com"
-      region: "ca-central-1"
-    stanza: db
 
 pgBackRest:
-  image: # it's not necessary to specify an image as the images specified in the Crunchy Postgres Operator will be pulled by default
   retention: "15" # Ideally a larger number such as 30 backups/days
-  # If retention-full-type set to 'count' then the oldest backups will expire when the number of backups reach the number defined in retention
-  # If retention-full-type set to 'time' then the number defined in retention will take that many days worth of full backups before expiration
-  retentionFullType: count
   repos:
-    schedules:
-      full: 0 8 * * *
-      incremental: 0 0,4,12,16,20 * * *
     volume:
-      accessModes: "ReadWriteOnce"
       storage: 2Gi
-      storageClassName: netapp-file-backup
-  repoHost:
-    requests:
-      cpu: 1m
-      memory: 64Mi
-    limits:
-      cpu: 50m
-      memory: 128Mi
-  sidecars:
-    requests:
-      cpu: 1m
-      memory: 64Mi
-    limits:
-      cpu: 50m
-      memory: 128Mi
   s3:
     enabled: true
-    createS3Secret: true
-    # the s3 secret name
-    s3Secret: s3-pgbackrest
-    # the path start with /, it will be created under bucket if it doesn't exist
-    s3Path: "/habackup"
-    # s3UriStyle is host or path
-    s3UriStyle: path
-    # bucket specifies the S3 bucket to use,
     bucket: "dootprod"
-    # endpoint specifies the S3 endpoint to use.
     endpoint: "nrs.objectstore.gov.bc.ca"
-    # region specifies the S3 region to use. If your S3 storage system does not
-    # use "region", fill this in with a random value.
-    region: "ca-central-1"
-    # key is the S3 key. This is stored in a Secret.
-    # Please DO NOT push this value to GitHub
-    key: "s3keyValue"
-    # keySecret is the S3 key secret. This is stored in a Secret.
-    # Please DO NOT push this value to GitHub
-    keySecret: "s3SecretValue"
-    # setting the below to be one plus of the default schedule
-    # to avoid conflicts
-    fullSchedule: "0 9 * * *"
-    incrementalSchedule: "0 1,5,13,17,21 * * *"
-
-  # Restore from backup
-  restore:
-    enabled: false
-    # PVC=repo1 / S3=repo2
-    repoName: ~ # provide repo name
-    target: ~ # 2024-03-24 17:16:00-07 this is the target timestamp to go back to in current cluster
-
-  # Specify the repo to use for manual full backups
-  # PVC=repo1 / S3=repo2
-  manual:
-    repoName: repo1
-
-patroni:
-  postgresql:
-    pg_hba: "host all all 0.0.0.0/0 md5"
-    parameters:
-      shared_buffers: 16MB # default is 128MB; a good tuned default for shared_buffers is 25% of the memory allocated to the pod
-      wal_buffers: "64kB" # this can be set to -1 to automatically set as 1/32 of shared_buffers or 64kB, whichever is larger
-      min_wal_size: 32MB
-      max_wal_size: 64MB # default is 1GB
-      max_slot_wal_keep_size: 128MB # default is -1, allowing unlimited wal growth when replicas fall behind
 
 proxy:
   pgBouncer:
-    image: # it's not necessary to specify an image as the images specified in the Crunchy Postgres Operator will be pulled by default
     replicas: 1
-    requests:
-      cpu: 1m
-      memory: 64Mi
-    limits:
-      cpu: 50m
-      memory: 128Mi
 
-# Postgres Cluster resource values:
 pgmonitor:
-  enabled: false
   namespace: a7dd13 #The high level namespace of your project without the -tools -dev, etc part.
-  exporter:
-    image: # it's not necessary to specify an image as the images specified in the Crunchy Postgres Operator will be pulled by default
-    requests:
-      cpu: 1m
-      memory: 64Mi
-    limits:
-      cpu: 50m
-      memory: 128Mi

--- a/helm/crunchy-postgres/values-test.yaml
+++ b/helm/crunchy-postgres/values-test.yaml
@@ -1,149 +1,27 @@
 fullnameOverride: crunchy-postgres
 
-crunchyImage: # it's not necessary to specify an image as the images specified in the Crunchy Postgres Operator will be pulled by default
-#crunchyImage: artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-postgres-gis:ubi8-15.2-3.3-0 # use this image for POSTGIS
 postgresVersion: 17
-#postGISVersion: '3.3' # use this version of POSTGIS. both crunchyImage and this property needs to have valid values for POSTGIS to be enabled.
-imagePullPolicy: IfNotPresent
-
-# enable to bootstrap a standby cluster from backup. Then disable to promote this standby to primary
-standby:
-  enabled: false
-  # If you want to recover from PVC, use repo1. If you want to recover from S3, use repo2
-  repoName: repo2
 
 instances:
-  name: ha # high availability
   replicas: 2
   dataVolumeClaimSpec:
     storage: 2Gi
-    storageClassName: netapp-block-standard
   requests:
     cpu: 100m
-    memory: 256Mi
-  limits:
-    cpu: 400m
-    memory: 512Mi
-  replicaCertCopy:
-    requests:
-      cpu: 1m
-      memory: 32Mi
-    limits:
-      cpu: 50m
-      memory: 64Mi
-
-# If we need to restore the cluster from a backup, we need to set the following values
-# assuming restore from repo2 (s3), adjust as needed if your S3 repo is different
-dataSource:
-  enabled: false
-  # should have the same name and contain the same keys as the pgbackrest secret
-  secretName: s3-pgbackrest
-  repo:
-    name: repo2
-    path: "/habackup"
-    s3:
-      bucket: "bucketName"
-      endpoint: "s3.ca-central-1.amazonaws.com"
-      region: "ca-central-1"
-    stanza: db
 
 pgBackRest:
-  image: # it's not necessary to specify an image as the images specified in the Crunchy Postgres Operator will be pulled by default
   retention: "15" # Ideally a larger number such as 30 backups/days
-  # If retention-full-type set to 'count' then the oldest backups will expire when the number of backups reach the number defined in retention
-  # If retention-full-type set to 'time' then the number defined in retention will take that many days worth of full backups before expiration
-  retentionFullType: count
   repos:
-    schedules:
-      full: 0 8 * * *
-      incremental: 0 0,4,12,16,20 * * *
     volume:
-      accessModes: "ReadWriteOnce"
       storage: 2Gi
-      storageClassName: netapp-file-backup
-  repoHost:
-    requests:
-      cpu: 1m
-      memory: 64Mi
-    limits:
-      cpu: 50m
-      memory: 128Mi
-  sidecars:
-    requests:
-      cpu: 1m
-      memory: 64Mi
-    limits:
-      cpu: 50m
-      memory: 128Mi
   s3:
     enabled: true
-    createS3Secret: true
-    # the s3 secret name
-    s3Secret: s3-pgbackrest
-    # the path start with /, it will be created under bucket if it doesn't exist
-    s3Path: "/habackup"
-    # s3UriStyle is host or path
-    s3UriStyle: path
-    # bucket specifies the S3 bucket to use,
     bucket: "doottest"
-    # endpoint specifies the S3 endpoint to use.
     endpoint: "nrs.objectstore.gov.bc.ca"
-    # region specifies the S3 region to use. If your S3 storage system does not
-    # use "region", fill this in with a random value.
-    region: "ca-central-1"
-    # key is the S3 key. This is stored in a Secret.
-    # Please DO NOT push this value to GitHub
-    key: "s3keyValue"
-    # keySecret is the S3 key secret. This is stored in a Secret.
-    # Please DO NOT push this value to GitHub
-    keySecret: "s3SecretValue"
-    # setting the below to be one plus of the default schedule
-    # to avoid conflicts
-    fullSchedule: "0 9 * * *"
-    incrementalSchedule: "0 1,5,13,17,21 * * *"
-
-  # Restore from backup
-  restore:
-    enabled: false
-    # PVC=repo1 / S3=repo2
-    repoName: ~ # provide repo name
-    target: ~ # 2024-03-24 17:16:00-07 this is the target timestamp to go back to in current cluster
-
-  # Specify the repo to use for manual full backups
-  # PVC=repo1 / S3=repo2
-  manual:
-    repoName: repo1
-
-patroni:
-  postgresql:
-    pg_hba: "host all all 0.0.0.0/0 md5"
-    parameters:
-      shared_buffers: 16MB # default is 128MB; a good tuned default for shared_buffers is 25% of the memory allocated to the pod
-      wal_buffers: "64kB" # this can be set to -1 to automatically set as 1/32 of shared_buffers or 64kB, whichever is larger
-      min_wal_size: 32MB
-      max_wal_size: 64MB # default is 1GB
-      max_slot_wal_keep_size: 128MB # default is -1, allowing unlimited wal growth when replicas fall behind
 
 proxy:
   pgBouncer:
-    image: # it's not necessary to specify an image as the images specified in the Crunchy Postgres Operator will be pulled by default
     replicas: 1
-    requests:
-      cpu: 1m
-      memory: 64Mi
-    limits:
-      cpu: 50m
-      memory: 128Mi
 
-# Postgres Cluster resource values:
 pgmonitor:
-  enabled: false
   namespace: a7dd13 #The high level namespace of your project without the -tools -dev, etc part.
-  exporter:
-    image: # it's not necessary to specify an image as the images specified in the Crunchy Postgres Operator will be pulled by default
-    requests:
-      cpu: 1m
-      memory: 64Mi
-    limits:
-      cpu: 50m
-      memory: 128Mi

--- a/helm/crunchy-postgres/values-training.yaml
+++ b/helm/crunchy-postgres/values-training.yaml
@@ -1,149 +1,22 @@
 fullnameOverride: crunchy-postgres-training
 
-crunchyImage: # it's not necessary to specify an image as the images specified in the Crunchy Postgres Operator will be pulled by default
-#crunchyImage: artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-postgres-gis:ubi8-15.2-3.3-0 # use this image for POSTGIS
 postgresVersion: 17
-#postGISVersion: '3.3' # use this version of POSTGIS. both crunchyImage and this property needs to have valid values for POSTGIS to be enabled.
-imagePullPolicy: IfNotPresent
-
-# enable to bootstrap a standby cluster from backup. Then disable to promote this standby to primary
-standby:
-  enabled: false
-  # If you want to recover from PVC, use repo1. If you want to recover from S3, use repo2
-  repoName: repo2
 
 instances:
-  name: ha # high availability
-  replicas: 1
+  replicas: 2
   dataVolumeClaimSpec:
     storage: 2Gi
-    storageClassName: netapp-block-standard
   requests:
     cpu: 100m
-    memory: 256Mi
-  limits:
-    cpu: 400m
-    memory: 512Mi
-  replicaCertCopy:
-    requests:
-      cpu: 1m
-      memory: 32Mi
-    limits:
-      cpu: 50m
-      memory: 64Mi
-
-# If we need to restore the cluster from a backup, we need to set the following values
-# assuming restore from repo2 (s3), adjust as needed if your S3 repo is different
-dataSource:
-  enabled: false
-  # should have the same name and contain the same keys as the pgbackrest secret
-  secretName: s3-pgbackrest
-  repo:
-    name: repo2
-    path: "/habackup"
-    s3:
-      bucket: "bucketName"
-      endpoint: "s3.ca-central-1.amazonaws.com"
-      region: "ca-central-1"
-    stanza: db
 
 pgBackRest:
-  image: # it's not necessary to specify an image as the images specified in the Crunchy Postgres Operator will be pulled by default
-  retention: "2" # Ideally a larger number such as 30 backups/days
-  # If retention-full-type set to 'count' then the oldest backups will expire when the number of backups reach the number defined in retention
-  # If retention-full-type set to 'time' then the number defined in retention will take that many days worth of full backups before expiration
-  retentionFullType: count
   repos:
-    schedules:
-      full: 0 8 * * *
-      incremental: 0 0,4,12,16,20 * * *
     volume:
-      accessModes: "ReadWriteOnce"
       storage: 1Gi
-      storageClassName: netapp-file-backup
-  repoHost:
-    requests:
-      cpu: 1m
-      memory: 64Mi
-    limits:
-      cpu: 50m
-      memory: 128Mi
-  sidecars:
-    requests:
-      cpu: 1m
-      memory: 64Mi
-    limits:
-      cpu: 50m
-      memory: 128Mi
-  s3:
-    enabled: false
-    createS3Secret: true
-    # the s3 secret name
-    s3Secret: s3-pgbackrest
-    # the path start with /, it will be created under bucket if it doesn't exist
-    s3Path: "/habackup"
-    # s3UriStyle is host or path
-    s3UriStyle: path
-    # bucket specifies the S3 bucket to use,
-    bucket: "bucketName"
-    # endpoint specifies the S3 endpoint to use.
-    endpoint: "endpointName"
-    # region specifies the S3 region to use. If your S3 storage system does not
-    # use "region", fill this in with a random value.
-    region: "ca-central-1"
-    # key is the S3 key. This is stored in a Secret.
-    # Please DO NOT push this value to GitHub
-    key: "s3keyValue"
-    # keySecret is the S3 key secret. This is stored in a Secret.
-    # Please DO NOT push this value to GitHub
-    keySecret: "s3SecretValue"
-    # setting the below to be one plus of the default schedule
-    # to avoid conflicts
-    fullSchedule: "0 9 * * *"
-    incrementalSchedule: "0 1,5,13,17,21 * * *"
-
-  # Restore from backup
-  restore:
-    enabled: false
-    # PVC=repo1 / S3=repo2
-    repoName: ~ # provide repo name
-    target: ~ # 2024-03-24 17:16:00-07 this is the target timestamp to go back to in current cluster
-
-  # Specify the repo to use for manual full backups
-  # PVC=repo1 / S3=repo2
-  manual:
-    repoName: repo1
-
-patroni:
-  postgresql:
-    pg_hba: "host all all 0.0.0.0/0 md5"
-    parameters:
-      shared_buffers: 16MB # default is 128MB; a good tuned default for shared_buffers is 25% of the memory allocated to the pod
-      wal_buffers: "64kB" # this can be set to -1 to automatically set as 1/32 of shared_buffers or 64kB, whichever is larger
-      min_wal_size: 32MB
-      max_wal_size: 64MB # default is 1GB
-      max_slot_wal_keep_size: 128MB # default is -1, allowing unlimited wal growth when replicas fall behind
 
 proxy:
   pgBouncer:
-    image: # it's not necessary to specify an image as the images specified in the Crunchy Postgres Operator will be pulled by default
     replicas: 1
-    requests:
-      cpu: 1m
-      memory: 64Mi
-    limits:
-      cpu: 50m
-      memory: 128Mi
 
-# Postgres Cluster resource values:
 pgmonitor:
-  enabled: false
   namespace: a7dd13 #The high level namespace of your project without the -tools -dev, etc part.
-  exporter:
-    image: # it's not necessary to specify an image as the images specified in the Crunchy Postgres Operator will be pulled by default
-    requests:
-      cpu: 1m
-      memory: 64Mi
-    limits:
-      cpu: 50m
-      memory: 128Mi

--- a/helm/crunchy-postgres/values.yaml
+++ b/helm/crunchy-postgres/values.yaml
@@ -1,0 +1,122 @@
+fullnameOverride: crunchy-postgres
+
+crunchyImage: # it's not necessary to specify an image as the images specified in the Crunchy Postgres Operator will be pulled by default
+#crunchyImage: artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-postgres-gis:ubi8-15.2-3.3-0 # use this image for POSTGIS
+postgresVersion: 15
+#postGISVersion: '3.3' # use this version of POSTGIS.
+imagePullPolicy: IfNotPresent
+#openshift, so it stops putting invalid security context constraints on the pods
+openshift: true
+
+# enable to bootstrap a standby cluster from backup. Then disable to promote this standby to primary
+standby:
+  enabled: false
+  # If you want to recover from PVC, use repo1. If you want to recover from S3, use repo2
+  repoName: repo2
+
+instances:
+  name: ha # high availability
+  replicas: 2
+  dataVolumeClaimSpec:
+    storage: 480Mi
+    storageClassName: netapp-block-standard
+  requests:
+    cpu: 1m
+    memory: 256Mi
+  replicaCertCopy:
+    requests:
+      cpu: 1m
+      memory: 32Mi
+
+# If we need to restore the cluster from a backup, we need to set the following values
+# assuming restore from repo2 (s3), adjust as needed if your S3 repo is different
+dataSource:
+  enabled: false
+  # should have the same name and contain the same keys as the pgbackrest secret
+  secretName: s3-pgbackrest
+  repo:
+    name: repo2
+    path: "/habackup"
+    s3:
+      bucket: "bucketName"
+      endpoint: "s3.ca-central-1.amazonaws.com"
+      region: "ca-central-1"
+    stanza: db
+
+pgBackRest:
+  image: # it's not necessary to specify an image as the images specified in the Crunchy Postgres Operator will be pulled by default
+  retention: "2" # Ideally a larger number such as 30 backups/days
+  # If retention-full-type set to 'count' then the oldest backups will expire when the number of backups reach the number defined in retention
+  # If retention-full-type set to 'time' then the number defined in retention will take that many days worth of full backups before expiration
+  retentionFullType: count
+  repo1:
+    enabled: true
+  repos:
+    schedules:
+      full: 0 8 * * *
+      incremental: 0 0,4,12,16,20 * * *
+    volume:
+      accessModes: "ReadWriteOnce"
+      storage: 64Mi
+      storageClassName: netapp-file-backup
+  repoHost:
+    requests:
+      cpu: 1m
+      memory: 64Mi
+  sidecars:
+    requests:
+      cpu: 1m
+      memory: 64Mi
+  s3:
+    enabled: false
+    createS3Secret: true
+    # the s3 secret name
+    s3Secret: s3-pgbackrest
+    # the path start with /, it will be created under bucket if it doesn't exist
+    s3Path: "/habackup"
+    # s3UriStyle is host or path
+    s3UriStyle: path
+    # bucket specifies the S3 bucket to use,
+    bucket: "bucketName"
+    # endpoint specifies the S3 endpoint to use.
+    endpoint: "endpointName"
+    # region specifies the S3 region to use. If your S3 storage system does not
+    # use "region", fill this in with a random value.
+    region: "ca-central-1"
+    # key is the S3 key. This is stored in a Secret.
+    # Please DO NOT push this value to GitHub
+    key: "s3keyValue"
+    # keySecret is the S3 key secret. This is stored in a Secret.
+    # Please DO NOT push this value to GitHub
+    keySecret: "s3SecretValue"
+    # setting the below to be one plus of the default schedule
+    # to avoid conflicts
+    fullSchedule: "0 9 * * *"
+    incrementalSchedule: "0 1,5,13,17,21 * * *"
+
+patroni:
+  postgresql:
+    pg_hba: "host all all 0.0.0.0/0 md5"
+    parameters:
+      shared_buffers: 16MB # default is 128MB; a good tuned default for shared_buffers is 25% of the memory allocated to the pod
+      wal_buffers: "64kB" # this can be set to -1 to automatically set as 1/32 of shared_buffers or 64kB, whichever is larger
+      min_wal_size: 32MB
+      max_wal_size: 64MB # default is 1GB
+      max_slot_wal_keep_size: 128MB # default is -1, allowing unlimited wal growth when replicas fall behind
+
+proxy:
+  pgBouncer:
+    image: # it's not necessary to specify an image as the images specified in the Crunchy Postgres Operator will be pulled by default
+    replicas: 2
+    requests:
+      cpu: 1m
+      memory: 64Mi
+
+# Postgres Cluster resource values:
+pgmonitor:
+  enabled: false
+  exporter:
+    image: # it's not necessary to specify an image as the images specified in the Crunchy Postgres Operator will be pulled by default
+    requests:
+      cpu: 1m
+      memory: 64Mi


### PR DESCRIPTION
### Jira Ticket

CMS-1540

### Description
This change is part of the groundwork for a change in the `bcgov/bcparks.ca` repo. The `crunchy-postgres` Helm configuration from DOOT is going to be be used as a template for migrating Strapi from Patroni to CrunchyDB

This PR includes the following changes

1. Updates the environment-specific configuration files so they only include settings that are different than the default settings in `values.yaml`. This matches how Helm is being used elsewhere in the project.
2. Fixes omissions in the `README.md`
3. Refreshes upstream files from https://github.com/bcgov/crunchy-postgres with newer versions and omitted files


