### PR TITLE
CMS-1714: Use dev Strapi as SP training backend

### DIFF
--- a/helm/deployment/values-training.yaml
+++ b/helm/deployment/values-training.yaml
@@ -1,6 +1,6 @@
 cluster:
   ssoAuthUrl: https://loginproxy.gov.bc.ca/auth
-  cmsUrl: https://alpha-test-cms.bcparks.ca
+  cmsUrl: https://dev-cms.bcparks.ca
 
 images:
   frontend:
@@ -11,7 +11,7 @@ images:
 frontend:
   env:
     externalUrl: https://training-staff.bcparks.ca
-    publicUrl: https://alpha-test.bcparks.ca
+    publicUrl: https://dev.bcparks.ca
 
 backend:
   env:


### PR DESCRIPTION
### Jira Ticket

CMS-1714

### Description
The Staff Portal frontend depends on Strapi but training does not have a dedicated Strapi environment. Training previously used alpha-test-cms, which relies on test Keycloak and caused 401 errors.
With DEV CMS now configured to use prod Keycloak, Training can safely switch to dev-cms for compatible authentication.

**Notes**

- Depends on https://github.com/bcgov/bcparks.ca/pull/1816 
- Merging this PR does not update OpenShift config — it only commits the change to source control

