### PR TITLE
CMS-1341: Rename human-assigned Strapi fields

### DIFF
--- a/backend/constants/dateType.js
+++ b/backend/constants/dateType.js
@@ -1,6 +1,6 @@
 // Database values for date types
 // Stored as the `dateTypeId` field in Strapi,
-// and `strapiDateTypeId` in the DOOT DateTypes table.
+// and `dateTypeNumber` in the DOOT DateTypes table.
 
 export const BACKCOUNTRY_REGISTRATION = 8;
 export const FIRST_COME_FIRST_SERVED = 9;

--- a/backend/constants/featureType.js
+++ b/backend/constants/featureType.js
@@ -1,6 +1,6 @@
 // Database values for feature types
 // Stored as the `featureTypeId` field in Strapi,
-// and `strapiFeatureTypeId` in the DOOT FeatureTypes table.
+// and `featureTypeNumber` in the DOOT FeatureTypes table.
 
 export const ANCHORAGE = 1;
 export const BACKCOUNTRY = 2;

--- a/backend/migrations/20260513170816-rename-strapi-fields.js
+++ b/backend/migrations/20260513170816-rename-strapi-fields.js
@@ -1,0 +1,49 @@
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    // Rename Strapi human-assigned number fields
+    await queryInterface.renameColumn(
+      "DateTypes",
+      "strapiDateTypeId",
+      "dateTypeNumber",
+    );
+    await queryInterface.renameColumn(
+      "FeatureTypes",
+      "strapiFeatureTypeId",
+      "featureTypeNumber",
+    );
+    await queryInterface.renameColumn(
+      "Features",
+      "strapiOrcsFeatureNumber",
+      "orcsFeatureNumber",
+    );
+    await queryInterface.renameColumn(
+      "ParkAreas",
+      "strapiOrcsAreaNumber",
+      "orcsAreaNumber",
+    );
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.renameColumn(
+      "DateTypes",
+      "dateTypeNumber",
+      "strapiDateTypeId",
+    );
+    await queryInterface.renameColumn(
+      "FeatureTypes",
+      "featureTypeNumber",
+      "strapiFeatureTypeId",
+    );
+    await queryInterface.renameColumn(
+      "Features",
+      "orcsFeatureNumber",
+      "strapiOrcsFeatureNumber",
+    );
+    await queryInterface.renameColumn(
+      "ParkAreas",
+      "orcsAreaNumber",
+      "strapiOrcsAreaNumber",
+    );
+  },
+};

