### PR TITLE
CMS-1711: Add relational filters

### DIFF
--- a/frontend/src/components/advisories/shared/filterStatus/FilterStatus.jsx
+++ b/frontend/src/components/advisories/shared/filterStatus/FilterStatus.jsx
@@ -91,10 +91,10 @@ export default function FilterStatus({
         {hasAnyFilters && (
           <button
             type="button"
-            className="btn btn-sm btn-outline-secondary"
+            className="btn btn-link"
             onClick={onClearAll}
           >
-            Clear All Filters
+            Clear filters
           </button>
         )}
       </div>

--- a/frontend/src/lib/advisories/utils/AdvisoryDashboardQuery.js
+++ b/frontend/src/lib/advisories/utils/AdvisoryDashboardQuery.js
@@ -97,14 +97,9 @@ export function buildFilter(
 
   if (selectedDistrictIds.length > 0) {
     filters.push({
-      $or: [
-        { recreationDistricts: { documentId: { $in: selectedDistrictIds } } },
-        {
-          recreationResources: {
-            recreationDistrict: { documentId: { $in: selectedDistrictIds } },
-          },
-        },
-      ],
+      recreationResources: {
+        recreationDistrict: { documentId: { $in: selectedDistrictIds } },
+      },
     });
   }
 

--- a/frontend/src/lib/advisories/utils/AdvisoryDashboardQuery.js
+++ b/frontend/src/lib/advisories/utils/AdvisoryDashboardQuery.js
@@ -82,15 +82,29 @@ export function buildFilter(
 
   if (selectedRegionIds.length > 0) {
     filters.push({
-      regions: { documentId: { $in: selectedRegionIds } },
+      $or: [
+        { regions: { documentId: { $in: selectedRegionIds } } },
+        {
+          protectedAreas: {
+            managementAreas: {
+              region: { documentId: { $in: selectedRegionIds } },
+            },
+          },
+        },
+      ],
     });
   }
 
   if (selectedDistrictIds.length > 0) {
     filters.push({
-      recreationResources: {
-        recreationDistrict: { documentId: { $in: selectedDistrictIds } },
-      },
+      $or: [
+        { recreationDistricts: { documentId: { $in: selectedDistrictIds } } },
+        {
+          recreationResources: {
+            recreationDistrict: { documentId: { $in: selectedDistrictIds } },
+          },
+        },
+      ],
     });
   }
 


### PR DESCRIPTION
### Jira Ticket

CMS-1711

### Description
<!-- What did you change, and why? -->
- Region filter now matches advisories with selected `regions` or with `protectedAreas -> managementAreas -> region`
- District filter now matches advisories with selected `recreationDistricts` or with `recreationResources -> recreationDistrict`
- Updated the Clear filters button styling
