### PR TITLE
CMS-1739: Update action button styles & behavior

### DIFF
--- a/frontend/src/components/advisories/shared/tableActionButton/TableActionButton.jsx
+++ b/frontend/src/components/advisories/shared/tableActionButton/TableActionButton.jsx
@@ -3,8 +3,8 @@ import PropTypes from "prop-types";
 import Dropdown from "react-bootstrap/Dropdown";
 import DropdownButton from "react-bootstrap/DropdownButton";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faMagnifyingGlass, faChevronDown } from "@fa-kit/icons/classic/solid";
-import { faPen, faEyeSlash } from "@fa-kit/icons/classic/regular";
+import { faChevronDown } from "@fa-kit/icons/classic/solid";
+import { faEyeSlash, faMemo, faPen } from "@fa-kit/icons/classic/regular";
 
 import "./TableActionButton.scss";
 
@@ -82,7 +82,7 @@ export function TableActionButton({
         size="sm"
       >
         <Dropdown.Item onClick={(event) => action(event, onView)}>
-          <FontAwesomeIcon icon={faMagnifyingGlass} />
+          <FontAwesomeIcon icon={faMemo} />
           View
         </Dropdown.Item>
         <Dropdown.Item onClick={(event) => action(event, onEdit)}>

--- a/frontend/src/components/advisories/shared/tableActionButton/TableActionButton.jsx
+++ b/frontend/src/components/advisories/shared/tableActionButton/TableActionButton.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import PropTypes from "prop-types";
+import classNames from "classnames";
 import Dropdown from "react-bootstrap/Dropdown";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faChevronDown } from "@fa-kit/icons/classic/solid";
@@ -27,6 +28,7 @@ export function TableActionButton({
   onView,
   onEdit,
   onUnpublish,
+  className = "",
 }) {
   const [isOpen, setIsOpen] = useState(false);
 
@@ -74,7 +76,10 @@ export function TableActionButton({
   }, [rowId]);
 
   return (
-    <div className="action-button" onClick={(event) => event.stopPropagation()}>
+    <div
+      className={classNames("action-button", className)}
+      onClick={(event) => event.stopPropagation()}
+    >
       <Dropdown
         show={isOpen}
         onToggle={handleToggle}
@@ -117,4 +122,5 @@ TableActionButton.propTypes = {
   onView: PropTypes.func.isRequired,
   onEdit: PropTypes.func.isRequired,
   onUnpublish: PropTypes.func.isRequired,
+  className: PropTypes.string,
 };

--- a/frontend/src/components/advisories/shared/tableActionButton/TableActionButton.jsx
+++ b/frontend/src/components/advisories/shared/tableActionButton/TableActionButton.jsx
@@ -70,10 +70,11 @@ export function TableActionButton({
         onToggle={handleToggle}
         title={
           <>
-            <span>Actions</span>
+            <span className="visually-hidden">Actions</span>
             <FontAwesomeIcon
               icon={faChevronDown}
               className="action-button__icon"
+              aria-label="Actions"
             />
           </>
         }

--- a/frontend/src/components/advisories/shared/tableActionButton/TableActionButton.jsx
+++ b/frontend/src/components/advisories/shared/tableActionButton/TableActionButton.jsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from "react";
 import PropTypes from "prop-types";
 import Dropdown from "react-bootstrap/Dropdown";
-import DropdownButton from "react-bootstrap/DropdownButton";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faChevronDown } from "@fa-kit/icons/classic/solid";
 import { faEyeSlash, faMemo, faPen } from "@fa-kit/icons/classic/regular";
@@ -9,6 +8,18 @@ import { faEyeSlash, faMemo, faPen } from "@fa-kit/icons/classic/regular";
 import "./TableActionButton.scss";
 
 const ACTION_DROPDOWN_OPEN_EVENT = "table-action-dropdown-open";
+const ACTION_MENU_POPPER_CONFIG = {
+  strategy: "fixed",
+  modifiers: [
+    {
+      name: "preventOverflow",
+      options: {
+        altAxis: true,
+        tether: false,
+      },
+    },
+  ],
+};
 
 export function TableActionButton({
   rowId,
@@ -64,39 +75,38 @@ export function TableActionButton({
 
   return (
     <div className="action-button" onClick={(event) => event.stopPropagation()}>
-      <DropdownButton
-        id={`action-button-${rowId}`}
+      <Dropdown
         show={isOpen}
         onToggle={handleToggle}
-        title={
-          <>
-            <span className="visually-hidden">Actions</span>
-            <FontAwesomeIcon
-              icon={faChevronDown}
-              className="action-button__icon"
-              aria-label="Actions"
-            />
-          </>
-        }
         className="action-button__dropdown-button"
-        size="sm"
       >
-        <Dropdown.Item onClick={(event) => action(event, onView)}>
-          <FontAwesomeIcon icon={faMemo} />
-          View
-        </Dropdown.Item>
-        <Dropdown.Item onClick={(event) => action(event, onEdit)}>
-          <FontAwesomeIcon icon={faPen} />
-          Edit
-        </Dropdown.Item>
-        <Dropdown.Item
-          disabled={!canUnpublish}
-          onClick={(event) => action(event, onUnpublish)}
-        >
-          <FontAwesomeIcon icon={faEyeSlash} />
-          Unpublish
-        </Dropdown.Item>
-      </DropdownButton>
+        <Dropdown.Toggle id={`action-button-${rowId}`} size="sm">
+          <span className="visually-hidden">Actions</span>
+          <FontAwesomeIcon
+            icon={faChevronDown}
+            className="action-button__icon"
+            aria-label="Actions"
+          />
+        </Dropdown.Toggle>
+
+        <Dropdown.Menu renderOnMount popperConfig={ACTION_MENU_POPPER_CONFIG}>
+          <Dropdown.Item onClick={(event) => action(event, onView)}>
+            <FontAwesomeIcon icon={faMemo} />
+            View
+          </Dropdown.Item>
+          <Dropdown.Item onClick={(event) => action(event, onEdit)}>
+            <FontAwesomeIcon icon={faPen} />
+            Edit
+          </Dropdown.Item>
+          <Dropdown.Item
+            disabled={!canUnpublish}
+            onClick={(event) => action(event, onUnpublish)}
+          >
+            <FontAwesomeIcon icon={faEyeSlash} />
+            Unpublish
+          </Dropdown.Item>
+        </Dropdown.Menu>
+      </Dropdown>
     </div>
   );
 }

--- a/frontend/src/components/advisories/shared/tableActionButton/TableActionButton.scss
+++ b/frontend/src/components/advisories/shared/tableActionButton/TableActionButton.scss
@@ -12,13 +12,12 @@
 
       .action-button__icon {
         height: 0.75rem;
-        margin-left: 0.5rem;
         transition: transform 0.5s ease;
         width: 0.75rem;
       }
 
       &.show {
-        .action-button__icon{
+        .action-button__icon {
           transform: rotate(180deg);
         }
       }

--- a/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.jsx
+++ b/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.jsx
@@ -910,15 +910,10 @@ export default function AdvisoryDashboard() {
         title: "",
         field: "id",
         filtering: false,
-        headerStyle: {
-          minWidth: 100,
-        },
-        cellStyle: {
-          minWidth: 100,
-          textAlign: "left",
-        },
+
         render: (rowData) => (
           <TableActionButton
+            className="ms-1 me-3"
             rowId={rowData.documentId}
             canUnpublish={["SCH", "PUB"].includes(rowData.advisoryStatus?.code)}
             onView={() => navigate(`/advisory-summary/${rowData.documentId}`)}


### PR DESCRIPTION
### Jira Ticket

CMS-1739

### Description
<!-- What did you change, and why? -->

From Figma screen 1.0.1, items 13, 14, and 17:
Updated the "Actions" dropdown to just show the chevron icon and have the text hidden.
Updated the popper js options to keep the menu inside the viewport if you scroll away from the toggle button. I had to change the component itself to use the base Dropdown component instead of DropdownButton to use the popperConfig prop
Updated the icon and some minor sizing/style stuff to have the column take up less horizontal space without looking cramped