### PR TITLE
CMS-1732: Add mark reviewed

### DIFF
--- a/frontend/src/components/advisories/shared/tableActionButton/TableActionButton.jsx
+++ b/frontend/src/components/advisories/shared/tableActionButton/TableActionButton.jsx
@@ -80,9 +80,7 @@ export function TableActionButton({
   }, [rowId]);
 
   return (
-    <div
-      className={classNames("action-button", className)}
-    >
+    <div className={classNames("action-button", className)}>
       <Dropdown
         show={isOpen}
         onToggle={handleToggle}
@@ -114,7 +112,7 @@ export function TableActionButton({
             Unpublish
           </Dropdown.Item>
           {onMarkReviewed && (
-            <Dropdown.Item onClick={(event) => action(event, onMarkReviewed)}>
+            <Dropdown.Item onClick={() => action(onMarkReviewed)}>
               <FontAwesomeIcon icon={faCircleCheck} />
               Mark reviewed
             </Dropdown.Item>

--- a/frontend/src/components/advisories/shared/tableActionButton/TableActionButton.jsx
+++ b/frontend/src/components/advisories/shared/tableActionButton/TableActionButton.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import PropTypes from "prop-types";
 import classNames from "classnames";
 import Dropdown from "react-bootstrap/Dropdown";
+import { Link } from "react-router-dom";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faChevronDown } from "@fa-kit/icons/classic/solid";
 import {
@@ -30,8 +31,8 @@ const ACTION_MENU_POPPER_CONFIG = {
 export function TableActionButton({
   rowId,
   canUnpublish = false,
-  onView,
-  onEdit,
+  viewPath,
+  editPath,
   onMarkReviewed,
   onUnpublish,
   className = "",
@@ -96,11 +97,19 @@ export function TableActionButton({
         </Dropdown.Toggle>
 
         <Dropdown.Menu renderOnMount popperConfig={ACTION_MENU_POPPER_CONFIG}>
-          <Dropdown.Item onClick={() => action(onView)}>
+          <Dropdown.Item
+            as={Link}
+            to={viewPath}
+            onClick={() => setIsOpen(false)}
+          >
             <FontAwesomeIcon icon={faMemo} />
             View
           </Dropdown.Item>
-          <Dropdown.Item onClick={() => action(onEdit)}>
+          <Dropdown.Item
+            as={Link}
+            to={editPath}
+            onClick={() => setIsOpen(false)}
+          >
             <FontAwesomeIcon icon={faPen} />
             Edit
           </Dropdown.Item>
@@ -126,8 +135,8 @@ export function TableActionButton({
 TableActionButton.propTypes = {
   rowId: PropTypes.string.isRequired,
   canUnpublish: PropTypes.bool,
-  onView: PropTypes.func.isRequired,
-  onEdit: PropTypes.func.isRequired,
+  viewPath: PropTypes.string,
+  editPath: PropTypes.string,
   onMarkReviewed: PropTypes.func,
   onUnpublish: PropTypes.func.isRequired,
   className: PropTypes.string,

--- a/frontend/src/components/advisories/shared/tableActionButton/TableActionButton.jsx
+++ b/frontend/src/components/advisories/shared/tableActionButton/TableActionButton.jsx
@@ -4,7 +4,12 @@ import classNames from "classnames";
 import Dropdown from "react-bootstrap/Dropdown";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faChevronDown } from "@fa-kit/icons/classic/solid";
-import { faEyeSlash, faMemo, faPen } from "@fa-kit/icons/classic/regular";
+import {
+  faCircleCheck,
+  faEyeSlash,
+  faMemo,
+  faPen,
+} from "@fa-kit/icons/classic/regular";
 
 import "./TableActionButton.scss";
 
@@ -27,6 +32,7 @@ export function TableActionButton({
   canUnpublish = false,
   onView,
   onEdit,
+  onMarkReviewed,
   onUnpublish,
   className = "",
 }) {
@@ -107,6 +113,12 @@ export function TableActionButton({
             <FontAwesomeIcon icon={faEyeSlash} />
             Unpublish
           </Dropdown.Item>
+          {onMarkReviewed && (
+            <Dropdown.Item onClick={(event) => action(event, onMarkReviewed)}>
+              <FontAwesomeIcon icon={faCircleCheck} />
+              Mark reviewed
+            </Dropdown.Item>
+          )}
         </Dropdown.Menu>
       </Dropdown>
     </div>
@@ -118,6 +130,7 @@ TableActionButton.propTypes = {
   canUnpublish: PropTypes.bool,
   onView: PropTypes.func.isRequired,
   onEdit: PropTypes.func.isRequired,
+  onMarkReviewed: PropTypes.func,
   onUnpublish: PropTypes.func.isRequired,
   className: PropTypes.string,
 };

--- a/frontend/src/components/advisories/shared/tableActionButton/TableActionButton.jsx
+++ b/frontend/src/components/advisories/shared/tableActionButton/TableActionButton.jsx
@@ -33,8 +33,8 @@ export function TableActionButton({
   canUnpublish = false,
   viewPath,
   editPath,
-  onMarkReviewed,
   onUnpublish,
+  onMarkReviewed,
   className = "",
 }) {
   const [isOpen, setIsOpen] = useState(false);
@@ -135,8 +135,8 @@ export function TableActionButton({
 TableActionButton.propTypes = {
   rowId: PropTypes.string.isRequired,
   canUnpublish: PropTypes.bool,
-  viewPath: PropTypes.string,
-  editPath: PropTypes.string,
+  viewPath: PropTypes.string.isRequired,
+  editPath: PropTypes.string.isRequired,
   onMarkReviewed: PropTypes.func,
   onUnpublish: PropTypes.func.isRequired,
   className: PropTypes.string,

--- a/frontend/src/constants/advisoryQuery.js
+++ b/frontend/src/constants/advisoryQuery.js
@@ -1,6 +1,6 @@
 import qs from "qs";
 
-export const ADVISORY_UNPUBLISH_QUERY = qs.stringify(
+export const ADVISORY_QUERY = qs.stringify(
   {
     populate: {
       accessStatus: { populate: "*" },

--- a/frontend/src/hooks/advisories/useAdvisoryFlashMessage.js
+++ b/frontend/src/hooks/advisories/useAdvisoryFlashMessage.js
@@ -30,7 +30,7 @@ export default function useAdvisoryFlashMessage() {
   const openUnpublishError = useCallback(
     (message) => {
       openUnpublishFlashMessage(
-        "Failed to unpublish Advisory / closure",
+        "Failed to unpublish advisory / closure",
         message,
         "error",
       );
@@ -41,7 +41,7 @@ export default function useAdvisoryFlashMessage() {
   const openUnpublishSuccess = useCallback(
     (message) => {
       openUnpublishFlashMessage(
-        "Unpublished Advisory / closure",
+        "Unpublished advisory / closure",
         message,
         "success",
       );

--- a/frontend/src/hooks/advisories/useAdvisoryFlashMessage.js
+++ b/frontend/src/hooks/advisories/useAdvisoryFlashMessage.js
@@ -30,7 +30,7 @@ export default function useAdvisoryFlashMessage() {
   const openUnpublishError = useCallback(
     (message) => {
       openUnpublishFlashMessage(
-        "Failed to unpublish Advisory / Closure",
+        "Failed to unpublish Advisory / closure",
         message,
         "error",
       );
@@ -41,7 +41,7 @@ export default function useAdvisoryFlashMessage() {
   const openUnpublishSuccess = useCallback(
     (message) => {
       openUnpublishFlashMessage(
-        "Unpublished Advisory / Closure",
+        "Unpublished Advisory / closure",
         message,
         "success",
       );

--- a/frontend/src/hooks/advisories/useAdvisoryMarkReviewed.js
+++ b/frontend/src/hooks/advisories/useAdvisoryMarkReviewed.js
@@ -74,7 +74,6 @@ export default function useAdvisoryMarkReviewed({
           data: buildReviewPayload(
             advisoryData,
             reviewedStatus.documentId,
-            reviewedStatus.code,
             reviewedByName,
             isApprover ? "approver" : "submitter",
           ),

--- a/frontend/src/hooks/advisories/useAdvisoryMarkReviewed.js
+++ b/frontend/src/hooks/advisories/useAdvisoryMarkReviewed.js
@@ -47,7 +47,6 @@ function resolveReviewedStatus(rowData, advisoryStatuses) {
 export default function useAdvisoryMarkReviewed({
   advisoryStatuses,
   reviewedByName,
-  isApprover,
   openMarkReviewedError,
   openMarkReviewedSuccess,
   onSuccess,
@@ -75,7 +74,6 @@ export default function useAdvisoryMarkReviewed({
             advisoryData,
             reviewedStatus.documentId,
             reviewedByName,
-            isApprover ? "approver" : "submitter",
           ),
         });
 
@@ -92,7 +90,6 @@ export default function useAdvisoryMarkReviewed({
       advisoryStatuses,
       cmsGet,
       cmsPut,
-      isApprover,
       reviewedByName,
       onSuccess,
       openMarkReviewedError,

--- a/frontend/src/hooks/advisories/useAdvisoryMarkReviewed.js
+++ b/frontend/src/hooks/advisories/useAdvisoryMarkReviewed.js
@@ -1,0 +1,81 @@
+import { useCallback } from "react";
+import moment from "moment";
+
+import { ADVISORY_UNPUBLISH_QUERY } from "@/constants/advisoryQuery";
+import useCms from "@/hooks/useCms";
+import { buildReviewPayload } from "@/lib/advisories/utils/AdvisoryReviewPayload";
+
+function resolveReviewedStatus(rowData, advisoryStatuses) {
+  const publishedStatus = advisoryStatuses.find(
+    (status) => status.code === "PUB",
+  );
+  const scheduledStatus = advisoryStatuses.find(
+    (status) => status.code === "SCH",
+  );
+
+  if (rowData.advisoryStatus?.code === "PUB") {
+    return publishedStatus;
+  }
+
+  return moment(rowData.advisoryDate).isAfter(moment())
+    ? scheduledStatus
+    : publishedStatus;
+}
+
+export default function useAdvisoryMarkReviewed({
+  advisoryStatuses,
+  reviewedByName,
+  isApprover,
+  openMarkReviewedError,
+  openMarkReviewedSuccess,
+  onSuccess,
+}) {
+  const { cmsGet, cmsPut } = useCms();
+
+  return useCallback(
+    async (rowData) => {
+      const reviewedStatus = resolveReviewedStatus(rowData, advisoryStatuses);
+
+      if (!reviewedStatus?.documentId) {
+        openMarkReviewedError(
+          "Could not resolve the status for the reviewed advisory.",
+        );
+        return;
+      }
+
+      try {
+        const advisoryData = await cmsGet(
+          `public-advisory-audits/${rowData.documentId}?${ADVISORY_UNPUBLISH_QUERY}`,
+        );
+
+        await cmsPut(`public-advisory-audits/${rowData.documentId}`, {
+          data: buildReviewPayload(
+            advisoryData,
+            reviewedStatus.documentId,
+            reviewedStatus.code,
+            reviewedByName,
+            isApprover ? "approver" : "submitter",
+          ),
+        });
+
+        openMarkReviewedSuccess(`${rowData.title} was marked as reviewed.`);
+        onSuccess();
+      } catch (error) {
+        console.error("Error marking advisory as reviewed:", error);
+        openMarkReviewedError(
+          `Could not mark ${rowData.title} as reviewed. Please try again.`,
+        );
+      }
+    },
+    [
+      advisoryStatuses,
+      cmsGet,
+      cmsPut,
+      isApprover,
+      reviewedByName,
+      onSuccess,
+      openMarkReviewedError,
+      openMarkReviewedSuccess,
+    ],
+  );
+}

--- a/frontend/src/hooks/advisories/useAdvisoryMarkReviewed.js
+++ b/frontend/src/hooks/advisories/useAdvisoryMarkReviewed.js
@@ -1,5 +1,5 @@
 import { useCallback } from "react";
-import moment from "moment";
+import { isFuture, isValid, parseISO } from "date-fns";
 
 import { ADVISORY_QUERY } from "@/constants/advisoryQuery";
 import { buildReviewPayload } from "@/lib/advisories/utils/AdvisoryReviewPayload";
@@ -35,7 +35,9 @@ function resolveReviewedStatus(rowData, advisoryStatuses) {
 
   // If the status is currently HQR, set to SCH if future posting date, else PUB
   if (statusCode === "HQR") {
-    return moment(rowData.advisoryDate).isAfter(moment())
+    const advisoryDate = parseISO(rowData.advisoryDate);
+
+    return isValid(advisoryDate) && isFuture(advisoryDate)
       ? scheduledStatus
       : publishedStatus;
   }

--- a/frontend/src/hooks/advisories/useAdvisoryMarkReviewed.js
+++ b/frontend/src/hooks/advisories/useAdvisoryMarkReviewed.js
@@ -1,9 +1,9 @@
 import { useCallback } from "react";
 import moment from "moment";
 
-import { ADVISORY_UNPUBLISH_QUERY } from "@/constants/advisoryQuery";
-import useCms from "@/hooks/useCms";
+import { ADVISORY_QUERY } from "@/constants/advisoryQuery";
 import { buildReviewPayload } from "@/lib/advisories/utils/AdvisoryReviewPayload";
+import useCms from "@/hooks/useCms";
 
 function resolveReviewedStatus(rowData, advisoryStatuses) {
   const publishedStatus = advisoryStatuses.find(
@@ -12,14 +12,36 @@ function resolveReviewedStatus(rowData, advisoryStatuses) {
   const scheduledStatus = advisoryStatuses.find(
     (status) => status.code === "SCH",
   );
+  const unpublishedStatus = advisoryStatuses.find(
+    (status) => status.code === "UNP",
+  );
 
-  if (rowData.advisoryStatus?.code === "PUB") {
+  const statusCode = rowData.advisoryStatus?.code;
+
+  // If the status is currently PUB, keep it PUB but just update the reviewedAt/reviewedBy fields
+  if (statusCode === "PUB") {
     return publishedStatus;
   }
 
-  return moment(rowData.advisoryDate).isAfter(moment())
-    ? scheduledStatus
-    : publishedStatus;
+  // If the status is currently SCH, keep it SCH but just update the reviewedAt/reviewedBy fields
+  if (statusCode === "SCH") {
+    return scheduledStatus;
+  }
+
+  // If the status is currently UNP, keep it UNP but just update the reviewedAt/reviewedBy fields
+  if (statusCode === "UNP") {
+    return unpublishedStatus;
+  }
+
+  // If the status is currently HQR, set to SCH if future posting date, else PUB
+  if (statusCode === "HQR") {
+    return moment(rowData.advisoryDate).isAfter(moment())
+      ? scheduledStatus
+      : publishedStatus;
+  }
+
+  // Default - keep the existing status unchanged
+  return advisoryStatuses.find((status) => status.code === statusCode);
 }
 
 export default function useAdvisoryMarkReviewed({
@@ -45,7 +67,7 @@ export default function useAdvisoryMarkReviewed({
 
       try {
         const advisoryData = await cmsGet(
-          `public-advisory-audits/${rowData.documentId}?${ADVISORY_UNPUBLISH_QUERY}`,
+          `public-advisory-audits/${rowData.documentId}?${ADVISORY_QUERY}`,
         );
 
         await cmsPut(`public-advisory-audits/${rowData.documentId}`, {

--- a/frontend/src/hooks/advisories/useAdvisoryUnpublish.js
+++ b/frontend/src/hooks/advisories/useAdvisoryUnpublish.js
@@ -1,6 +1,6 @@
 import { useCallback } from "react";
 
-import { ADVISORY_UNPUBLISH_QUERY } from "@/constants/advisoryQuery";
+import { ADVISORY_QUERY } from "@/constants/advisoryQuery";
 import { buildUnpublishPayload } from "@/lib/advisories/utils/AdvisoryUnpublishPayload";
 import useCms from "@/hooks/useCms";
 
@@ -27,7 +27,7 @@ export default function useAdvisoryUnpublish({
 
       try {
         const advisoryData = await cmsGet(
-          `public-advisory-audits/${rowData.documentId}?${ADVISORY_UNPUBLISH_QUERY}`,
+          `public-advisory-audits/${rowData.documentId}?${ADVISORY_QUERY}`,
         );
 
         await cmsPut(`public-advisory-audits/${rowData.documentId}`, {

--- a/frontend/src/lib/advisories/utils/AdvisoryReviewDashboardQuery.js
+++ b/frontend/src/lib/advisories/utils/AdvisoryReviewDashboardQuery.js
@@ -23,6 +23,21 @@ export default function buildReviewFilter({ isReviewDashboard }) {
             },
           },
         },
+        // Exclude advisories that are already marked as reviewed
+        {
+          $or: [
+            {
+              reviewedByName: {
+                $null: true,
+              },
+            },
+            {
+              reviewedAt: {
+                $null: true,
+              },
+            },
+          ],
+        },
         {
           $or: [
             // Expiry date approaching within 1 week

--- a/frontend/src/lib/advisories/utils/AdvisoryReviewPayload.js
+++ b/frontend/src/lib/advisories/utils/AdvisoryReviewPayload.js
@@ -1,9 +1,23 @@
 import moment from "moment";
 
+/**
+ * Maps an array of CMS relation objects to an array of their documentIds.
+ * @param {Array|null} items Array of CMS objects with a documentId property, or null
+ * @returns {Array<string>} Array of documentId strings
+ */
 function mapDocumentIds(items) {
   return (items || []).map((item) => item.documentId);
 }
 
+/**
+ * Build the review payload
+ * @param {Object} advisoryData The full advisory record fetched from CMS
+ * @param {string} reviewedStatusId The documentId of the reviewed status
+ * @param {string} reviewedStatusCode The code of the reviewed status
+ * @param {string} reviewedByName The current user's name (from auth.user?.profile?.name)
+ * @param {string} modifiedByRole The current user's role ("approver" or "submitter")
+ * @returns {Object} The normalized payload ready for cmsPut
+ */
 export function buildReviewPayload(
   advisoryData,
   reviewedStatusId,
@@ -50,11 +64,9 @@ export function buildReviewPayload(
     isEffectiveDateDisplayed: advisoryData.isEffectiveDateDisplayed,
     isEndDateDisplayed: advisoryData.isEndDateDisplayed,
     isUpdatedDateDisplayed: advisoryData.isUpdatedDateDisplayed,
-    publishedAt:
-      advisoryData.publishedAt ||
-      (["PUB", "SCH"].includes(reviewedStatusCode) ? reviewedAt : null),
-    isLatestRevision: advisoryData.isLatestRevision,
     reviewedByName,
     reviewedAt,
+    publishedAt: advisoryData.publishedAt,
+    isLatestRevision: advisoryData.isLatestRevision,
   };
 }

--- a/frontend/src/lib/advisories/utils/AdvisoryReviewPayload.js
+++ b/frontend/src/lib/advisories/utils/AdvisoryReviewPayload.js
@@ -13,7 +13,6 @@ function mapDocumentIds(items) {
  * Build the review payload
  * @param {Object} advisoryData The full advisory record fetched from CMS
  * @param {string} reviewedStatusId The documentId of the reviewed status
- * @param {string} reviewedStatusCode The code of the reviewed status
  * @param {string} reviewedByName The current user's name (from auth.user?.profile?.name)
  * @param {string} modifiedByRole The current user's role ("approver" or "submitter")
  * @returns {Object} The normalized payload ready for cmsPut
@@ -21,7 +20,6 @@ function mapDocumentIds(items) {
 export function buildReviewPayload(
   advisoryData,
   reviewedStatusId,
-  reviewedStatusCode,
   reviewedByName,
   modifiedByRole,
 ) {

--- a/frontend/src/lib/advisories/utils/AdvisoryReviewPayload.js
+++ b/frontend/src/lib/advisories/utils/AdvisoryReviewPayload.js
@@ -1,0 +1,60 @@
+import moment from "moment";
+
+function mapDocumentIds(items) {
+  return (items || []).map((item) => item.documentId);
+}
+
+export function buildReviewPayload(
+  advisoryData,
+  reviewedStatusId,
+  reviewedStatusCode,
+  reviewedByName,
+  modifiedByRole,
+) {
+  const reviewedAt = moment().toISOString();
+
+  return {
+    title: advisoryData.title,
+    description: advisoryData.description,
+    revisionNumber: advisoryData.revisionNumber,
+    isSafetyRelated: advisoryData.isSafetyRelated,
+    listingRank: advisoryData.listingRank,
+    note: advisoryData.note,
+    submittedBy: advisoryData.submittedBy,
+    updatedDate: advisoryData.updatedDate,
+    modifiedDate: reviewedAt,
+    modifiedBy: reviewedByName,
+    modifiedByRole,
+    advisoryDate: advisoryData.advisoryDate,
+    effectiveDate: advisoryData.effectiveDate,
+    endDate: advisoryData.endDate,
+    expiryDate: advisoryData.expiryDate,
+    accessStatus: advisoryData.accessStatus?.documentId || null,
+    eventType: advisoryData.eventType?.documentId || null,
+    urgency: advisoryData.urgency?.documentId || null,
+    standardMessages: mapDocumentIds(advisoryData.standardMessages),
+    protectedAreas: mapDocumentIds(advisoryData.protectedAreas),
+    advisoryStatus: reviewedStatusId,
+    links: mapDocumentIds(advisoryData.links),
+    regions: mapDocumentIds(advisoryData.regions),
+    sections: mapDocumentIds(advisoryData.sections),
+    managementAreas: mapDocumentIds(advisoryData.managementAreas),
+    sites: mapDocumentIds(advisoryData.sites),
+    fireCentres: mapDocumentIds(advisoryData.fireCentres),
+    fireZones: mapDocumentIds(advisoryData.fireZones),
+    naturalResourceDistricts: mapDocumentIds(
+      advisoryData.naturalResourceDistricts,
+    ),
+    recreationResources: mapDocumentIds(advisoryData.recreationResources),
+    isAdvisoryDateDisplayed: advisoryData.isAdvisoryDateDisplayed,
+    isEffectiveDateDisplayed: advisoryData.isEffectiveDateDisplayed,
+    isEndDateDisplayed: advisoryData.isEndDateDisplayed,
+    isUpdatedDateDisplayed: advisoryData.isUpdatedDateDisplayed,
+    publishedAt:
+      advisoryData.publishedAt ||
+      (["PUB", "SCH"].includes(reviewedStatusCode) ? reviewedAt : null),
+    isLatestRevision: advisoryData.isLatestRevision,
+    reviewedByName,
+    reviewedAt,
+  };
+}

--- a/frontend/src/lib/advisories/utils/AdvisoryReviewPayload.js
+++ b/frontend/src/lib/advisories/utils/AdvisoryReviewPayload.js
@@ -14,14 +14,12 @@ function mapDocumentIds(items) {
  * @param {Object} advisoryData The full advisory record fetched from CMS
  * @param {string} reviewedStatusId The documentId of the reviewed status
  * @param {string} reviewedByName The current user's name (from auth.user?.profile?.name)
- * @param {string} modifiedByRole The current user's role ("approver" or "submitter")
  * @returns {Object} The normalized payload ready for cmsPut
  */
 export function buildReviewPayload(
   advisoryData,
   reviewedStatusId,
   reviewedByName,
-  modifiedByRole,
 ) {
   const reviewedAt = moment().toISOString();
 
@@ -36,7 +34,7 @@ export function buildReviewPayload(
     updatedDate: advisoryData.updatedDate,
     modifiedDate: reviewedAt,
     modifiedBy: reviewedByName,
-    modifiedByRole,
+    modifiedByRole: "approver",
     advisoryDate: advisoryData.advisoryDate,
     effectiveDate: advisoryData.effectiveDate,
     endDate: advisoryData.endDate,

--- a/frontend/src/router/pages/advisories/advisory/Advisory.jsx
+++ b/frontend/src/router/pages/advisories/advisory/Advisory.jsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect, useContext, useMemo } from "react";
-import { Navigate, useParams } from "react-router-dom";
+import { Navigate, useParams, useSearchParams } from "react-router-dom";
 import PropTypes from "prop-types";
 import "./Advisory.css";
 import moment from "moment";
@@ -20,6 +20,8 @@ import { ROLES } from "@/config/permissions";
 
 export default function Advisory({ mode }) {
   const { setError } = useContext(ErrorContext);
+  const [searchParams] = useSearchParams();
+  const tabParam = searchParams.get("tab");
 
   const [revisionNumber, setRevisionNumber] = useState();
   const [standardMessages, setStandardMessages] = useState([]);
@@ -1168,11 +1170,16 @@ export default function Advisory({ mode }) {
   }
 
   if (toDashboard) {
+    const dashboardPath =
+      tabParam === "review"
+        ? "/advisories-and-closures/review"
+        : "/advisories-and-closures";
+
     return (
       <Navigate
         push
         to={{
-          pathname: `/advisories-and-closures`,
+          pathname: dashboardPath,
           index: 0,
         }}
       />
@@ -1184,12 +1191,11 @@ export default function Advisory({ mode }) {
   }
 
   if (isConfirmation) {
-    return (
-      <Navigate
-        to={`/advisory-summary/${advisoryId}`}
-        state={{ confirmationText }}
-      />
-    );
+    const summaryUrl = `/advisory-summary/${advisoryId}`;
+    const finalUrl =
+      tabParam === "review" ? `${summaryUrl}?tab=review` : summaryUrl;
+
+    return <Navigate to={finalUrl} state={{ confirmationText }} />;
   }
 
   return (

--- a/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.jsx
+++ b/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.jsx
@@ -145,7 +145,7 @@ export default function AdvisoryDashboard({
   const openUnpublishError = useCallback(
     (message) => {
       globalFlashMessage.open(
-        "Failed to unpublish Advisory / Closure",
+        "Failed to unpublish Advisory / closure",
         message,
         {
           variant: "error",
@@ -157,7 +157,7 @@ export default function AdvisoryDashboard({
 
   const openUnpublishSuccess = useCallback(
     (message) => {
-      globalFlashMessage.open("Unpublished Advisory / Closure", message, {
+      globalFlashMessage.open("Unpublished Advisory / closure", message, {
         variant: "success",
       });
     },
@@ -167,7 +167,7 @@ export default function AdvisoryDashboard({
   const openMarkReviewedError = useCallback(
     (message) => {
       globalFlashMessage.open(
-        "Failed to mark Advisory / Closure reviewed",
+        "Failed to mark Advisory / closure reviewed",
         message,
         {
           variant: "error",
@@ -179,7 +179,7 @@ export default function AdvisoryDashboard({
 
   const openMarkReviewedSuccess = useCallback(
     (message) => {
-      globalFlashMessage.open("Marked Advisory / Closure reviewed", message, {
+      globalFlashMessage.open("Marked Advisory / closure reviewed", message, {
         variant: "success",
       });
     },
@@ -841,7 +841,7 @@ export default function AdvisoryDashboard({
           <>
             Advisory /
             <br />
-            Closure status
+            closure status
           </>
         ),
         filterOnItemSelect: true,

--- a/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.jsx
+++ b/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.jsx
@@ -15,7 +15,7 @@ import {
   useDebounceValue,
 } from "usehooks-ts";
 import qs from "qs";
-import { Link, Navigate, NavLink, useNavigate } from "react-router-dom";
+import { Link, Navigate, NavLink } from "react-router-dom";
 import { useAuth } from "react-oidc-context";
 import ErrorContext from "@/contexts/ErrorContext";
 import FlashMessageContext from "@/contexts/FlashMessageContext";
@@ -103,7 +103,6 @@ export default function AdvisoryDashboard({
   const globalFlashMessage = useContext(FlashMessageContext);
   const auth = useAuth();
   const { hasAnyRole } = useAccess();
-  const navigate = useNavigate();
   const {
     getRegions,
     getManagementAreas,
@@ -1212,16 +1211,16 @@ export default function AdvisoryDashboard({
             className="ms-1 me-3"
             rowId={rowData.documentId}
             canUnpublish={["SCH", "PUB"].includes(rowData.advisoryStatus?.code)}
-            onView={() => {
-              const url = `/advisory-summary/${rowData.documentId}`;
-
-              navigate(isReviewDashboard ? `${url}?tab=review` : url);
-            }}
-            onEdit={() => {
-              const url = `/update-advisory/${rowData.documentId}`;
-
-              navigate(isReviewDashboard ? `${url}?tab=review` : url);
-            }}
+            viewPath={
+              isReviewDashboard
+                ? `/advisory-summary/${rowData.documentId}?tab=review`
+                : `/advisory-summary/${rowData.documentId}`
+            }
+            editPath={
+              isReviewDashboard
+                ? `/update-advisory/${rowData.documentId}?tab=review`
+                : `/update-advisory/${rowData.documentId}`
+            }
             onMarkReviewed={() => handleMarkReviewed(rowData)}
             onUnpublish={() => handleUnpublish(rowData)}
           />
@@ -1231,7 +1230,6 @@ export default function AdvisoryDashboard({
     [
       urgencies,
       advisoryStatuses,
-      navigate,
       handleMarkReviewed,
       handleUnpublish,
       isReviewDashboard,

--- a/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.jsx
+++ b/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.jsx
@@ -145,7 +145,7 @@ export default function AdvisoryDashboard({
   const openUnpublishError = useCallback(
     (message) => {
       globalFlashMessage.open(
-        "Failed to unpublish Advisory / closure",
+        "Failed to unpublish advisory / closure",
         message,
         {
           variant: "error",
@@ -157,7 +157,7 @@ export default function AdvisoryDashboard({
 
   const openUnpublishSuccess = useCallback(
     (message) => {
-      globalFlashMessage.open("Unpublished Advisory / closure", message, {
+      globalFlashMessage.open("Unpublished advisory / closure", message, {
         variant: "success",
       });
     },
@@ -167,7 +167,7 @@ export default function AdvisoryDashboard({
   const openMarkReviewedError = useCallback(
     (message) => {
       globalFlashMessage.open(
-        "Failed to mark Advisory / closure reviewed",
+        "Failed to mark advisory / closure reviewed",
         message,
         {
           variant: "error",
@@ -179,7 +179,7 @@ export default function AdvisoryDashboard({
 
   const openMarkReviewedSuccess = useCallback(
     (message) => {
-      globalFlashMessage.open("Marked Advisory / closure reviewed", message, {
+      globalFlashMessage.open("Marked advisory / closure reviewed", message, {
         variant: "success",
       });
     },

--- a/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.jsx
+++ b/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.jsx
@@ -201,7 +201,6 @@ export default function AdvisoryDashboard({
   const handleMarkReviewed = useAdvisoryMarkReviewed({
     advisoryStatuses,
     reviewedByName: auth.user?.profile?.name,
-    isApprover: hasAnyRole(["approver"]),
     openMarkReviewedError,
     openMarkReviewedSuccess,
     onSuccess() {

--- a/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.jsx
+++ b/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.jsx
@@ -51,6 +51,7 @@ import {
   buildFilter,
   buildSort,
 } from "@/lib/advisories/utils/AdvisoryDashboardQuery";
+import useAdvisoryMarkReviewed from "@/hooks/advisories/useAdvisoryMarkReviewed";
 import useAdvisoryUnpublish from "@/hooks/advisories/useAdvisoryUnpublish";
 import { TABLE_FILTER_LABELS } from "@/constants/advisoryDashboardFilter";
 import { REVIEW_STATUS } from "@/constants/reviewStatus";
@@ -164,6 +165,28 @@ export default function AdvisoryDashboard({
     [globalFlashMessage],
   );
 
+  const openMarkReviewedError = useCallback(
+    (message) => {
+      globalFlashMessage.open(
+        "Failed to mark Advisory / Closure reviewed",
+        message,
+        {
+          variant: "error",
+        },
+      );
+    },
+    [globalFlashMessage],
+  );
+
+  const openMarkReviewedSuccess = useCallback(
+    (message) => {
+      globalFlashMessage.open("Marked Advisory / Closure reviewed", message, {
+        variant: "success",
+      });
+    },
+    [globalFlashMessage],
+  );
+
   const handleUnpublish = useAdvisoryUnpublish({
     advisoryStatuses,
     modifiedBy: auth.user?.profile?.name,
@@ -172,6 +195,18 @@ export default function AdvisoryDashboard({
     openUnpublishSuccess,
     onSuccess() {
       // Refresh the advisory dashboard to reflect the unpublished change
+      setRefreshKey((current) => current + 1);
+    },
+  });
+
+  const handleMarkReviewed = useAdvisoryMarkReviewed({
+    advisoryStatuses,
+    reviewedByName: auth.user?.profile?.name,
+    isApprover: hasAnyRole(["approver"]),
+    openMarkReviewedError,
+    openMarkReviewedSuccess,
+    onSuccess() {
+      // Refresh the advisory dashboard to reflect the reviewed change
       setRefreshKey((current) => current + 1);
     },
   });
@@ -1179,12 +1214,20 @@ export default function AdvisoryDashboard({
             canUnpublish={["SCH", "PUB"].includes(rowData.advisoryStatus?.code)}
             onView={() => navigate(`/advisory-summary/${rowData.documentId}`)}
             onEdit={() => navigate(`/update-advisory/${rowData.documentId}`)}
+            onMarkReviewed={() => handleMarkReviewed(rowData)}
             onUnpublish={() => handleUnpublish(rowData)}
           />
         ),
       },
     ],
-    [urgencies, advisoryStatuses, navigate, handleUnpublish, isReviewDashboard],
+    [
+      urgencies,
+      advisoryStatuses,
+      navigate,
+      handleMarkReviewed,
+      handleUnpublish,
+      isReviewDashboard,
+    ],
   );
 
   if (toCreate) {

--- a/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.jsx
+++ b/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.jsx
@@ -210,6 +210,8 @@ export default function AdvisoryDashboard({
     },
   });
 
+  const canMarkReviewed = isReviewDashboard && hasAnyRole(["approver"]);
+
   const defaultPageFilters = [
     { filterName: "region", filterValue: [], type: "page" },
     { filterName: "district", filterValue: [], type: "page" },
@@ -1221,8 +1223,11 @@ export default function AdvisoryDashboard({
                 ? `/update-advisory/${rowData.documentId}?tab=review`
                 : `/update-advisory/${rowData.documentId}`
             }
-            onMarkReviewed={() => handleMarkReviewed(rowData)}
             onUnpublish={() => handleUnpublish(rowData)}
+            // Only show "Mark reviewed" button on the review dashboard for approvers
+            {...(canMarkReviewed
+              ? { onMarkReviewed: () => handleMarkReviewed(rowData) }
+              : {})}
           />
         ),
       },
@@ -1230,8 +1235,9 @@ export default function AdvisoryDashboard({
     [
       urgencies,
       advisoryStatuses,
-      handleMarkReviewed,
       handleUnpublish,
+      handleMarkReviewed,
+      canMarkReviewed,
       isReviewDashboard,
     ],
   );

--- a/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.jsx
+++ b/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.jsx
@@ -1212,8 +1212,16 @@ export default function AdvisoryDashboard({
             className="ms-1 me-3"
             rowId={rowData.documentId}
             canUnpublish={["SCH", "PUB"].includes(rowData.advisoryStatus?.code)}
-            onView={() => navigate(`/advisory-summary/${rowData.documentId}`)}
-            onEdit={() => navigate(`/update-advisory/${rowData.documentId}`)}
+            onView={() => {
+              const url = `/advisory-summary/${rowData.documentId}`;
+
+              navigate(isReviewDashboard ? `${url}?tab=review` : url);
+            }}
+            onEdit={() => {
+              const url = `/update-advisory/${rowData.documentId}`;
+
+              navigate(isReviewDashboard ? `${url}?tab=review` : url);
+            }}
             onMarkReviewed={() => handleMarkReviewed(rowData)}
             onUnpublish={() => handleUnpublish(rowData)}
           />

--- a/frontend/src/router/pages/advisories/advisorySummary/AdvisorySummary.jsx
+++ b/frontend/src/router/pages/advisories/advisorySummary/AdvisorySummary.jsx
@@ -262,6 +262,15 @@ export default function AdvisorySummary() {
     [advisory?.advisoryStatus?.code],
   );
 
+  // The URL to the update page, including the "tab" search param if it exists
+  const updateAdvisoryUrl = useMemo(() => {
+    const baseUrl = `/update-advisory/${documentId}`;
+
+    return tabParam
+      ? `${baseUrl}?tab=${encodeURIComponent(tabParam)}`
+      : baseUrl;
+  }, [documentId, tabParam]);
+
   // Formatted string for "Last updated..." timestamp
   const lastUpdatedString = useMemo(() => {
     if (!advisory.modifiedDate) return null;
@@ -327,7 +336,7 @@ export default function AdvisorySummary() {
       tabParam === "review"
         ? "/advisories-and-closures/review"
         : "/advisories-and-closures";
-        
+
     return (
       <Navigate
         push
@@ -340,7 +349,7 @@ export default function AdvisorySummary() {
   }
 
   if (toUpdate) {
-    return <Navigate to={`/update-advisory/${documentId}`} />;
+    return <Navigate to={updateAdvisoryUrl} />;
   }
 
   if (toError) {

--- a/frontend/src/router/pages/advisories/advisorySummary/AdvisorySummary.jsx
+++ b/frontend/src/router/pages/advisories/advisorySummary/AdvisorySummary.jsx
@@ -1,5 +1,10 @@
 import { useState, useEffect, useContext, useMemo, useCallback } from "react";
-import { Navigate, useLocation, useParams } from "react-router-dom";
+import {
+  Navigate,
+  useLocation,
+  useParams,
+  useSearchParams,
+} from "react-router-dom";
 import { format } from "date-fns";
 import ErrorContext from "@/contexts/ErrorContext";
 import CmsDataContext from "@/contexts/CmsDataContext";
@@ -47,6 +52,8 @@ export default function AdvisorySummary() {
   const [snackMessageInfo, setSnackMessageInfo] = useState(null);
   const { documentId } = useParams();
   const location = useLocation();
+  const [searchParams] = useSearchParams();
+  const tabParam = searchParams.get("tab");
   const [confirmationText, setConfirmationText] = useState(
     location.state?.confirmationText || "",
   );
@@ -316,11 +323,16 @@ export default function AdvisorySummary() {
   }
 
   if (toDashboard) {
+    const dashboardPath =
+      tabParam === "review"
+        ? "/advisories-and-closures/review"
+        : "/advisories-and-closures";
+        
     return (
       <Navigate
         push
         to={{
-          pathname: `/advisories-and-closures`,
+          pathname: dashboardPath,
           index: index >= 0 ? index : 0,
         }}
       />


### PR DESCRIPTION
### Jira Ticket

CMS-1732

### Description
<!-- What did you change, and why? -->
- Added "Mark reviewed" option in the action dropdown
  - When it's clicked, it updates the public advisory audit with `reviewedAt` and `reviewedByName`
  - The advisory will NOT appear in the review tab once it's reviewed 
  - It keeps the advisory status, but the status `HQR` will be updated to `PUB` or `SCH` based on the advisory date
- Added `tabParam` to define from which tab page was accessed so that users can go back to the previous location (tab)
- Added a flash message to show if marking the advisory as reviewed is successful
