### PR TITLE
CMS-1645: Update Advisory form label styles

### DIFF
--- a/frontend/src/components/advisories/composite/advisoryAreaPicker/AdvisoryAreaPicker.jsx
+++ b/frontend/src/components/advisories/composite/advisoryAreaPicker/AdvisoryAreaPicker.jsx
@@ -346,7 +346,7 @@ export default function AdvisoryAreaPicker({
             <Form.Label>
               Fire centre(s)
               <br />
-              <span className="bc-parks-only">BC Parks Only</span>
+              <span className="bc-parks-only">BC Parks only</span>
             </Form.Label>
             <Select
               id="fire-centres"
@@ -371,7 +371,7 @@ export default function AdvisoryAreaPicker({
             <Form.Label>
               Fire zone(s)
               <br />
-              <span className="bc-parks-only">BC Parks Only</span>
+              <span className="bc-parks-only">BC Parks only</span>
             </Form.Label>
             <Select
               id="fire-zones"
@@ -399,7 +399,7 @@ export default function AdvisoryAreaPicker({
             <Form.Label>
               Natural resource district(s)
               <br />
-              <span className="bc-parks-only">BC Parks Only</span>
+              <span className="bc-parks-only">BC Parks only</span>
             </Form.Label>
             <Select
               id="natural-resource-districts"

--- a/frontend/src/components/advisories/composite/advisoryForm/AdvisoryForm.scss
+++ b/frontend/src/components/advisories/composite/advisoryForm/AdvisoryForm.scss
@@ -246,7 +246,7 @@
 .helpIcon {
   width: 1.25rem;
   height: 1.25rem;
-  margin-left: 4px;
+  margin-left: 0.5em;
 }
 
 @media (max-width: 767.98px) {


### PR DESCRIPTION
### Jira Ticket

CMS-1645

### Description
<!-- What did you change, and why? -->

Small tweaks from QA for the Advisory edit form:
- Increase spacing between the label and the tooltip help text icon (from 4px to 8px at the current font size)
- Fix capitalization on "BC Parks only" notes