### PR TITLE
CMS-1631: Determine new season status based on date annuals

### DIFF
--- a/backend/tasks/create-seasons/create-seasons.js
+++ b/backend/tasks/create-seasons/create-seasons.js
@@ -16,10 +16,10 @@ import {
   ParkArea,
   Season,
 } from "../../models/index.js";
-import * as STATUS from "../../constants/seasonStatus.js";
 import * as SEASON_TYPE from "../../constants/seasonType.js";
 import { populateAnnualDateRangesForYear } from "../populate-date-ranges/populate-annual-date-ranges.js";
 import { populateBlankDateRangesForYear } from "../populate-date-ranges/populate-blank-date-ranges.js";
+import resolveNewSeasonStatus from "../../utils/resolveNewSeasonStatus.js";
 import {
   createPublishableId,
   createDateableId,
@@ -82,11 +82,18 @@ export default async function createSeasons(operatingYear, transaction = null) {
 
     if (season) return season.id;
 
+    // Determine the status of the new season based on annual dates
+    const status = await resolveNewSeasonStatus(
+      publishableId,
+      SEASON_TYPE.REGULAR,
+      transaction,
+    );
+
     const newSeason = await Season.create(
       {
         publishableId,
         operatingYear: year,
-        status: STATUS.REQUESTED,
+        status,
         readyToPublish: true,
         seasonType: SEASON_TYPE.REGULAR,
       },

--- a/backend/tasks/create-winter-seasons/create-winter-seasons.js
+++ b/backend/tasks/create-winter-seasons/create-winter-seasons.js
@@ -4,8 +4,8 @@
 import "../../env.js";
 
 import { DateRange, DateType, Park, Season } from "../../models/index.js";
-import * as STATUS from "../../constants/seasonStatus.js";
 import * as SEASON_TYPE from "../../constants/seasonType.js";
+import resolveNewSeasonStatus from "../../utils/resolveNewSeasonStatus.js";
 import {
   createPublishableId,
   createDateableId,
@@ -79,12 +79,19 @@ export default async function createWinterSeasons(
       return existingSeason.id;
     }
 
+    // Determine the status of the new season based on annual dates
+    const status = await resolveNewSeasonStatus(
+      publishableId,
+      SEASON_TYPE.WINTER,
+      transaction,
+    );
+
     const newSeason = await Season.create(
       {
         publishableId,
         operatingYear: year,
         seasonType: SEASON_TYPE.WINTER,
-        status: STATUS.REQUESTED,
+        status,
         readyToPublish: true,
       },
       { transaction },

--- a/backend/tasks/populate-date-ranges/populate-annual-date-ranges.js
+++ b/backend/tasks/populate-date-ranges/populate-annual-date-ranges.js
@@ -10,9 +10,9 @@ import {
   DateType,
 } from "../../models/index.js";
 import { findDateableIdByPublishableId } from "../../utils/findDateableIdByPublishableId.js";
-import * as STATUS from "../../constants/seasonStatus.js";
 import * as SEASON_TYPE from "../../constants/seasonType.js";
 import * as DATE_TYPE from "../../constants/dateType.js";
+import resolveNewSeasonStatus from "../../utils/resolveNewSeasonStatus.js";
 
 // Functions
 
@@ -85,11 +85,18 @@ export async function populateAnnualDateRangesForYear(
       // create season if no target season found
       // @TODO: Update criteria to create seasons in create-seasons/create-winter-seasons instead
       if (!targetSeason) {
+        // Determine the status of the new season based on annual dates
+        const status = await resolveNewSeasonStatus(
+          annual.publishableId,
+          prevSeason.seasonType,
+          transaction,
+        );
+
         targetSeason = await Season.create(
           {
             publishableId: annual.publishableId,
             operatingYear: targetYear,
-            status: STATUS.PENDING_REVIEW,
+            status,
             readyToPublish: true,
             seasonType: prevSeason.seasonType,
           },

--- a/backend/utils/dateTypesHelpers.js
+++ b/backend/utils/dateTypesHelpers.js
@@ -63,7 +63,7 @@ export function getDateTypesForPark(
 }
 
 /**
- * Returns the DateTypes applicable to a Feature in a specific order.
+ * Returns the DateTypes applicable to a Feature in the order they should appear in the app.
  * For Features, it includes Operation, Reservation, and Backcountry registration dates if applicable.
  * @param {Object} feature Feature object
  * @param {Object} dateTypesByDateTypeId Object mapping date type strapiDateTypeId to objects

--- a/backend/utils/resolveNewSeasonStatus.js
+++ b/backend/utils/resolveNewSeasonStatus.js
@@ -1,0 +1,207 @@
+import {
+  DateRangeAnnual,
+  Feature,
+  Park,
+  ParkArea,
+  Publishable,
+} from "../models/index.js";
+import {
+  getAllDateTypes,
+  getDateTypesForFeature,
+  getDateTypesForPark,
+} from "./dateTypesHelpers.js";
+import * as STATUS from "../constants/seasonStatus.js";
+import * as DATE_TYPE from "../constants/dateType.js";
+
+// Cache the results of getAllDateTypes
+let cachedDateTypeMapsPromise = null;
+
+/**
+ * Fetches all date types and constructs lookup maps for Park- and Feature-level date types,
+ * keyed by strapiDateTypeId. Caches the results to prevent extra DB queries.
+ * @param {Transaction|null} [transaction=null] Sequelize transaction
+ * @returns {Promise<{parkDateTypesByDateTypeId: Object, featureDateTypesByDateTypeId: Object}>} An object containing two maps of date types keyed by strapiDateTypeId
+ */
+async function getCachedDateTypeMaps(transaction = null) {
+  if (!cachedDateTypeMapsPromise) {
+    // Build lookup maps and populate the cache promise
+    cachedDateTypeMapsPromise = getAllDateTypes({}, transaction).then(
+      (allDateTypes) => ({
+        // Object map of all Park-level date types by strapiDateTypeId
+        parkDateTypesByDateTypeId: Object.fromEntries(
+          allDateTypes
+            .filter((dateType) => dateType.parkLevel)
+            .map((dateType) => [dateType.strapiDateTypeId, dateType]),
+        ),
+
+        // Object map of all Feature-level date types by strapiDateTypeId
+        featureDateTypesByDateTypeId: Object.fromEntries(
+          allDateTypes
+            .filter((dateType) => dateType.featureLevel)
+            .map((dateType) => [dateType.strapiDateTypeId, dateType]),
+        ),
+      }),
+    );
+  }
+
+  return cachedDateTypeMapsPromise;
+}
+
+/**
+ * Returns the status for a new season based on its dates.
+ * Returns `PENDING_REVIEW` when every DateRange for this Season is an annual date. Otherwise returns `REQUESTED`.
+ * @param {number} publishableId The ID of the publishable associated with the season
+ * @param {string} seasonType The type of the season from constants/seasonType
+ * @param {Object} [transaction=null] Optional Sequelize transaction object for database operations
+ * @returns {Promise<string>} The status for the new season from constants/seasonStatus
+ */
+export default async function resolveNewSeasonStatus(
+  publishableId,
+  seasonType,
+  transaction = null,
+) {
+  // Get the publishable entity by its ID so we can get all associated dateable IDs
+  const publishable = await Publishable.findOne({
+    where: { id: publishableId },
+    include: [
+      {
+        model: Park,
+        as: "park",
+        attributes: [
+          "id",
+          "dateableId",
+          "hasTier1Dates",
+          "hasTier2Dates",
+          "hasWinterFeeDates",
+        ],
+        required: false,
+      },
+      {
+        model: ParkArea,
+        as: "parkArea",
+        attributes: ["id", "dateableId"],
+        required: false,
+      },
+      {
+        model: Feature,
+        as: "feature",
+        attributes: [
+          "id",
+          "dateableId",
+          "hasReservations",
+          "hasBackcountryPermits",
+        ],
+        required: false,
+      },
+    ],
+    transaction,
+  });
+
+  // If the publishable ID exists in the DB, one of park/parkArea/feature should be non-null
+  if (!publishable) {
+    throw new Error(`Publishable with ID ${publishableId} not found.`);
+  }
+
+  // Get cached date type lookup maps, keyed by strapiDateTypeId
+  const { parkDateTypesByDateTypeId, featureDateTypesByDateTypeId } =
+    await getCachedDateTypeMaps(transaction);
+
+  // Build set of expected dateableId + dateTypeId combinations for this Publishable
+  const expectedPairs = new Set();
+  const { park, parkArea, feature } = publishable;
+
+  if (park) {
+    // Get applicable date types for this Park and season type
+    const dateTypes = getDateTypesForPark(
+      park,
+      parkDateTypesByDateTypeId,
+      seasonType,
+    );
+
+    // Tier 1 / Tier 2 dates can never be annual, and always need to be reviewed
+    if (
+      // Return REQUESTED if the Park has Tier dates
+      dateTypes.some(
+        (dateType) =>
+          dateType.strapiDateTypeId === DATE_TYPE.TIER_1 ||
+          dateType.strapiDateTypeId === DATE_TYPE.TIER_2,
+      )
+    ) {
+      return STATUS.REQUESTED;
+    }
+
+    // Add every Dateable + DateType combination to the set
+    for (const dateType of dateTypes) {
+      expectedPairs.add(`${park.dateableId}:${dateType.id}`);
+    }
+  } else if (feature) {
+    // Get applicable date types for this Feature
+    const dateTypes = getDateTypesForFeature(
+      feature,
+      featureDateTypesByDateTypeId,
+    );
+
+    // Add every Dateable + DateType combination to the set
+    for (const dateType of dateTypes) {
+      expectedPairs.add(`${feature.dateableId}:${dateType.id}`);
+    }
+  } else if (parkArea) {
+    // Get all Features for this ParkArea that have dates
+    const features = await Feature.findAll({
+      where: { parkAreaId: parkArea.id, active: true, hasDates: true },
+      attributes: ["dateableId", "hasReservations", "hasBackcountryPermits"],
+      transaction,
+    });
+
+    for (const featureRow of features) {
+      // Get applicable date types for this Feature
+      const dateTypes = getDateTypesForFeature(
+        featureRow,
+        featureDateTypesByDateTypeId,
+      );
+
+      // Add every Dateable + DateType combination to the set
+      for (const dateType of dateTypes) {
+        expectedPairs.add(`${featureRow.dateableId}:${dateType.id}`);
+      }
+    }
+  } else {
+    throw new Error(`No entity found with publishableId ${publishableId}`);
+  }
+
+  // If no Dateables are found for this Publishable, return REQUESTED
+  if (expectedPairs.size === 0) {
+    return STATUS.REQUESTED;
+  }
+
+  // Fetch all DateRangeAnnual records for this publishable
+  const annuals = await DateRangeAnnual.findAll({
+    where: {
+      publishableId,
+    },
+    attributes: ["dateableId", "dateTypeId", "isDateRangeAnnual"],
+    transaction,
+  });
+
+  // Build a map of the DateRangeAnnual records keyed by dateableId + dateTypeId
+  // to look up when we check against the expected ID pairs
+  const annualByPair = new Map(
+    annuals.map((annual) => [
+      `${annual.dateableId}:${annual.dateTypeId}`,
+      annual,
+    ]),
+  );
+
+  // Check if every expected dateableId + dateTypeId combination has a corresponding DateRangeAnnual record with isDateRangeAnnual = true
+  const hasCompleteAnnualCoverage = [...expectedPairs].every((pairKey) => {
+    const annual = annualByPair.get(pairKey);
+
+    return annual && annual.isDateRangeAnnual === true;
+  });
+
+  // If all dates are annual, return PENDING_REVIEW
+  if (hasCompleteAnnualCoverage) return STATUS.PENDING_REVIEW;
+
+  // Otherwise, return REQUESTED
+  return STATUS.REQUESTED;
+}


### PR DESCRIPTION
### Jira Ticket

CMS-1631

### Description
<!-- What did you change, and why? -->

Added a function to determine the status of new seasons when we create them. If all dates in the season are "Same every year," then it will automatically give the season "Submitted" status (`PENDING_REVIEW`) since no editing is needed.
All other seasons get the "Requested" status as usual.

I updated all three scripts that create dates to use this function to determine the status of new seasons.