--- a/backend/models/datetype.js
+++ b/backend/models/datetype.js
@@ -37,7 +37,7 @@ export default (sequelize) => {
 
       // Stable ID for lookups and publishing
       // Links to the dateTypeId field in Strapi
-      strapiDateTypeId: {
+      dateTypeNumber: {
         type: DataTypes.INTEGER,
         allowNull: true,
       },

--- a/backend/models/feature.js
+++ b/backend/models/feature.js
@@ -77,7 +77,7 @@ export default (sequelize) => {
         defaultValue: false,
       },
 
-      strapiOrcsFeatureNumber: {
+      orcsFeatureNumber: {
         type: DataTypes.STRING,
         allowNull: true,
         defaultValue: null,

--- a/backend/models/featuretype.js
+++ b/backend/models/featuretype.js
@@ -17,7 +17,7 @@ export default (sequelize) => {
   FeatureType.init(
     {
       name: DataTypes.STRING,
-      strapiFeatureTypeId: DataTypes.INTEGER,
+      featureTypeNumber: DataTypes.INTEGER,
       icon: DataTypes.STRING,
       rank: DataTypes.INTEGER,
     },

--- a/backend/models/parkarea.js
+++ b/backend/models/parkarea.js
@@ -60,7 +60,7 @@ export default (sequelize) => {
         defaultValue: false,
       },
 
-      strapiOrcsAreaNumber: {
+      orcsAreaNumber: {
         type: DataTypes.STRING,
         allowNull: true,
         defaultValue: null,

--- a/backend/routes/api/export.js
+++ b/backend/routes/api/export.js
@@ -263,7 +263,7 @@ function getFeatureForDateRange(dateRange) {
  */
 function getGateDisplayValues(dateRange, gateDetail, annualData) {
   const isGateType =
-    dateRange.dateType.strapiDateTypeId === DATE_TYPE.PARK_GATE_OPEN;
+    dateRange.dateType.dateTypeNumber === DATE_TYPE.PARK_GATE_OPEN;
   const hasGate = gateDetail?.hasGate === true;
 
   let gateStartTime = "";
@@ -461,7 +461,7 @@ router.get(
         {
           model: DateType,
           as: "dateType",
-          attributes: ["id", "strapiDateTypeId", "name"],
+          attributes: ["id", "dateTypeNumber", "name"],
           required: true,
         },
       ],
@@ -540,7 +540,7 @@ router.get(
         // Skip non-winter fee dates for winter seasons
         if (
           season.seasonType === SEASON_TYPE.WINTER &&
-          dateRange.dateType.strapiDateTypeId !== DATE_TYPE.WINTER_FEE
+          dateRange.dateType.dateTypeNumber !== DATE_TYPE.WINTER_FEE
         ) {
           return null;
         }

--- a/backend/routes/api/filter-options.js
+++ b/backend/routes/api/filter-options.js
@@ -16,33 +16,39 @@ router.get(
   "/",
   asyncHandler(async (req, res) => {
     // Run all queries concurrently
-    const [sections, managementAreas, dateTypes, featureTypes, accessGroups, parkAreaTypes] =
-      await Promise.all([
-        Section.findAll({
-          attributes: ["id", "sectionNumber", "name"],
-          order: [["name", "ASC"]],
-        }),
-        ManagementArea.findAll({
-          attributes: ["id", "managementAreaNumber", "name"],
-          order: [["name", "ASC"]],
-        }),
-        DateType.findAll({
-          attributes: ["id", "strapiDateTypeId", "name"],
-          order: [["strapiDateTypeId", "ASC"]],
-        }),
-        FeatureType.findAll({
-          attributes: ["id", "strapiFeatureTypeId", "rank", "name"],
-          order: [["name", "ASC"]],
-        }),
-        AccessGroup.findAll({
-          attributes: ["id", "name"],
-          order: [["name", "ASC"]],
-        }),
-        ParkAreaType.findAll({
-          attributes: ["id", "parkAreaTypeNumber", "rank", "name"],
-          order: [["name", "ASC"]],
-        }),
-      ]);
+    const [
+      sections,
+      managementAreas,
+      dateTypes,
+      featureTypes,
+      accessGroups,
+      parkAreaTypes,
+    ] = await Promise.all([
+      Section.findAll({
+        attributes: ["id", "sectionNumber", "name"],
+        order: [["name", "ASC"]],
+      }),
+      ManagementArea.findAll({
+        attributes: ["id", "managementAreaNumber", "name"],
+        order: [["name", "ASC"]],
+      }),
+      DateType.findAll({
+        attributes: ["id", "dateTypeNumber", "name"],
+        order: [["dateTypeNumber", "ASC"]],
+      }),
+      FeatureType.findAll({
+        attributes: ["id", "featureTypeNumber", "rank", "name"],
+        order: [["name", "ASC"]],
+      }),
+      AccessGroup.findAll({
+        attributes: ["id", "name"],
+        order: [["name", "ASC"]],
+      }),
+      ParkAreaType.findAll({
+        attributes: ["id", "parkAreaTypeNumber", "rank", "name"],
+        order: [["name", "ASC"]],
+      }),
+    ]);
 
     const groupedDateTypes = [
       {
@@ -53,7 +59,7 @@ router.get(
             DATE_TYPE.TIER_1,
             DATE_TYPE.TIER_2,
             DATE_TYPE.WINTER_FEE,
-          ].includes(dt.strapiDateTypeId),
+          ].includes(dt.dateTypeNumber),
         ),
       },
       {
@@ -63,7 +69,7 @@ router.get(
             DATE_TYPE.OPERATION,
             DATE_TYPE.RESERVATION,
             DATE_TYPE.BACKCOUNTRY_REGISTRATION,
-          ].includes(dt.strapiDateTypeId),
+          ].includes(dt.dateTypeNumber),
         ),
       },
     ];

--- a/backend/routes/api/parks.js
+++ b/backend/routes/api/parks.js
@@ -55,7 +55,7 @@ function seasonModel(minYear, required = true) {
           {
             model: DateType,
             as: "dateType",
-            attributes: ["id", "strapiDateTypeId", "name"],
+            attributes: ["id", "dateTypeNumber", "name"],
           },
         ],
       },
@@ -84,7 +84,7 @@ function featureModel(minYear, where = {}) {
         model: FeatureType,
         as: "featureType",
         required: true,
-        attributes: ["id", "strapiFeatureTypeId", "name"],
+        attributes: ["id", "featureTypeNumber", "name"],
       },
       // Publishable Seasons for the Feature
       seasonModel(minYear, false),
@@ -102,7 +102,7 @@ function groupDateRangesByTypeAndYear(dateRanges, hasGate = null) {
   if (hasGate === false) {
     validRanges = validRanges.filter(
       (dateRange) =>
-        dateRange.dateType.strapiDateTypeId !== DATE_TYPE.PARK_GATE_OPEN,
+        dateRange.dateType.dateTypeNumber !== DATE_TYPE.PARK_GATE_OPEN,
     );
   }
 
@@ -127,7 +127,7 @@ function buildDateRangeObject(dateRange, operatingYear, readyToPublish) {
     dateType: dateRange.dateType
       ? {
           id: dateRange.dateType.id,
-          strapiDateTypeId: dateRange.dateType.strapiDateTypeId,
+          dateTypeNumber: dateRange.dateType.dateTypeNumber,
           name: dateRange.dateType.name,
         }
       : null,
@@ -226,7 +226,7 @@ function buildFeatureOutput(feature, seasons, includeCurrentSeason = true) {
     featureType: {
       id: feature.featureType.id,
       name: feature.featureType.name,
-      strapiFeatureTypeId: feature.featureType.strapiFeatureTypeId,
+      featureTypeNumber: feature.featureType.featureTypeNumber,
     },
     seasons: filteredSeasons,
     groupedDateRanges: groupDateRangesByTypeAndYear(featureDateRanges),
@@ -411,12 +411,12 @@ router.get(
       // For regular seasons, exclude Winter fee dates
       const parkDateRanges = getAllDateRanges(regularSeasons).filter(
         (dateRange) =>
-          dateRange.dateType?.strapiDateTypeId !== DATE_TYPE.WINTER_FEE,
+          dateRange.dateType?.dateTypeNumber !== DATE_TYPE.WINTER_FEE,
       );
       // For winter seasons, only include Winter fee dates
       const parkWinterDateRanges = getAllDateRanges(winterSeasons).filter(
         (dateRange) =>
-          dateRange.dateType?.strapiDateTypeId === DATE_TYPE.WINTER_FEE,
+          dateRange.dateType?.dateTypeNumber === DATE_TYPE.WINTER_FEE,
       );
       // get hasGate for park
       const parkHasGate = gateDetailMap.get(park.publishableId) ?? null;

--- a/backend/routes/api/publish.js
+++ b/backend/routes/api/publish.js
@@ -33,7 +33,7 @@ const FEATURE_ATTRIBUTES = [
   "id",
   "publishableId",
   "dateableId",
-  "strapiOrcsFeatureNumber",
+  "orcsFeatureNumber",
 ];
 
 // ensures non-feature rows appear before features
@@ -41,11 +41,11 @@ const NON_FEATURE_SORT_INDEX = -1;
 
 /**
  * Returns the sort index for the given feature type ID.
- * @param {number} strapiFeatureTypeId the strapi feature type ID
+ * @param {number} featureTypeNumber the human-assigned identifier from Strapi for the feature type
  * @returns {number} the sort index
  */
-function getSortIndex(strapiFeatureTypeId) {
-  const index = FEATURE_TYPE.SORT_ORDER.indexOf(strapiFeatureTypeId);
+function getSortIndex(featureTypeNumber) {
+  const index = FEATURE_TYPE.SORT_ORDER.indexOf(featureTypeNumber);
 
   return index === -1 ? Number.MAX_SAFE_INTEGER : index;
 }
@@ -74,7 +74,7 @@ function flattenSeasons(seasons) {
           ...baseRow,
           featureName: season.publishable.name,
           sortIndex: getSortIndex(
-            season.publishable.featureType.strapiFeatureTypeId,
+            season.publishable.featureType.featureTypeNumber,
           ),
         },
       ];
@@ -88,7 +88,7 @@ function flattenSeasons(seasons) {
       return season.publishable.features.map((feature) => ({
         ...baseRow,
         featureName: feature.name,
-        sortIndex: getSortIndex(feature.featureType.strapiFeatureTypeId),
+        sortIndex: getSortIndex(feature.featureType.featureTypeNumber),
       }));
     }
 
@@ -207,7 +207,7 @@ router.get(
               {
                 model: FeatureType,
                 as: "featureType",
-                attributes: ["strapiFeatureTypeId"],
+                attributes: ["featureTypeNumber"],
               },
             ],
           },
@@ -222,7 +222,7 @@ router.get(
           {
             model: FeatureType,
             as: "featureType",
-            attributes: ["strapiFeatureTypeId"],
+            attributes: ["featureTypeNumber"],
           },
         ],
       }),
@@ -363,11 +363,11 @@ async function formatDateRanges(entity, season) {
       {
         model: DateType,
         as: "dateType",
-        attributes: ["id", "strapiDateTypeId"],
+        attributes: ["id", "dateTypeNumber"],
 
         where: {
           // @TEMP: Filter out FCFS dates while they're being hidden in the UI
-          strapiDateTypeId: {
+          dateTypeNumber: {
             [Op.ne]: DATE_TYPE.FIRST_COME_FIRST_SERVED,
           },
         },
@@ -426,7 +426,7 @@ async function formatDateRanges(entity, season) {
       isDateAnnual,
       startDate: formatDate(dateRange.startDate),
       endDate: formatDate(dateRange.endDate),
-      dateTypeId: dateRange.dateType.strapiDateTypeId,
+      dateTypeId: dateRange.dateType.dateTypeNumber,
     };
   });
 }
@@ -487,14 +487,14 @@ async function formatParkData(park, season) {
 async function formatFeatureData(feature, season, includeGateInfo = false) {
   // Return null to skip publishing if the ORCS Feature Number is missing
   // We can't connect to anything in Strapi without this key
-  if (!feature.strapiOrcsFeatureNumber) return null;
+  if (!feature.orcsFeatureNumber) return null;
 
   try {
     const dateRanges = await formatDateRanges(feature, season);
 
     // Return formatted Feature data
     const featureData = {
-      orcsFeatureNumber: feature.strapiOrcsFeatureNumber,
+      orcsFeatureNumber: feature.orcsFeatureNumber,
       operatingYear: season.operatingYear,
       dateRanges,
     };
@@ -520,13 +520,13 @@ async function formatFeatureData(feature, season, includeGateInfo = false) {
 async function formatParkAreaData(parkArea, season) {
   // Return null to skip publishing if the ORCS Area Number is missing
   // We can't connect to anything in Strapi without this key
-  if (!parkArea.strapiOrcsAreaNumber) return null;
+  if (!parkArea.orcsAreaNumber) return null;
 
   const gateInfo = formatGateInfo(parkArea.gateDetails);
 
   // Format ParkArea data
   const formattedParkArea = {
-    orcsAreaNumber: parkArea.strapiOrcsAreaNumber,
+    orcsAreaNumber: parkArea.orcsAreaNumber,
     operatingYear: season.operatingYear,
     gateInfo,
   };
@@ -591,7 +591,7 @@ router.post(
           model: ParkArea,
           as: "parkArea",
 
-          attributes: ["id", "publishableId", "strapiOrcsAreaNumber"],
+          attributes: ["id", "publishableId", "orcsAreaNumber"],
 
           include: [
             {

--- a/backend/routes/api/seasons.js
+++ b/backend/routes/api/seasons.js
@@ -116,7 +116,7 @@ async function getPreviousSeasonDates(currentSeason, dateTypeWhere = {}) {
               model: DateType,
               as: "dateType",
               required: false,
-              attributes: ["id", "strapiDateTypeId", "name"],
+              attributes: ["id", "dateTypeNumber", "name"],
 
               // Filter DateTypes by level
               where: dateTypeWhere,
@@ -150,7 +150,7 @@ async function getDateRangeAnnuals(publishableId) {
       {
         model: DateType,
         as: "dateType",
-        attributes: ["id", "strapiDateTypeId", "name"],
+        attributes: ["id", "dateTypeNumber", "name"],
       },
     ],
   });
@@ -222,7 +222,7 @@ function dateRangesQueryPart(seasonId) {
       {
         model: DateType,
         as: "dateType",
-        attributes: ["id", "strapiDateTypeId", "name"],
+        attributes: ["id", "dateTypeNumber", "name"],
       },
     ],
   };
@@ -249,7 +249,7 @@ function featureTypeQueryPart() {
   return {
     model: FeatureType,
     as: "featureType",
-    attributes: ["id", "name", "icon", "strapiFeatureTypeId"],
+    attributes: ["id", "name", "icon", "featureTypeNumber"],
   };
 }
 
@@ -326,7 +326,7 @@ async function getFrontcountryFeatureReservationDates(park, operatingYear) {
         as: "dateType",
         attributes: ["id"],
         where: {
-          strapiDateTypeId: DATE_TYPE.RESERVATION,
+          dateTypeNumber: DATE_TYPE.RESERVATION,
         },
         required: true,
       },
@@ -349,7 +349,7 @@ async function getFrontcountryFeatureReservationDates(park, operatingYear) {
                 as: "featureType",
                 attributes: ["id"],
                 where: {
-                  strapiFeatureTypeId: FEATURE_TYPE.FRONTCOUNTRY_CAMPGROUND,
+                  featureTypeNumber: FEATURE_TYPE.FRONTCOUNTRY_CAMPGROUND,
                 },
                 required: true,
               },
@@ -387,7 +387,7 @@ async function getParkDates(park, operatingYear) {
           {
             model: DateType,
             as: "dateType",
-            attributes: ["id", "strapiDateTypeId", "name"],
+            attributes: ["id", "dateTypeNumber", "name"],
           },
         ],
       },
@@ -401,10 +401,10 @@ async function getParkDates(park, operatingYear) {
     ),
   );
 
-  // Group by strapiDateTypeId
+  // Group by dateTypeNumber
   const datesByStrapiId = _.groupBy(
     allRanges,
-    (range) => range.dateType?.strapiDateTypeId,
+    (range) => range.dateType?.dateTypeNumber,
   );
 
   // Use constants for Tier 1, Tier 2, and Winter fee
@@ -515,7 +515,7 @@ async function saveSeasonData({
   const winterFeeDateType = await DateType.findOne({
     attributes: ["id"],
     where: {
-      strapiDateTypeId: DATE_TYPE.WINTER_FEE,
+      dateTypeNumber: DATE_TYPE.WINTER_FEE,
     },
     transaction,
   });
@@ -721,7 +721,7 @@ router.get(
       featureLevel: true,
     });
 
-    const dateTypesByDateTypeId = _.keyBy(dateTypesArray, "strapiDateTypeId");
+    const dateTypesByDateTypeId = _.keyBy(dateTypesArray, "dateTypeNumber");
 
     const { feature } = seasonModel;
 
@@ -831,7 +831,7 @@ router.get(
 
     const featureDateTypesByDateTypeId = _.keyBy(
       featureDateTypesArray,
-      "strapiDateTypeId",
+      "dateTypeNumber",
     );
 
     // Add some Park-level dates to the payload
@@ -1012,7 +1012,7 @@ router.get(
       parkLevel: true,
     });
 
-    const dateTypesByDateTypeId = _.keyBy(dateTypesArray, "strapiDateTypeId");
+    const dateTypesByDateTypeId = _.keyBy(dateTypesArray, "dateTypeNumber");
 
     // Return the DateTypes in a specific order
     const orderedDateTypes = getDateTypesForPark(

--- a/backend/strapi-sync/import-date-types/README.md
+++ b/backend/strapi-sync/import-date-types/README.md
@@ -1,22 +1,22 @@
 # import-date-types.js
 
-Imports and updates `DateType` records from Strapi's `park-date-type` collection by matching the `dateTypeId` with the `strapiDateTypeId` on existing date types in the DOOT database.
+Imports and updates `DateType` records from Strapi's `park-date-type` collection by matching the `dateTypeId` with the `dateTypeNumber` on existing date types in the DOOT database.
 
 **The script:**
 
 - Fetches park date type data from Strapi using sync utilities
-- Matches existing DOOT date types by comparing Strapi `dateTypeId` with DOOT `strapiDateTypeId`
+- Matches existing DOOT date types by comparing Strapi `dateTypeId` with DOOT `dateTypeNumber`
 - Creates or updates date type records the data mapped in the table below
 
 **Data mapping:**
 
-| Strapi Field   | DOOT Field         | Notes                        |
-| -------------- | ------------------ | ---------------------------- |
-| `dateType`     | `name`             | Date type name               |
-| `dateTypeId`   | `strapiDateTypeId` | Well known key               |
-| `description`  | `description`      | Date type description        |
-| `featureLevel` | `featureLevel`     | Defaults to false if not set |
-| `parkLevel`    | `parkLevel`        | Defaults to false if not set |
+| Strapi Field   | DOOT Field       | Notes                        |
+| -------------- | ---------------- | ---------------------------- |
+| `dateType`     | `name`           | Date type name               |
+| `dateTypeId`   | `dateTypeNumber` | Well known key               |
+| `description`  | `description`    | Date type description        |
+| `featureLevel` | `featureLevel`   | Defaults to false if not set |
+| `parkLevel`    | `parkLevel`      | Defaults to false if not set |
 
 ## Transaction Safety
 
@@ -34,6 +34,6 @@ node strapi-sync/import-date-types/import-date-types.js
 The script logs progress and provides summary counts of created, updated, and skipped records. Date types without valid `dateTypeId` values are skipped with warnings. The script shows:
 
 - Number of park date types found in Strapi
-- Existing `strapiDateTypeId` values in DOOT for debugging
+- Existing `dateTypeNumber` values in DOOT for debugging
 - Per-record lookup results and processing status
 - Final summary with counts of created, updated, skipped and unchanged records

--- a/backend/strapi-sync/import-date-types/import-date-types.js
+++ b/backend/strapi-sync/import-date-types/import-date-types.js
@@ -21,14 +21,14 @@ export default async function importStrapiDateTypes(transaction = null) {
       return { created: 0, updated: 0, skipped: 0, unchanged: 0 };
     }
 
-    // Get all DOOT DateTypes for strapiDateTypeId lookup
+    // Get all DOOT DateTypes for dateTypeNumber lookup
     const dootDateTypes = await DateType.findAll({
-      where: { strapiDateTypeId: { [Op.ne]: null } },
+      where: { dateTypeNumber: { [Op.ne]: null } },
       transaction,
     });
     const dateTypeLookup = new Map(
       dootDateTypes.map((dateType) => [
-        dateType.strapiDateTypeId, // Key: e.g. "10"
+        dateType.dateTypeNumber, // Key: e.g. "10"
         dateType, // Value: DateType record
       ]),
     );
@@ -54,7 +54,7 @@ export default async function importStrapiDateTypes(transaction = null) {
 
       const dateTypeToSave = {
         name: dateType,
-        strapiDateTypeId: dateTypeId,
+        dateTypeNumber: dateTypeId,
         description: strapiDateType.description,
         featureLevel: strapiDateType.featureLevel || false,
         parkLevel: strapiDateType.parkLevel || false,
@@ -74,14 +74,14 @@ export default async function importStrapiDateTypes(transaction = null) {
         // Update matched date type
         await matchedDateType.update(dateTypeToSave, { transaction });
         console.log(
-          `Updated date type: ${dateType} (strapiDateTypeId: ${dateTypeId})`,
+          `Updated date type: ${dateType} (dateTypeNumber: ${dateTypeId})`,
         );
         updatedCount++;
       } else {
         // Create new date type
         await DateType.create(dateTypeToSave, { transaction });
         console.log(
-          `Created date type: ${dateType} (strapiDateTypeId: ${dateTypeId})`,
+          `Created date type: ${dateType} (dateTypeNumber: ${dateTypeId})`,
         );
         createdCount++;
       }

--- a/backend/strapi-sync/import-feature-types/README.md
+++ b/backend/strapi-sync/import-feature-types/README.md
@@ -1,22 +1,22 @@
 # import-feature-types.js
 
-Imports and updates `FeatureType` records from Strapi's `park-feature-type` collection by matching the `featureTypeId` with the `strapiFeatureTypeId` on existing feature types in the DOOT database.
+Imports and updates `FeatureType` records from Strapi's `park-feature-type` collection by matching the `featureTypeId` with the `featureTypeNumber` on existing feature types in the DOOT database.
 
 **The script:**
 
 - Fetches park feature type data from Strapi using sync utilities
-- Matches existing DOOT feature types by comparing Strapi `featureTypeId` with DOOT `strapiFeatureTypeId`
-- Creates or updates feature type records with name and strapiFeatureTypeId
+- Matches existing DOOT feature types by comparing Strapi `featureTypeId` with DOOT `featureTypeNumber`
+- Creates or updates feature type records with name and featureTypeNumber
 - Uses efficient Map-based lookup for fast matching between systems
 
 **Data mapping:**
 
-| Strapi Field      | DOOT Field            | Notes                                                        |
-| ----------------- | --------------------- | ------------------------------------------------------------ |
-| `parkFeatureType` | `name`                | Feature type name                                            |
-| `featureTypeId`   | `strapiFeatureTypeId` | Used for matching existing records                           |
-| (none)            | `icon`                | Default to `information` (?) on insert / no change on update |
-| `rank`            | `rank`                | Used for display sorting                                     |
+| Strapi Field      | DOOT Field          | Notes                                                        |
+| ----------------- | ------------------- | ------------------------------------------------------------ |
+| `parkFeatureType` | `name`              | Feature type name                                            |
+| `featureTypeId`   | `featureTypeNumber` | Used for matching existing records                           |
+| (none)            | `icon`              | Default to `information` (?) on insert / no change on update |
+| `rank`            | `rank`              | Used for display sorting                                     |
 
 ## Transaction Safety
 
@@ -34,6 +34,6 @@ node strapi-sync/import-feature-types/import-feature-types.js
 The script logs progress and provides summary counts of created, updated, and skipped records. Feature types without valid `featureTypeId` values are skipped with warnings. The script shows:
 
 - Number of park feature types found in Strapi
-- Existing `strapiFeatureTypeId` values in DOOT for debugging
+- Existing `featureTypeNumber` values in DOOT for debugging
 - Per-record lookup results and processing status
 - Final summary with counts of created, updated, skipped and unchanged records

--- a/backend/strapi-sync/import-feature-types/import-feature-types.js
+++ b/backend/strapi-sync/import-feature-types/import-feature-types.js
@@ -21,14 +21,14 @@ export default async function importStrapiFeatureTypes(transaction = null) {
       return { created: 0, updated: 0, skipped: 0, unchanged: 0 };
     }
 
-    // Get all DOOT FeatureTypes for strapiFeatureTypeId lookup
+    // Get all DOOT FeatureTypes for featureTypeNumber lookup
     const dootFeatureTypes = await FeatureType.findAll({
-      where: { strapiFeatureTypeId: { [Op.ne]: null } },
+      where: { featureTypeNumber: { [Op.ne]: null } },
       transaction,
     });
     const featureTypeLookup = new Map(
       dootFeatureTypes.map((featureType) => [
-        featureType.strapiFeatureTypeId, // Key: e.g. "10"
+        featureType.featureTypeNumber, // Key: e.g. "10"
         featureType, // Value: FeatureType record
       ]),
     );
@@ -58,7 +58,7 @@ export default async function importStrapiFeatureTypes(transaction = null) {
 
       const featureTypeToSave = {
         name: parkFeatureType,
-        strapiFeatureTypeId: featureTypeId,
+        featureTypeNumber: featureTypeId,
         rank: rank || 1000000,
       };
 
@@ -76,7 +76,7 @@ export default async function importStrapiFeatureTypes(transaction = null) {
         // Update matched feature type
         await matchedFeatureType.update(featureTypeToSave, { transaction });
         console.log(
-          `Updated feature type: ${parkFeatureType} (strapiFeatureTypeId: ${featureTypeId})`,
+          `Updated feature type: ${parkFeatureType} (featureTypeNumber: ${featureTypeId})`,
         );
         updatedCount++;
       } else {
@@ -86,7 +86,7 @@ export default async function importStrapiFeatureTypes(transaction = null) {
         // Create new feature type
         await FeatureType.create(featureTypeToSave, { transaction });
         console.log(
-          `Created feature type: ${parkFeatureType} (strapiFeatureTypeId: ${featureTypeId})`,
+          `Created feature type: ${parkFeatureType} (featureTypeNumber: ${featureTypeId})`,
         );
         createdCount++;
       }

--- a/backend/strapi-sync/import-features/README.md
+++ b/backend/strapi-sync/import-features/README.md
@@ -5,27 +5,27 @@ Imports and updates `Feature` records from Strapi's `park-feature` collection by
 **The script:**
 
 - Fetches park feature data from Strapi using sync utilities
-- Matches existing DOOT features by comparing Strapi `orcsFeatureNumber` with DOOT `strapiOrcsFeatureNumber`
+- Matches existing DOOT features by comparing Strapi `orcsFeatureNumber` with DOOT `orcsFeatureNumber`
 - Sets the `parkId` field in DOOT Feature by matching Strapi `protectedArea.orcs` to DOOT `park.orcs`
 - Sets the `featureTypeId` relation by matching Strapi `parkFeature.featureTypeId` to DOOT `featureType.strapiId`.
-- Sets the `parkAreaId` relation by matching Strapi `parkArea.orcsAreaNumber` to DOOT `parkArea.strapiOrcsAreaNumber`.
+- Sets the `parkAreaId` relation by matching Strapi `parkArea.orcsAreaNumber` to DOOT `parkArea.orcsAreaNumber`.
 - Creates or updates feature records with name, active status, reservation system flags, and park relation
 - Uses efficient Map-based lookup for fast matching between systems
 
 **Data mapping:**
 
-| Strapi Field                    | DOOT Field                | Notes                                        |
-| ------------------------------- | ------------------------- | -------------------------------------------- |
-| `parkFeatureName`               | `name`                    | Feature name                                 |
-| `orcsFeatureNumber`             | `strapiOrcsFeatureNumber` | Used for matching existing records           |
-| `isActive`                      | `active`                  | Defaults to `true` if not provided           |
-| `inReservationSystem`           | `inReservationSystem`     | Defaults to `false` if not provided          |
-| `hasReservations`               | `hasReservations`         | Defaults to `false` if not provided          |
-| `hasBackcountryPermits`         | `hasBackcountryPermits`   | Defaults to `false` if not provided          |
-| `hasDates`                      | `hasDates`                | Defaults to `false` if not provided          |
-| `parkFeatureType.featureTypeId` | `featureTypeId`           | DOOT Feature Type, matched by well-known key |
-| `protectedArea.orcs`            | `parkId`                  | DOOT Park, matched by well-known key         |
-| `parkArea.orcsAreaNumber`       | `parkAreaId`              | DOOT Park Area, matched by well-known key    |
+| Strapi Field                    | DOOT Field              | Notes                                        |
+| ------------------------------- | ----------------------- | -------------------------------------------- |
+| `parkFeatureName`               | `name`                  | Feature name                                 |
+| `orcsFeatureNumber`             | `orcsFeatureNumber`     | Used for matching existing records           |
+| `isActive`                      | `active`                | Defaults to `true` if not provided           |
+| `inReservationSystem`           | `inReservationSystem`   | Defaults to `false` if not provided          |
+| `hasReservations`               | `hasReservations`       | Defaults to `false` if not provided          |
+| `hasBackcountryPermits`         | `hasBackcountryPermits` | Defaults to `false` if not provided          |
+| `hasDates`                      | `hasDates`              | Defaults to `false` if not provided          |
+| `parkFeatureType.featureTypeId` | `featureTypeId`         | DOOT Feature Type, matched by well-known key |
+| `protectedArea.orcs`            | `parkId`                | DOOT Park, matched by well-known key         |
+| `parkArea.orcsAreaNumber`       | `parkAreaId`            | DOOT Park Area, matched by well-known key    |
 
 ## Transaction Safety
 
@@ -43,7 +43,7 @@ node strapi-sync/import-features/import-features.js
 The script logs progress and provides summary counts of created, updated, and skipped records. Features without valid `orcsFeatureNumber` values or without a matching DOOT Park for `parkId` are skipped with warnings. The script shows:
 
 - Number of park features found in Strapi
-- Existing `strapiOrcsFeatureNumber` values in DOOT for debugging
+- Existing `orcsFeatureNumber` values in DOOT for debugging
 - Existing DOOT Park ORCS values for parkId matching
 - Per-record lookup results and processing status
 - Final summary with counts of created, updated, skipped, deactivated and unchanged records

--- a/backend/strapi-sync/import-features/import-features.js
+++ b/backend/strapi-sync/import-features/import-features.js
@@ -41,14 +41,14 @@ export default async function importStrapiFeatures(transaction = null) {
       );
     }
 
-    // Get all DOOT Features for strapiOrcsFeatureNumber lookup
+    // Get all DOOT Features for orcsFeatureNumber lookup
     const dootFeatures = await Feature.findAll({
-      where: { strapiOrcsFeatureNumber: { [Op.ne]: null } },
+      where: { orcsFeatureNumber: { [Op.ne]: null } },
       transaction,
     });
     const featureLookup = new Map(
       dootFeatures.map((feature) => [
-        feature.strapiOrcsFeatureNumber, // Key: e.g. "1234-1"
+        feature.orcsFeatureNumber, // Key: e.g. "1234-1"
         feature, // Value: Feature record
       ]),
     );
@@ -69,24 +69,24 @@ export default async function importStrapiFeatures(transaction = null) {
 
     // Get all DOOT Park areas for orcsAreaNumber lookup
     const dootParkAreas = await ParkArea.findAll({
-      where: { strapiOrcsAreaNumber: { [Op.ne]: null } },
+      where: { orcsAreaNumber: { [Op.ne]: null } },
       transaction,
     });
     const parkAreaLookup = new Map(
       dootParkAreas.map((parkArea) => [
-        parkArea.strapiOrcsAreaNumber, // Key: e.g. "1234-1"
+        parkArea.orcsAreaNumber, // Key: e.g. "1234-1"
         parkArea, // Value: ParkArea record
       ]),
     );
 
-    // Get all DOOT FeatureTypes for strapiFeatureTypeId lookup
+    // Get all DOOT FeatureTypes for featureTypeNumber lookup
     const dootFeatureTypes = await FeatureType.findAll({
-      where: { strapiFeatureTypeId: { [Op.ne]: null } },
+      where: { featureTypeNumber: { [Op.ne]: null } },
       transaction,
     });
     const featureTypeLookup = new Map(
       dootFeatureTypes.map((featureType) => [
-        featureType.strapiFeatureTypeId, // Key: e.g. "10"
+        featureType.featureTypeNumber, // Key: e.g. "10"
         featureType, // Value: FeatureType record
       ]),
     );
@@ -142,11 +142,11 @@ export default async function importStrapiFeatures(transaction = null) {
 
       // Get the featureTypeId from the related parkFeatureType
       let featureTypeId = null;
-      const strapiFeatureTypeId = parkFeatureType?.featureTypeId;
+      const featureTypeNumber = parkFeatureType?.featureTypeId;
 
-      if (strapiFeatureTypeId) {
+      if (featureTypeNumber) {
         const matchedFeatureType =
-          featureTypeLookup.get(strapiFeatureTypeId) ?? null;
+          featureTypeLookup.get(featureTypeNumber) ?? null;
 
         featureTypeId = matchedFeatureType?.id ?? null;
       }
@@ -159,12 +159,12 @@ export default async function importStrapiFeatures(transaction = null) {
         continue;
       }
 
-      // Find matched ParkFeature by strapiOrcsFeatureNumber
+      // Find matched ParkFeature by orcsFeatureNumber
       const matchedDootFeature = featureLookup.get(orcsFeatureNumber);
 
       const dootFeatureToSave = {
         name: parkFeatureName,
-        strapiOrcsFeatureNumber: orcsFeatureNumber,
+        orcsFeatureNumber: orcsFeatureNumber,
         active: isActive ?? false,
         inReservationSystem: inReservationSystem ?? false,
         hasReservations: hasReservations ?? false,
@@ -211,7 +211,7 @@ export default async function importStrapiFeatures(transaction = null) {
           // Update matched feature
           await matchedDootFeature.update(dootFeatureToSave, { transaction });
           console.log(
-            `Updated Feature: ${parkFeatureName} (strapiOrcsFeatureNumber: ${orcsFeatureNumber})`,
+            `Updated Feature: ${parkFeatureName} (orcsFeatureNumber: ${orcsFeatureNumber})`,
           );
         } else {
           unchangedCount++;
@@ -220,7 +220,7 @@ export default async function importStrapiFeatures(transaction = null) {
         // Create new feature
         await Feature.create(dootFeatureToSave, { transaction });
         console.log(
-          `Created Feature: ${parkFeatureName} (strapiOrcsFeatureNumber: ${orcsFeatureNumber})`,
+          `Created Feature: ${parkFeatureName} (orcsFeatureNumber: ${orcsFeatureNumber})`,
         );
         createdCount++;
       } else {
@@ -232,28 +232,26 @@ export default async function importStrapiFeatures(transaction = null) {
     }
 
     // Create a Set of Strapi orcsFeatureNumbers for efficient lookup
-    const strapiOrcsFeatureNumbers = new Set(
+    const orcsFeatureNumbers = new Set(
       strapiParkFeatures.map((pf) => pf.orcsFeatureNumber),
     );
 
     // loop through DOOT ParkFeatures to find any that are missing from Strapi data
     for (const dootParkFeature of dootFeatures) {
-      if (
-        !strapiOrcsFeatureNumbers.has(dootParkFeature.strapiOrcsFeatureNumber)
-      ) {
+      if (!orcsFeatureNumbers.has(dootParkFeature.orcsFeatureNumber)) {
         if (!useSafeMode) {
           // Deactivate the DOOT ParkFeature
           if (dootParkFeature.active) {
             dootParkFeature.active = false;
             await dootParkFeature.save({ transaction });
             console.log(
-              `Deactivated Feature: ${dootParkFeature.name} (strapiOrcsFeatureNumber: ${dootParkFeature.strapiOrcsFeatureNumber}) due to removal from Strapi.`,
+              `Deactivated Feature: ${dootParkFeature.name} (orcsFeatureNumber: ${dootParkFeature.orcsFeatureNumber}) due to removal from Strapi.`,
             );
             deactivatedCount++;
           }
         } else {
           console.warn(
-            `Skipped deactivating Feature due to safe mode: ${dootParkFeature.name} (strapiOrcsFeatureNumber: ${dootParkFeature.strapiOrcsFeatureNumber})`,
+            `Skipped deactivating Feature due to safe mode: ${dootParkFeature.name} (orcsFeatureNumber: ${dootParkFeature.orcsFeatureNumber})`,
           );
           skippedCount++;
         }

--- a/backend/strapi-sync/import-features/validation.js
+++ b/backend/strapi-sync/import-features/validation.js
@@ -2,20 +2,20 @@ import { Op } from "sequelize";
 import { Feature } from "../../models/index.js";
 
 /**
- * Validates DOOT Features for invalid strapiOrcsFeatureNumber values
+ * Validates DOOT Features for invalid orcsFeatureNumber values
  * @param {Transaction} [transaction] Optional Sequelize transaction
  * @returns {Promise<boolean>} Returns true if validation passes, false if validation fails
  */
 export async function validateDootFeatures(transaction = null) {
   let isValid = true;
 
-  // Validate DOOT Features to make sure all records have a strapiOrcsFeatureNumber in the
+  // Validate DOOT Features to make sure all records have a orcsFeatureNumber in the
   // format #-# (e.g. "1234-1")
   const invalidFeatures = await Feature.findAll({
     where: {
       [Op.or]: [
-        { strapiOrcsFeatureNumber: null },
-        { strapiOrcsFeatureNumber: { [Op.notRegexp]: "^[0-9]+-[0-9]+$" } },
+        { orcsFeatureNumber: null },
+        { orcsFeatureNumber: { [Op.notRegexp]: "^[0-9]+-[0-9]+$" } },
       ],
     },
     transaction,
@@ -24,11 +24,11 @@ export async function validateDootFeatures(transaction = null) {
   if (invalidFeatures.length > 0) {
     for (const feature of invalidFeatures) {
       console.warn(
-        `Invalid DOOT Feature: ${feature.name} (${feature.id}) - strapiOrcsFeatureNumber: "${feature.strapiOrcsFeatureNumber}"`,
+        `Invalid DOOT Feature: ${feature.name} (${feature.id}) - orcsFeatureNumber: "${feature.orcsFeatureNumber}"`,
       );
     }
     console.error(
-      `Found ${invalidFeatures.length} DOOT Features with missing or incorrectly formatted strapiOrcsFeatureNumber.`,
+      `Found ${invalidFeatures.length} DOOT Features with missing or incorrectly formatted orcsFeatureNumber.`,
     );
     isValid = false;
   }

--- a/backend/strapi-sync/import-park-areas/README.md
+++ b/backend/strapi-sync/import-park-areas/README.md
@@ -5,21 +5,21 @@ Imports and updates `ParkArea` records from Strapi's `park-area` collection by m
 **The script:**
 
 - Fetches park area data from Strapi using sync utilities
-- Matches existing DOOT park areas by comparing Strapi `orcsAreaNumber` with DOOT `strapiOrcsAreaNumber`
+- Matches existing DOOT park areas by comparing Strapi `orcsAreaNumber` with DOOT `orcsAreaNumber`
 - Sets the `parkId` field in DOOT ParkArea by matching Strapi `protectedArea.orcs` to DOOT `park.orcs`
 - Creates or updates park area records with name, active status, reservation system flags, and park relation
 - Uses efficient Map-based lookup for fast matching between systems
 
 **Data mapping:**
 
-| Strapi Field              | DOOT Field             | Notes                                          |
-| ------------------------- | ---------------------- | ---------------------------------------------- |
-| `parkAreaName`            | `name`                 | Park area name                                 |
-| `isActive`                | `active`               | Defaults to `false` if not provided            |
-| `inReservationSystem`     | `inReservationSystem`  | Defaults to `false` if not provided            |
-| `orcsAreaNumber`          | `strapiOrcsAreaNumber` | Used for matching existing records             |
-| `protectedArea.orcs`      | `parkId`               | DOOT Park ID, matched by ORCS value            |
-| `parkAreaType.areaTypeId` | `parkAreaTypeId`       | DOOT Park Area Type, matched by well-known key |
+| Strapi Field              | DOOT Field            | Notes                                          |
+| ------------------------- | --------------------- | ---------------------------------------------- |
+| `parkAreaName`            | `name`                | Park area name                                 |
+| `isActive`                | `active`              | Defaults to `false` if not provided            |
+| `inReservationSystem`     | `inReservationSystem` | Defaults to `false` if not provided            |
+| `orcsAreaNumber`          | `orcsAreaNumber`      | Used for matching existing records             |
+| `protectedArea.orcs`      | `parkId`              | DOOT Park ID, matched by ORCS value            |
+| `parkAreaType.areaTypeId` | `parkAreaTypeId`      | DOOT Park Area Type, matched by well-known key |
 
 ## Transaction Safety
 
@@ -37,7 +37,7 @@ node strapi-sync/import-park-areas/import-park-areas.js
 The script logs progress and provides summary counts of created, updated, and skipped records. Park areas without valid `orcsAreaNumber` values or without a matching DOOT Park for `parkId` are skipped with warnings. The script shows:
 
 - Number of park areas found in Strapi
-- Existing `strapiOrcsAreaNumber` values in DOOT for debugging
+- Existing `orcsAreaNumber` values in DOOT for debugging
 - Existing DOOT Park ORCS values for parkId matching
 - Per-record lookup results and processing status
 - Final summary with counts of created, updated, skipped, deactivated and unchanged records

--- a/backend/strapi-sync/import-park-areas/import-park-areas.js
+++ b/backend/strapi-sync/import-park-areas/import-park-areas.js
@@ -44,14 +44,14 @@ export default async function importStrapiParkAreas(transaction = null) {
       );
     }
 
-    // Get all DOOT ParkAreas for strapiOrcsAreaNumber lookup
+    // Get all DOOT ParkAreas for orcsAreaNumber lookup
     const dootParkAreas = await ParkArea.findAll({
-      where: { strapiOrcsAreaNumber: { [Op.ne]: null } },
+      where: { orcsAreaNumber: { [Op.ne]: null } },
       transaction,
     });
     const parkAreaLookup = new Map(
       dootParkAreas.map((parkArea) => [
-        parkArea.strapiOrcsAreaNumber, // Key: e.g. "1234-1"
+        parkArea.orcsAreaNumber, // Key: e.g. "1234-1"
         parkArea, // Value: ParkArea record
       ]),
     );
@@ -144,12 +144,12 @@ export default async function importStrapiParkAreas(transaction = null) {
         continue;
       }
 
-      // Find matched ParkArea by strapiOrcsAreaNumber
+      // Find matched ParkArea by orcsAreaNumber
       const matchedDootParkArea = parkAreaLookup.get(orcsAreaNumber);
 
       const dootParkAreaToSave = {
         name: parkAreaName,
-        strapiOrcsAreaNumber: orcsAreaNumber,
+        orcsAreaNumber: orcsAreaNumber,
         active: isActive ?? false,
         inReservationSystem: inReservationSystem ?? false,
         parkId,
@@ -192,7 +192,7 @@ export default async function importStrapiParkAreas(transaction = null) {
           // Update matched park area
           await matchedDootParkArea.update(dootParkAreaToSave, { transaction });
           console.log(
-            `Updated ParkArea: ${parkAreaName} (strapiOrcsAreaNumber: ${orcsAreaNumber})`,
+            `Updated ParkArea: ${parkAreaName} (orcsAreaNumber: ${orcsAreaNumber})`,
           );
         } else {
           unchangedCount++;
@@ -201,7 +201,7 @@ export default async function importStrapiParkAreas(transaction = null) {
         // Create new park area
         await ParkArea.create(dootParkAreaToSave, { transaction });
         console.log(
-          `Created ParkArea: ${parkAreaName} (strapiOrcsAreaNumber: ${orcsAreaNumber})`,
+          `Created ParkArea: ${parkAreaName} (orcsAreaNumber: ${orcsAreaNumber})`,
         );
         createdCount++;
       } else {
@@ -213,26 +213,26 @@ export default async function importStrapiParkAreas(transaction = null) {
     }
 
     // Create a Set of Strapi orcsAreaNumbers for efficient lookup
-    const strapiOrcsAreaNumbers = new Set(
+    const orcsAreaNumbers = new Set(
       strapiParkAreas.map((pa) => pa.orcsAreaNumber),
     );
 
     // loop through DOOT ParkAreas to find any that are missing from Strapi data
     for (const dootParkArea of dootParkAreas) {
-      if (!strapiOrcsAreaNumbers.has(dootParkArea.strapiOrcsAreaNumber)) {
+      if (!orcsAreaNumbers.has(dootParkArea.orcsAreaNumber)) {
         if (!useSafeMode) {
           // Deactivate the DOOT ParkArea
           if (dootParkArea.active) {
             dootParkArea.active = false;
             await dootParkArea.save({ transaction });
             console.log(
-              `Deactivated ParkArea: ${dootParkArea.name} (strapiOrcsAreaNumber: ${dootParkArea.strapiOrcsAreaNumber}) due to removal from Strapi.`,
+              `Deactivated ParkArea: ${dootParkArea.name} (orcsAreaNumber: ${dootParkArea.orcsAreaNumber}) due to removal from Strapi.`,
             );
             deactivatedCount++;
           }
         } else {
           console.warn(
-            `Skipped deactivating ParkArea due to safe mode: ${dootParkArea.name} (strapiOrcsAreaNumber: ${dootParkArea.strapiOrcsAreaNumber})`,
+            `Skipped deactivating ParkArea due to safe mode: ${dootParkArea.name} (orcsAreaNumber: ${dootParkArea.orcsAreaNumber})`,
           );
           skippedCount++;
         }

--- a/backend/strapi-sync/import-park-areas/validation.js
+++ b/backend/strapi-sync/import-park-areas/validation.js
@@ -2,19 +2,19 @@ import { Op } from "sequelize";
 import { ParkArea } from "../../models/index.js";
 
 /**
- * Validates DOOT Park Areas for invalid strapiOrcsAreaNumber values
+ * Validates DOOT Park Areas for invalid orcsAreaNumber values
  * @param {Transaction} [transaction] Optional Sequelize transaction
  * @returns {Promise<boolean>} Returns true if validation passes, false if validation fails
  */
 export async function validateDootParkAreas(transaction = null) {
   let isValid = true;
 
-  // Make sure all records DOOT have a strapiOrcsAreaNumber in the format #-# (e.g. "1234-1")
+  // Make sure all records DOOT have a orcsAreaNumber in the format #-# (e.g. "1234-1")
   const invalidParkAreas = await ParkArea.findAll({
     where: {
       [Op.or]: [
-        { strapiOrcsAreaNumber: null },
-        { strapiOrcsAreaNumber: { [Op.notRegexp]: "^[0-9]+-[0-9]+$" } },
+        { orcsAreaNumber: null },
+        { orcsAreaNumber: { [Op.notRegexp]: "^[0-9]+-[0-9]+$" } },
       ],
     },
     transaction,
@@ -23,11 +23,11 @@ export async function validateDootParkAreas(transaction = null) {
   if (invalidParkAreas.length > 0) {
     for (const parkArea of invalidParkAreas) {
       console.warn(
-        `Invalid DOOT ParkArea: ${parkArea.name} (${parkArea.id}) - strapiOrcsAreaNumber: "${parkArea.strapiOrcsAreaNumber}"`,
+        `Invalid DOOT ParkArea: ${parkArea.name} (${parkArea.id}) - orcsAreaNumber: "${parkArea.orcsAreaNumber}"`,
       );
     }
     console.error(
-      `Found ${invalidParkAreas.length} DOOT ParkAreas with missing or incorrectly formatted strapiOrcsAreaNumber.`,
+      `Found ${invalidParkAreas.length} DOOT ParkAreas with missing or incorrectly formatted orcsAreaNumber.`,
     );
     isValid = false;
   }

--- a/backend/strapi-sync/import-parks/import-parks.js
+++ b/backend/strapi-sync/import-parks/import-parks.js
@@ -143,7 +143,7 @@ export default async function importStrapiProtectedAreas(transaction = null) {
         managementAreas: managementAreaArray,
       };
 
-      // Find matched ProtectedArea by strapiOrcsAreaNumber
+      // Find matched ProtectedArea by orcsAreaNumber
 
       if (matchedDootPark) {
         // Check if any values are different

--- a/backend/tasks/create-date-range-annual/create-date-range-annual.js
+++ b/backend/tasks/create-date-range-annual/create-date-range-annual.js
@@ -50,7 +50,7 @@ export async function createDateRangeAnnualEntries() {
   try {
     // get dateType "Park gate open"
     const gateDateType = await DateType.findOne({
-      where: { strapiDateTypeId: DATE_TYPE.PARK_GATE_OPEN },
+      where: { dateTypeNumber: DATE_TYPE.PARK_GATE_OPEN },
       transaction,
     });
 

--- a/backend/tasks/create-test-park/create-test-park.js
+++ b/backend/tasks/create-test-park/create-test-park.js
@@ -88,7 +88,7 @@ for (const featureType of featureTypes) {
       strapiId: null,
       inReservationSystem: true,
       hasBackcountryPermits: true,
-      strapiOrcsFeatureNumber: null,
+      orcsFeatureNumber: null,
     },
     { transaction },
   );
@@ -106,7 +106,7 @@ for (const featureType of featureTypes) {
       publishableId: parkAreaPublishable.id,
       active: true,
       inReservationSystem: true,
-      strapiOrcsAreaNumber: null,
+      orcsAreaNumber: null,
     },
     {
       transaction,
@@ -133,7 +133,7 @@ for (const featureType of featureTypes) {
         strapiId: null,
         inReservationSystem: true,
         hasBackcountryPermits: true,
-        strapiOrcsFeatureNumber: null,
+        orcsFeatureNumber: null,
       },
       {
         name: `Test Area Feature 2/2 - ${featureType.name}`,
@@ -149,7 +149,7 @@ for (const featureType of featureTypes) {
         strapiId: null,
         inReservationSystem: true,
         hasBackcountryPermits: true,
-        strapiOrcsFeatureNumber: null,
+        orcsFeatureNumber: null,
       },
     ],
     { transaction },

--- a/backend/tasks/populate-date-ranges/populate-annual-date-ranges.js
+++ b/backend/tasks/populate-date-ranges/populate-annual-date-ranges.js
@@ -27,7 +27,7 @@ export async function populateAnnualDateRangesForYear(
         {
           model: DateType,
           as: "dateType",
-          attributes: ["strapiDateTypeId"],
+          attributes: ["dateTypeNumber"],
         },
       ],
 
@@ -46,7 +46,7 @@ export async function populateAnnualDateRangesForYear(
 
       // Season type based on the date type of the DateRangeAnnual
       const seasonType =
-        annual.dateType.strapiDateTypeId === DATE_TYPE.WINTER_FEE
+        annual.dateType.dateTypeNumber === DATE_TYPE.WINTER_FEE
           ? SEASON_TYPE.WINTER
           : SEASON_TYPE.REGULAR;
 
@@ -106,7 +106,7 @@ export async function populateAnnualDateRangesForYear(
 
       // For winter seasons, only copy Winter fee date types
       if (targetSeason.seasonType === SEASON_TYPE.WINTER) {
-        if (annual.dateType.strapiDateTypeId !== DATE_TYPE.WINTER_FEE) {
+        if (annual.dateType.dateTypeNumber !== DATE_TYPE.WINTER_FEE) {
           console.log(
             `Skipping non-winter fee dates for winter season ${targetSeason.operatingYear} (publishableId=${annual.publishableId})`,
           );

--- a/backend/tasks/populate-date-ranges/populate-blank-date-ranges.js
+++ b/backend/tasks/populate-date-ranges/populate-blank-date-ranges.js
@@ -112,7 +112,7 @@ export async function populateBlankDateRangesForYear(
         parkDateTypes.push({
           id: dateType.id,
           name: dateType.name,
-          strapiDateTypeId: dateType.strapiDateTypeId,
+          dateTypeNumber: dateType.dateTypeNumber,
         });
       }
 
@@ -121,18 +121,15 @@ export async function populateBlankDateRangesForYear(
         featureDateTypes.push({
           id: dateType.id,
           name: dateType.name,
-          strapiDateTypeId: dateType.strapiDateTypeId,
+          dateTypeNumber: dateType.dateTypeNumber,
         });
       }
     });
 
-    const parkDateTypesByDateTypeId = _.keyBy(
-      parkDateTypes,
-      "strapiDateTypeId",
-    );
+    const parkDateTypesByDateTypeId = _.keyBy(parkDateTypes, "dateTypeNumber");
     const featureDateTypesByDateTypeId = _.keyBy(
       featureDateTypes,
-      "strapiDateTypeId",
+      "dateTypeNumber",
     );
 
     // Create a list of seasonId+dateableId+dateTypeId combinations
@@ -148,7 +145,7 @@ export async function populateBlankDateRangesForYear(
           (dateType) =>
             // Exclude the Park gate open date type,
             // handled by `populateBlankGateOperatingDates` in ./populate-blank-gate-dates.js
-            dateType.strapiDateTypeId !== DATE_TYPE.PARK_GATE_OPEN,
+            dateType.dateTypeNumber !== DATE_TYPE.PARK_GATE_OPEN,
         );
 
         return dateTypes.map((dateType) => ({

--- a/backend/tasks/populate-date-ranges/populate-blank-gate-dates.js
+++ b/backend/tasks/populate-date-ranges/populate-blank-gate-dates.js
@@ -27,7 +27,7 @@ export default async function populateBlankGateOperatingDates(
     attributes: ["id"],
 
     where: {
-      strapiDateTypeId: DATE_TYPE.PARK_GATE_OPEN,
+      dateTypeNumber: DATE_TYPE.PARK_GATE_OPEN,
     },
 
     transaction,

--- a/backend/tasks/update-orcs-area-numbers/README.md
+++ b/backend/tasks/update-orcs-area-numbers/README.md
@@ -1,6 +1,6 @@
 # update-orcs-area-numbers.js
 
-This script synchronizes ORCS area numbers from Strapi to the local DOOT database by updating the `strapiOrcsAreaNumber` field in the `ParkAreas` table.
+This script synchronizes ORCS area numbers from Strapi to the local DOOT database by updating the `orcsAreaNumber` field in the `ParkAreas` table.
 
 ## This script is temporary
 
@@ -9,7 +9,7 @@ When DOOT's Strapi sync scripts are updated, these values will be fetched during
 ## What does the script do?
 
 1. **Fetches all park areas from Strapi** using `/api/park-areas` endpoint
-2. **Updates local ParkArea records** by matching `Park.orcs` and `ParkAreas.name` and updating `strapiOrcsAreaNumber`
+2. **Updates local ParkArea records** by matching `Park.orcs` and `ParkAreas.name` and updating `orcsAreaNumber`
 3. **Transaction Safety** - all operations in a transaction, rolled back on error
 
 ## How to run
@@ -26,7 +26,7 @@ node tasks/update-orcs-area-numbers/update-orcs-area-numbers.js
 ## Output
 
 - Logs progress for each page fetched
-- Reports: `"Updated X parkAreas with strapiOrcsAreaNumber"`
+- Reports: `"Updated X parkAreas with orcsAreaNumber"`
 - Errors cause transaction rollback with error message
 
 ## Notes

--- a/backend/tasks/update-orcs-area-numbers/update-orcs-area-numbers.js
+++ b/backend/tasks/update-orcs-area-numbers/update-orcs-area-numbers.js
@@ -35,7 +35,7 @@ export default async function updateOrcsAreaNumbers(transaction = null) {
   try {
     // Fetch all parkArea records in the DOOT db
     const dootAreas = await ParkArea.findAll({
-      attributes: ["id", "name", "strapiOrcsAreaNumber"],
+      attributes: ["id", "name", "orcsAreaNumber"],
       include: [
         {
           model: Park,
@@ -49,28 +49,28 @@ export default async function updateOrcsAreaNumbers(transaction = null) {
     for (const area of dootAreas) {
       const key = `${area.park.orcs}|${standardizeName(area.name)}`;
 
-      // Match on key to populate the strapiOrcsAreaNumber
+      // Match on key to populate the orcsAreaNumber
       const orcsAreaNumber = strapiEntities.get(key);
 
       // Skip updating if there's no orcsAreaNumber from Strapi
       if (!orcsAreaNumber) continue;
 
       // Skip updating if the orcsAreaNumber hasn't changed
-      if (area.strapiOrcsAreaNumber === orcsAreaNumber) continue;
+      if (area.orcsAreaNumber === orcsAreaNumber) continue;
 
       // Update and save the area record
-      area.strapiOrcsAreaNumber = orcsAreaNumber;
+      area.orcsAreaNumber = orcsAreaNumber;
       await area.save({ transaction });
 
       updateCount += 1;
     }
   } catch (error) {
-    console.error("Failed to update strapiOrcsAreaNumber:", error);
+    console.error("Failed to update orcsAreaNumber:", error);
     // Transaction rollback is handled by the caller.
     throw error;
   }
 
-  console.log(`Updated ${updateCount} parkAreas with strapiOrcsAreaNumber.`);
+  console.log(`Updated ${updateCount} parkAreas with orcsAreaNumber.`);
 }
 
 // Run directly
@@ -82,7 +82,7 @@ if (process.argv[1] === new URL(import.meta.url).pathname) {
     await transaction.commit();
   } catch (err) {
     await transaction.rollback();
-    console.error("Failed to update strapiOrcsAreaNumber:", err);
+    console.error("Failed to update orcsAreaNumber:", err);
     throw err;
   }
 }

--- a/backend/tasks/update-orcs-feature-numbers/README.md
+++ b/backend/tasks/update-orcs-feature-numbers/README.md
@@ -1,6 +1,6 @@
 # update-orcs-feature-numbers.js
 
-This script synchronizes ORCS feature numbers from Strapi to the local DOOT database by updating the `strapiOrcsFeatureNumber` field in the `Features` table.
+This script synchronizes ORCS feature numbers from Strapi to the local DOOT database by updating the `orcsFeatureNumber` field in the `Features` table.
 
 ## This script is temporary
 
@@ -10,7 +10,7 @@ When DOOT's Strapi sync scripts are updated, these values will be fetched during
 
 1. **Fetches all park features from Strapi** using `/api/park-features` endpoint
 2. **Handles duplicate featureIds** - skips any `featureId` values that occur more than once to avoid data conflicts
-3. **Updates local Feature records** by matching `strapiFeatureId` and updating `strapiOrcsFeatureNumber`
+3. **Updates local Feature records** by matching `strapiFeatureId` and updating `orcsFeatureNumber`
 4. **Transaction Safety** - all operations in a transaction, rolled back on error
 
 ## How to run
@@ -27,7 +27,7 @@ node tasks/update-orcs-feature-numbers/update-orcs-feature-numbers.js
 ## Output
 
 - Logs progress for each page fetched
-- Reports: `"Updated X features with strapiOrcsFeatureNumber"`
+- Reports: `"Updated X features with orcsFeatureNumber"`
 - Errors cause transaction rollback with error message
 
 ## Notes

--- a/backend/tasks/update-orcs-feature-numbers/update-orcs-feature-numbers.js
+++ b/backend/tasks/update-orcs-feature-numbers/update-orcs-feature-numbers.js
@@ -32,34 +32,34 @@ export default async function updateOrcsFeatureNumbers(transaction = null) {
   try {
     // Fetch all Feature records in the DOOT db
     const dootFeatures = await Feature.findAll({
-      attributes: ["id", "strapiFeatureId", "strapiOrcsFeatureNumber"],
+      attributes: ["id", "strapiFeatureId", "orcsFeatureNumber"],
 
       transaction,
     });
 
     for (const feature of dootFeatures) {
-      // Match on featureId to populate the strapiOrcsFeatureNumber
+      // Match on featureId to populate the orcsFeatureNumber
       const orcsFeatureNumber = featureIdMap.get(feature.strapiFeatureId);
 
       // Skip updating if there's no orcsFeatureNumber from Strapi
       if (!orcsFeatureNumber) continue;
 
       // Skip updating if the orcsFeatureNumber hasn't changed
-      if (feature.strapiOrcsFeatureNumber === orcsFeatureNumber) continue;
+      if (feature.orcsFeatureNumber === orcsFeatureNumber) continue;
 
       // Update and save the feature record
-      feature.strapiOrcsFeatureNumber = orcsFeatureNumber;
+      feature.orcsFeatureNumber = orcsFeatureNumber;
       await feature.save({ transaction });
 
       updateCount += 1;
     }
   } catch (error) {
-    console.error("Failed to update strapiOrcsFeatureNumber:", error);
+    console.error("Failed to update orcsFeatureNumber:", error);
     if (transaction) await transaction.rollback();
     throw error;
   }
 
-  console.log(`Updated ${updateCount} features with strapiOrcsFeatureNumber.`);
+  console.log(`Updated ${updateCount} features with orcsFeatureNumber.`);
 }
 
 // Run directly
@@ -71,7 +71,7 @@ if (process.argv[1] === new URL(import.meta.url).pathname) {
     await transaction.commit();
   } catch (err) {
     await transaction.rollback();
-    console.error("Failed to update strapiOrcsFeatureNumber:", err);
+    console.error("Failed to update orcsFeatureNumber:", err);
     throw err;
   }
 }

--- a/backend/utils/dateTypesHelpers.js
+++ b/backend/utils/dateTypesHelpers.js
@@ -13,7 +13,7 @@ export async function getAllDateTypes(where = {}, transaction = null) {
     attributes: [
       "id",
       "name",
-      "strapiDateTypeId",
+      "dateTypeNumber",
       "description",
       "parkLevel",
       "featureLevel",
@@ -28,7 +28,7 @@ export async function getAllDateTypes(where = {}, transaction = null) {
 /**
  * Returns the DateTypes applicable to a Park or Feature in a specific order.
  * @param {Object} park Park object
- * @param {Object} dateTypesByDateTypeId Object mapping date type strapiDateTypeId to objects
+ * @param {Object} dateTypesByDateTypeId Object mapping date type dateTypeNumber to objects
  * @param {string} [seasonType] Season type ("winter" or "regular") to filter applicable date types
  * @returns {Array} Applicable DateType objects for the Park, in order
  */
@@ -66,7 +66,7 @@ export function getDateTypesForPark(
  * Returns the DateTypes applicable to a Feature in the order they should appear in the app.
  * For Features, it includes Operation, Reservation, and Backcountry registration dates if applicable.
  * @param {Object} feature Feature object
- * @param {Object} dateTypesByDateTypeId Object mapping date type strapiDateTypeId to objects
+ * @param {Object} dateTypesByDateTypeId Object mapping date type dateTypeNumber to objects
  * @returns {Array} An array of DateType objects in the specified order.
  */
 export function getDateTypesForFeature(feature, dateTypesByDateTypeId) {

--- a/backend/utils/resolveNewSeasonStatus.js
+++ b/backend/utils/resolveNewSeasonStatus.js
@@ -18,27 +18,27 @@ let cachedDateTypeMapsPromise = null;
 
 /**
  * Fetches all date types and constructs lookup maps for Park- and Feature-level date types,
- * keyed by strapiDateTypeId. Caches the results to prevent extra DB queries.
+ * keyed by dateTypeNumber. Caches the results to prevent extra DB queries.
  * @param {Transaction|null} [transaction=null] Sequelize transaction
- * @returns {Promise<{parkDateTypesByDateTypeId: Object, featureDateTypesByDateTypeId: Object}>} An object containing two maps of date types keyed by strapiDateTypeId
+ * @returns {Promise<{parkDateTypesByDateTypeId: Object, featureDateTypesByDateTypeId: Object}>} An object containing two maps of date types keyed by dateTypeNumber
  */
 async function getCachedDateTypeMaps(transaction = null) {
   if (!cachedDateTypeMapsPromise) {
     // Build lookup maps and populate the cache promise
     cachedDateTypeMapsPromise = getAllDateTypes({}, transaction).then(
       (allDateTypes) => ({
-        // Object map of all Park-level date types by strapiDateTypeId
+        // Object map of all Park-level date types by dateTypeNumber
         parkDateTypesByDateTypeId: Object.fromEntries(
           allDateTypes
             .filter((dateType) => dateType.parkLevel)
-            .map((dateType) => [dateType.strapiDateTypeId, dateType]),
+            .map((dateType) => [dateType.dateTypeNumber, dateType]),
         ),
 
-        // Object map of all Feature-level date types by strapiDateTypeId
+        // Object map of all Feature-level date types by dateTypeNumber
         featureDateTypesByDateTypeId: Object.fromEntries(
           allDateTypes
             .filter((dateType) => dateType.featureLevel)
-            .map((dateType) => [dateType.strapiDateTypeId, dateType]),
+            .map((dateType) => [dateType.dateTypeNumber, dateType]),
         ),
       }),
     );
@@ -102,7 +102,7 @@ export default async function resolveNewSeasonStatus(
     throw new Error(`Publishable with ID ${publishableId} not found.`);
   }
 
-  // Get cached date type lookup maps, keyed by strapiDateTypeId
+  // Get cached date type lookup maps, keyed by dateTypeNumber
   const { parkDateTypesByDateTypeId, featureDateTypesByDateTypeId } =
     await getCachedDateTypeMaps(transaction);
 
@@ -123,8 +123,8 @@ export default async function resolveNewSeasonStatus(
       // Return REQUESTED if the Park has Tier dates
       dateTypes.some(
         (dateType) =>
-          dateType.strapiDateTypeId === DATE_TYPE.TIER_1 ||
-          dateType.strapiDateTypeId === DATE_TYPE.TIER_2,
+          dateType.dateTypeNumber === DATE_TYPE.TIER_1 ||
+          dateType.dateTypeNumber === DATE_TYPE.TIER_2,
       )
     ) {
       return STATUS.REQUESTED;

--- a/frontend/src/components/EditAndReviewTable.jsx
+++ b/frontend/src/components/EditAndReviewTable.jsx
@@ -125,18 +125,18 @@ DateTypeTableRow.propTypes = {
 function DateTableRow({ groupedDateRanges, currentYear }) {
   if (!currentYear || !groupedDateRanges) return null;
 
-  // Helper to get the strapiDateTypeId from the first item in a groupedDateRange
-  function getStrapiDateTypeId(datesObj) {
+  // Helper to get the dateTypeNumber from the first item in a groupedDateRange
+  function getDateTypeNumber(datesObj) {
     const firstRange = Object.values(datesObj)[0]?.[0];
 
-    return firstRange?.dateType?.strapiDateTypeId ?? Number.MAX_SAFE_INTEGER;
+    return firstRange?.dateType?.dateTypeNumber ?? Number.MAX_SAFE_INTEGER;
   }
 
   // Sort date types based on DATE_TYPE.SORT_ORDER
   const sortedDateTypes = Object.entries(groupedDateRanges).sort(
     ([, datesA], [, datesB]) =>
-      DATE_TYPE.SORT_ORDER.indexOf(getStrapiDateTypeId(datesA)) -
-      DATE_TYPE.SORT_ORDER.indexOf(getStrapiDateTypeId(datesB)),
+      DATE_TYPE.SORT_ORDER.indexOf(getDateTypeNumber(datesA)) -
+      DATE_TYPE.SORT_ORDER.indexOf(getDateTypeNumber(datesB)),
   );
 
   return sortedDateTypes.map(([dateTypeName, yearsObj]) => (
@@ -479,7 +479,7 @@ function Table({ park, formPanelHandler, sortOrder }) {
 
         {sortOrder.map((groupingType) => (
           <React.Fragment
-            key={`${groupingType.type}-${groupingType.parkAreaTypeNumber || groupingType.strapiFeatureTypeId}`}
+            key={`${groupingType.type}-${groupingType.parkAreaTypeNumber || groupingType.featureTypeNumber}`}
           >
             {groupingType.type === "ParkAreaType" && (
               <FeaturesByFeatureTypeWithAreas
@@ -497,8 +497,8 @@ function Table({ park, formPanelHandler, sortOrder }) {
                 park={park}
                 features={features.filter(
                   (f) =>
-                    f.featureType.strapiFeatureTypeId ===
-                    groupingType.strapiFeatureTypeId,
+                    f.featureType.featureTypeNumber ===
+                    groupingType.featureTypeNumber,
                 )}
                 formPanelHandler={formPanelHandler}
               />

--- a/frontend/src/components/FormPanel.jsx
+++ b/frontend/src/components/FormPanel.jsx
@@ -178,7 +178,7 @@ function SeasonForm({
   }, [level, season, seasonMetadata]);
 
   const dateTypesByStrapiId = useMemo(
-    () => keyBy(seasonMetadata?.dateTypes || [], "strapiDateTypeId"),
+    () => keyBy(seasonMetadata?.dateTypes || [], "dateTypeNumber"),
     [seasonMetadata],
   );
   // Find the "Park gate open" date type id

--- a/frontend/src/components/GateForm.jsx
+++ b/frontend/src/components/GateForm.jsx
@@ -82,7 +82,7 @@ export default function GateForm({
                   </TooltipWrapper>
                 </h6>
 
-                {isDateTypeOptional(dateType.strapiDateTypeId, level) && (
+                {isDateTypeOptional(dateType.dateTypeNumber, level) && (
                   <div className="my-2 text-secondary-grey">(Optional)</div>
                 )}
 
@@ -98,10 +98,7 @@ export default function GateForm({
                   removeDateRange={removeDateRange}
                   dateRangeAnnuals={dateRangeAnnuals}
                   updateDateRangeAnnual={updateDateRangeAnnual}
-                  optional={isDateTypeOptional(
-                    dateType.strapiDateTypeId,
-                    level,
-                  )}
+                  optional={isDateTypeOptional(dateType.dateTypeNumber, level)}
                 />
               </div>
             )}
@@ -169,7 +166,7 @@ GateForm.propTypes = {
   dateableId: PropTypes.number,
   dateType: PropTypes.shape({
     id: PropTypes.number,
-    strapiDateTypeId: PropTypes.number,
+    dateTypeNumber: PropTypes.number,
     name: PropTypes.string,
     description: PropTypes.string,
   }),

--- a/frontend/src/components/SeasonForms/AreaSeasonForm.jsx
+++ b/frontend/src/components/SeasonForms/AreaSeasonForm.jsx
@@ -54,7 +54,7 @@ function FeatureFormSectionComponent({
             </TooltipWrapper>
           </h6>
 
-          {isDateTypeOptional(dateType.strapiDateTypeId, "feature") && (
+          {isDateTypeOptional(dateType.dateTypeNumber, "feature") && (
             <div className="my-2 text-secondary-grey">(Optional)</div>
           )}
 
@@ -87,7 +87,7 @@ function FeatureFormSectionComponent({
             }
             dateRangeAnnuals={dateRangeAnnuals}
             updateDateRangeAnnual={updateDateRangeAnnual}
-            optional={isDateTypeOptional(dateType.strapiDateTypeId, "feature")}
+            optional={isDateTypeOptional(dateType.dateTypeNumber, "feature")}
           />
         </div>
       ))}
@@ -105,7 +105,7 @@ const dateRangeShape = PropTypes.shape({
   dateType: PropTypes.shape({
     name: PropTypes.string.isRequired,
     id: PropTypes.number.isRequired,
-    strapiDateTypeId: PropTypes.number.isRequired,
+    dateTypeNumber: PropTypes.number.isRequired,
   }),
 });
 
@@ -122,7 +122,7 @@ FeatureFormSectionComponent.propTypes = {
     PropTypes.shape({
       name: PropTypes.string.isRequired,
       id: PropTypes.number.isRequired,
-      strapiDateTypeId: PropTypes.number.isRequired,
+      dateTypeNumber: PropTypes.number.isRequired,
       description: PropTypes.string,
     }),
   ).isRequired,
@@ -516,7 +516,7 @@ export default function AreaSeasonForm({
                   </TooltipWrapper>
                 </h6>
 
-                {isDateTypeOptional(dateType.strapiDateTypeId, "parkArea") && (
+                {isDateTypeOptional(dateType.dateTypeNumber, "parkArea") && (
                   <div className="my-2 text-secondary-grey">(Optional)</div>
                 )}
 
@@ -535,7 +535,7 @@ export default function AreaSeasonForm({
                   dateRangeAnnuals={dateRangeAnnuals}
                   updateDateRangeAnnual={updateDateRangeAnnual}
                   optional={isDateTypeOptional(
-                    dateType.strapiDateTypeId,
+                    dateType.dateTypeNumber,
                     "parkArea",
                   )}
                 />
@@ -634,7 +634,7 @@ AreaSeasonForm.propTypes = {
       dateType: PropTypes.shape({
         name: PropTypes.string.isRequired,
         id: PropTypes.number.isRequired,
-        strapiDateTypeId: PropTypes.number.isRequired,
+        dateTypeNumber: PropTypes.number.isRequired,
       }),
     }),
   ).isRequired,
@@ -643,7 +643,7 @@ AreaSeasonForm.propTypes = {
     PropTypes.shape({
       name: PropTypes.string.isRequired,
       id: PropTypes.number.isRequired,
-      strapiDateTypeId: PropTypes.number.isRequired,
+      dateTypeNumber: PropTypes.number.isRequired,
       description: PropTypes.string,
     }),
   ).isRequired,
@@ -653,7 +653,7 @@ AreaSeasonForm.propTypes = {
       PropTypes.shape({
         name: PropTypes.string.isRequired,
         id: PropTypes.number.isRequired,
-        strapiDateTypeId: PropTypes.number.isRequired,
+        dateTypeNumber: PropTypes.number.isRequired,
         description: PropTypes.string,
       }),
     ),

--- a/frontend/src/components/SeasonForms/FeatureSeasonForm.jsx
+++ b/frontend/src/components/SeasonForms/FeatureSeasonForm.jsx
@@ -161,7 +161,7 @@ function FormSection({ dateTypes, feature, season, previousSeasonDates }) {
             </TooltipWrapper>
           </h6>
 
-          {isDateTypeOptional(dateType.strapiDateTypeId, "feature") && (
+          {isDateTypeOptional(dateType.dateTypeNumber, "feature") && (
             <div className="my-2 text-secondary-grey">(Optional)</div>
           )}
 
@@ -177,7 +177,7 @@ function FormSection({ dateTypes, feature, season, previousSeasonDates }) {
             removeDateRange={removeDateRange}
             dateRangeAnnuals={dateRangeAnnuals}
             updateDateRangeAnnual={updateDateRangeAnnual}
-            optional={isDateTypeOptional(dateType.strapiDateTypeId, "feature")}
+            optional={isDateTypeOptional(dateType.dateTypeNumber, "feature")}
           />
 
           <ErrorSlot element={elements.dateableSection(feature.dateableId)} />
@@ -304,7 +304,7 @@ FeatureSeasonForm.propTypes = {
       dateType: PropTypes.shape({
         name: PropTypes.string.isRequired,
         id: PropTypes.number.isRequired,
-        strapiDateTypeId: PropTypes.number.isRequired,
+        dateTypeNumber: PropTypes.number.isRequired,
       }),
     }),
   ).isRequired,
@@ -313,7 +313,7 @@ FeatureSeasonForm.propTypes = {
     PropTypes.shape({
       name: PropTypes.string.isRequired,
       id: PropTypes.number.isRequired,
-      strapiDateTypeId: PropTypes.number.isRequired,
+      dateTypeNumber: PropTypes.number.isRequired,
       description: PropTypes.string,
     }),
   ).isRequired,

--- a/frontend/src/components/SeasonForms/ParkSeasonForm.jsx
+++ b/frontend/src/components/SeasonForms/ParkSeasonForm.jsx
@@ -48,18 +48,18 @@ function FormSection({
             </TooltipWrapper>
           </h6>
 
-          {isDateTypeOptional(dateType.strapiDateTypeId, "park") && (
+          {isDateTypeOptional(dateType.dateTypeNumber, "park") && (
             <div className="my-2 text-secondary-grey">(Optional)</div>
           )}
 
           <PreviousDates
-            dateRanges={previousDatesByType?.[dateType.strapiDateTypeId]}
+            dateRanges={previousDatesByType?.[dateType.dateTypeNumber]}
           />
 
           <DateRangeFields
             dateableId={park.dateableId}
             dateType={dateType}
-            dateRanges={datesByType[dateType.strapiDateTypeId] ?? []}
+            dateRanges={datesByType[dateType.dateTypeNumber] ?? []}
             operatingYear={season.operatingYear}
             isWinterSeason={isWinterSeason}
             updateDateRange={updateDateRange}
@@ -67,7 +67,7 @@ function FormSection({
             removeDateRange={removeDateRange}
             dateRangeAnnuals={dateRangeAnnuals}
             updateDateRangeAnnual={updateDateRangeAnnual}
-            optional={isDateTypeOptional(dateType.strapiDateTypeId, "park")}
+            optional={isDateTypeOptional(dateType.dateTypeNumber, "park")}
           />
         </div>
       ))}
@@ -107,8 +107,8 @@ export default function ParkSeasonForm({
   // so split "Park gate open" and "Winter fee" out of the dateTypes array.
   const [gateDateType, winterDateType, regularDateTypes] = useMemo(() => {
     const grouped = groupBy(allDateTypes, (dateType) => {
-      if (dateType.strapiDateTypeId === DATE_TYPE.PARK_GATE_OPEN) return "gate";
-      if (dateType.strapiDateTypeId === DATE_TYPE.WINTER_FEE) return "winter";
+      if (dateType.dateTypeNumber === DATE_TYPE.PARK_GATE_OPEN) return "gate";
+      if (dateType.dateTypeNumber === DATE_TYPE.WINTER_FEE) return "winter";
       return "regular";
     });
 
@@ -144,12 +144,12 @@ export default function ParkSeasonForm({
   }, [park.inReservationSystem, park.hasTier1Dates, park.hasTier2Dates]);
 
   const datesByType = useMemo(
-    () => groupBy(park.dateable.dateRanges, "dateType.strapiDateTypeId"),
+    () => groupBy(park.dateable.dateRanges, "dateType.dateTypeNumber"),
     [park.dateable.dateRanges],
   );
 
   const previousDatesByType = useMemo(
-    () => groupBy(previousSeasonDates, "dateType.strapiDateTypeId"),
+    () => groupBy(previousSeasonDates, "dateType.dateTypeNumber"),
     [previousSeasonDates],
   );
 
@@ -401,7 +401,7 @@ ParkSeasonForm.propTypes = {
       dateType: PropTypes.shape({
         name: PropTypes.string.isRequired,
         id: PropTypes.number.isRequired,
-        strapiDateTypeId: PropTypes.number.isRequired,
+        dateTypeNumber: PropTypes.number.isRequired,
       }),
     }),
   ).isRequired,
@@ -429,7 +429,7 @@ ParkSeasonForm.propTypes = {
     PropTypes.shape({
       name: PropTypes.string.isRequired,
       id: PropTypes.number.isRequired,
-      strapiDateTypeId: PropTypes.number.isRequired,
+      dateTypeNumber: PropTypes.number.isRequired,
       description: PropTypes.string,
     }),
   ).isRequired,

--- a/frontend/src/constants/dateType.js
+++ b/frontend/src/constants/dateType.js
@@ -1,6 +1,6 @@
 // Database values for date types
 // Stored as the `dateTypeId` field in Strapi,
-// and `strapiDateTypeId` in the DOOT DateTypes table.
+// and `dateTypeNumber` in the DOOT DateTypes table.
 
 export const BACKCOUNTRY_REGISTRATION = 8;
 export const FIRST_COME_FIRST_SERVED = 9;

--- a/frontend/src/constants/featureType.js
+++ b/frontend/src/constants/featureType.js
@@ -1,6 +1,6 @@
 // Database values for feature types
 // Stored as the `featureTypeId` field in Strapi,
-// and `strapiFeatureTypeId` in the DOOT FeatureTypes table.
+// and `featureTypeNumber` in the DOOT FeatureTypes table.
 
 export const ANCHORAGE = 1;
 export const BACKCOUNTRY = 2;

--- a/frontend/src/hooks/useValidation/rules/reservationAndWinterNoOverlap.js
+++ b/frontend/src/hooks/useValidation/rules/reservationAndWinterNoOverlap.js
@@ -20,7 +20,7 @@ export default function reservationAndWinterNoOverlap(seasonData, context) {
   const frontcountryReservationDates = dateRanges.filter(
     (dateRange) =>
       dateRange.dateType.name === "Reservation" &&
-      dateRange.strapiFeatureTypeId === FEATURE_TYPE.FRONTCOUNTRY_CAMPGROUND &&
+      dateRange.featureTypeNumber === FEATURE_TYPE.FRONTCOUNTRY_CAMPGROUND &&
       dateRange.startDate &&
       dateRange.endDate,
   );

--- a/frontend/src/hooks/useValidation/rules/reservationSameAsTier1And2.js
+++ b/frontend/src/hooks/useValidation/rules/reservationSameAsTier1And2.js
@@ -24,7 +24,7 @@ export default function reservationSameAsTier1And2(seasonData, context) {
   const frontcountryReservationDates = dateRanges.filter(
     (dateRange) =>
       dateRange.dateType.name === "Reservation" &&
-      dateRange.strapiFeatureTypeId === FEATURE_TYPE.FRONTCOUNTRY_CAMPGROUND &&
+      dateRange.featureTypeNumber === FEATURE_TYPE.FRONTCOUNTRY_CAMPGROUND &&
       dateRange.startDate &&
       dateRange.endDate,
   );

--- a/frontend/src/hooks/useValidation/rules/winterAndReservationNoOverlap.js
+++ b/frontend/src/hooks/useValidation/rules/winterAndReservationNoOverlap.js
@@ -23,7 +23,7 @@ export default function winterAndReservationNoOverlap(seasonData, context) {
   // Get a list of Park-level winter dates
   const winterDates = dateRanges.filter(
     (dateRange) =>
-      dateRange.dateType.strapiDateTypeId === DATE_TYPE.WINTER_FEE &&
+      dateRange.dateType.dateTypeNumber === DATE_TYPE.WINTER_FEE &&
       dateRange.startDate &&
       dateRange.endDate,
   );

--- a/frontend/src/hooks/useValidation/useValidation.js
+++ b/frontend/src/hooks/useValidation/useValidation.js
@@ -43,13 +43,13 @@ const elements = {
 };
 
 /**
- * Adds the Strapi Feature Type ID to a date range object as `strapiFeatureTypeId`
- * @param {number} strapiFeatureTypeId The Strapi Feature Type ID to add to the date range
+ * Adds the Strapi Feature Type number to a date range object as `featureTypeNumber`
+ * @param {number} featureTypeNumber The Strapi Feature Type number to add to the date range
  * @param {Object} dateRange The date range object
- * @returns {Object} The date range object with the added `strapiFeatureTypeId` property
+ * @returns {Object} The date range object with the added `featureTypeNumber` property
  */
-function addFeatureTypeToDateRange(strapiFeatureTypeId, dateRange) {
-  return { ...dateRange, strapiFeatureTypeId };
+function addFeatureTypeToDateRange(featureTypeNumber, dateRange) {
+  return { ...dateRange, featureTypeNumber };
 }
 
 /**
@@ -106,7 +106,7 @@ function validate(seasonData, seasonContext) {
       feature.dateable.dateRanges.map((dateRange) =>
         // Add feature type for validation rules that need it (Winter fee/Tier 1 and 2 rules)
         addFeatureTypeToDateRange(
-          feature.featureType.strapiFeatureTypeId,
+          feature.featureType.featureTypeNumber,
           dateRange,
         ),
       ),
@@ -120,7 +120,7 @@ function validate(seasonData, seasonContext) {
     const dateRangesWithFeatureType = feature.dateable.dateRanges.map(
       (dateRange) =>
         addFeatureTypeToDateRange(
-          feature.featureType.strapiFeatureTypeId,
+          feature.featureType.featureTypeNumber,
           dateRange,
         ),
     );

--- a/frontend/src/lib/editAndReviewFilters.js
+++ b/frontend/src/lib/editAndReviewFilters.js
@@ -318,7 +318,7 @@ export function shouldShowTiersAndGateSection(park, filters) {
     // "Park gate open" date type always shows the "Tiers and gate" section
     if (
       filters.dateTypes.some(
-        (dateType) => dateType.strapiDateTypeId === DATE_TYPES.PARK_GATE_OPEN,
+        (dateType) => dateType.dateTypeNumber === DATE_TYPES.PARK_GATE_OPEN,
       )
     ) {
       return true;
@@ -328,7 +328,7 @@ export function shouldShowTiersAndGateSection(park, filters) {
     if (
       park.hasTier1Dates &&
       filters.dateTypes.some(
-        (dateType) => dateType.strapiDateTypeId === DATE_TYPES.TIER_1,
+        (dateType) => dateType.dateTypeNumber === DATE_TYPES.TIER_1,
       )
     ) {
       return true;
@@ -336,7 +336,7 @@ export function shouldShowTiersAndGateSection(park, filters) {
     if (
       park.hasTier2Dates &&
       filters.dateTypes.some(
-        (dateType) => dateType.strapiDateTypeId === DATE_TYPES.TIER_2,
+        (dateType) => dateType.dateTypeNumber === DATE_TYPES.TIER_2,
       )
     ) {
       return true;
@@ -407,7 +407,7 @@ export function shouldShowWinterFeeSection(park, filters) {
     // If "Winter fee" date type is selected, show the section
     if (
       filters.dateTypes.some(
-        (dateType) => dateType.strapiDateTypeId === DATE_TYPES.WINTER_FEE,
+        (dateType) => dateType.dateTypeNumber === DATE_TYPES.WINTER_FEE,
       )
     ) {
       return true;

--- a/frontend/src/lib/isDateTypeOptional.js
+++ b/frontend/src/lib/isDateTypeOptional.js
@@ -8,10 +8,10 @@ export const optionalTypes = {
 
 /**
  * Returns true if the date type is optional for the given level.
- * @param {number} strapiDateTypeId the strapi date type ID to check
+ * @param {number} dateTypeNumber the human-assigned identifier from Strapi to check
  * @param {string} level the level to check against ("park", "parkArea", "feature")
  * @returns {boolean} true if the date type is optional for the level, false otherwise
  */
-export default function isDateTypeOptional(strapiDateTypeId, level) {
-  return optionalTypes[level]?.includes(strapiDateTypeId) ?? false;
+export default function isDateTypeOptional(dateTypeNumber, level) {
+  return optionalTypes[level]?.includes(dateTypeNumber) ?? false;
 }

--- a/frontend/src/router/pages/EditAndReview.jsx
+++ b/frontend/src/router/pages/EditAndReview.jsx
@@ -54,7 +54,7 @@ function EditAndReview() {
         })),
         ...(filterOptions?.featureTypes ?? []).map((f) => ({
           rank: f.rank,
-          strapiFeatureTypeId: f.strapiFeatureTypeId,
+          featureTypeNumber: f.featureTypeNumber,
           type: "FeatureType",
         })),
       ].sort((a, b) => a.rank - b.rank),


### PR DESCRIPTION
### Jira Ticket

CMS-1341

### Description
<!-- What did you change, and why? -->

Some of the fields that refer to human-assigned numeric keys in Strapi had names beginning with "Strapi..." to indicate that it was a value coming from Strapi. This update renames 4 fields to make them system-agnostic. DOOT connects to Strapi, but those values may exist in other data sources.

This renames 4 db columns and updates all references to them in the code. Since this changes tons of files in the frontend and backend, it's likely to cause conflicts if you're working on the main branch. I've rebased onto the only open PR merging into main. If you're opening a _new_ PR merging into main, please branch off of this one!

- [x] Rebase onto main when #561 is merged

