### PR TITLE
CMS-1683: Rename and remove css classes beginning with "ad-"

### DIFF
--- a/frontend/src/components/advisories/composite/advisoryForm/AdvisoryForm.jsx
+++ b/frontend/src/components/advisories/composite/advisoryForm/AdvisoryForm.jsx
@@ -362,7 +362,7 @@ export default function AdvisoryForm({
 
     return (
       <div
-        className={`ad-helper-text ${isError ? "text-danger" : ""} ${className}`.trim()}
+        className={`adv-helper-text ${isError ? "text-danger" : ""} ${className}`.trim()}
       >
         {text}
       </div>
@@ -911,7 +911,7 @@ export default function AdvisoryForm({
                       Browse
                     </Btn>
                     {linkFileErrors[idx] && (
-                      <span className="d-block text-danger ad-helper-text">
+                      <span className="d-block text-danger adv-helper-text">
                         Select a file
                       </span>
                     )}
@@ -1576,7 +1576,7 @@ export default function AdvisoryForm({
 
       {!hasAnyRole([ROLES.ADVISORY_PUBLISH_WITHOUT_APPROVAL]) &&
         (isStatHoliday || isAfterHours) && (
-          <section className="ad-af-hour-box d-flex field-bg-blue">
+          <section className="adv-af-hour-box d-flex field-bg-blue">
             <FontAwesomeIcon
               icon={faTriangleExclamation}
               className="warningIcon"

--- a/frontend/src/components/advisories/composite/advisoryForm/AdvisoryForm.jsx
+++ b/frontend/src/components/advisories/composite/advisoryForm/AdvisoryForm.jsx
@@ -362,7 +362,7 @@ export default function AdvisoryForm({
 
     return (
       <div
-        className={`adv-helper-text ${isError ? "text-danger" : ""} ${className}`.trim()}
+        className={`act-helper-text ${isError ? "text-danger" : ""} ${className}`.trim()}
       >
         {text}
       </div>
@@ -911,7 +911,7 @@ export default function AdvisoryForm({
                       Browse
                     </Btn>
                     {linkFileErrors[idx] && (
-                      <span className="d-block text-danger adv-helper-text">
+                      <span className="d-block text-danger act-helper-text">
                         Select a file
                       </span>
                     )}
@@ -1576,7 +1576,7 @@ export default function AdvisoryForm({
 
       {!hasAnyRole([ROLES.ADVISORY_PUBLISH_WITHOUT_APPROVAL]) &&
         (isStatHoliday || isAfterHours) && (
-          <section className="adv-af-hour-box d-flex field-bg-blue">
+          <section className="act-af-hour-box d-flex field-bg-blue">
             <FontAwesomeIcon
               icon={faTriangleExclamation}
               className="warningIcon"

--- a/frontend/src/components/advisories/composite/advisoryForm/AdvisoryForm.scss
+++ b/frontend/src/components/advisories/composite/advisoryForm/AdvisoryForm.scss
@@ -65,15 +65,6 @@
   align-items: center !important;
 }
 
-.ad-label {
-  text-align: right;
-  padding-top: 8px;
-}
-
-.ad-summary-label {
-  text-align: right;
-}
-
 .urgency-btn-group,
 .safety-btn-group {
   display: inline-flex;
@@ -110,47 +101,6 @@
   border-bottom-right-radius: 100px !important;
 }
 
-.ad-btn-group .bcgov-button {
-  margin-right: 5px !important;
-}
-
-.ad-field {
-  padding: 10px;
-  border-radius: 4px !important;
-}
-
-.ad-disabled {
-  background-color: #f0f2f5 !important;
-}
-
-.ad-flex,
-.ad-link-flex {
-  display: flex;
-}
-
-.ad-flex-wrap {
-  flex-wrap: wrap !important;
-}
-
-.ad-flex-date {
-  display: flex;
-}
-
-#ad-confirm {
-  text-align: center !important;
-  line-height: 30px !important;
-  color: #234075 !important;
-}
-
-#ad-confirm span {
-  font-weight: bold;
-}
-
-.ad-interval-box .fa-chevron-down {
-  top: 15px !important;
-  right: 0px !important;
-}
-
 .row {
   padding: 5px 0px;
 }
@@ -164,40 +114,20 @@
   padding: 4px 16px !important;
 }
 
-.ad-af-hour-box {
+.adv-af-hour-box {
   padding: 15px;
 }
 
-.ad-af-hour-box p {
+.adv-af-hour-box p {
   margin-bottom: 0px !important;
 }
 
-.ad-af-hour-box svg.warningIcon {
+.adv-af-hour-box svg.warningIcon {
   font-size: 44px;
 }
 
-.ad-interval-select {
-  width: 100% !important;
-  margin-left: 8px !important;
-}
-
-.ad-link-group div {
-  padding-bottom: 5px !important;
-}
-
-.ad-auto-margin {
+.adv-auto-margin {
   margin: auto !important;
-}
-
-.ad-add-link:not(.ad-link-close) {
-  height: 40px;
-  font-size: 0.875rem;
-  color: var(--color-grey);
-  line-height: 40px;
-  background-color: white;
-  border-radius: 100px !important;
-  border: 1px solid var(--color-med-grey);
-  padding: 0 16px;
 }
 
 .clear-url-btn {
@@ -220,49 +150,19 @@
   background-color: white !important;
 }
 
-.ad-form .input-group {
+.adv-form .input-group {
   position: relative;
 }
 
-.ad-form .input-group input.url {
+.adv-form .input-group input.url {
   z-index: 1 !important;
   border-radius: var(--bs-border-radius) !important;
-}
-
-.ad-btn-row {
-  display: table-row !important;
-}
-
-.ad-date-label {
-  min-width: 115px !important;
-}
-.ad-form-error {
-  text-align: center !important;
-}
-
-.ad-upload-btn {
-  height: 44px !important;
 }
 
 .helpIcon {
   width: 1.25rem;
   height: 1.25rem;
   margin-left: 0.5em;
-}
-
-@media (max-width: 767.98px) {
-  .ad-label,
-  .ad-summary-label {
-    text-align: left !important;
-  }
-  .ad-flex,
-  .ad-btn-group {
-    display: block !important;
-  }
-  .ad-btn-group button {
-    width: 100% !important;
-    margin-top: 5px !important;
-  }
 }
 
 .multi-line-select-option {

--- a/frontend/src/components/advisories/composite/advisoryForm/AdvisoryForm.scss
+++ b/frontend/src/components/advisories/composite/advisoryForm/AdvisoryForm.scss
@@ -114,19 +114,19 @@
   padding: 4px 16px !important;
 }
 
-.adv-af-hour-box {
+.act-af-hour-box {
   padding: 15px;
 }
 
-.adv-af-hour-box p {
+.act-af-hour-box p {
   margin-bottom: 0px !important;
 }
 
-.adv-af-hour-box svg.warningIcon {
+.act-af-hour-box svg.warningIcon {
   font-size: 44px;
 }
 
-.adv-auto-margin {
+.act-auto-margin {
   margin: auto !important;
 }
 
@@ -150,11 +150,11 @@
   background-color: white !important;
 }
 
-.adv-form .input-group {
+.act-form .input-group {
   position: relative;
 }
 
-.adv-form .input-group input.url {
+.act-form .input-group input.url {
   z-index: 1 !important;
   border-radius: var(--bs-border-radius) !important;
 }

--- a/frontend/src/components/advisories/composite/advisorySummaryView/AdvisorySummaryView.jsx
+++ b/frontend/src/components/advisories/composite/advisorySummaryView/AdvisorySummaryView.jsx
@@ -147,7 +147,7 @@ export default function AdvisorySummaryView({
 
               <button
                 type="button"
-                className="ad-copy bcgov-button bcgov-normal-white"
+                className="adv-copy bcgov-button bcgov-normal-white"
                 onClick={() => {
                   navigator.clipboard
                     .writeText(parkUrls)
@@ -209,7 +209,7 @@ export default function AdvisorySummaryView({
 
               <button
                 type="button"
-                className="ad-copy bcgov-button bcgov-normal-white"
+                className="adv-copy bcgov-button bcgov-normal-white"
                 onClick={() => {
                   navigator.clipboard
                     .writeText(siteUrls)

--- a/frontend/src/components/advisories/composite/advisorySummaryView/AdvisorySummaryView.jsx
+++ b/frontend/src/components/advisories/composite/advisorySummaryView/AdvisorySummaryView.jsx
@@ -147,7 +147,7 @@ export default function AdvisorySummaryView({
 
               <button
                 type="button"
-                className="adv-copy bcgov-button bcgov-normal-white"
+                className="act-copy bcgov-button bcgov-normal-white"
                 onClick={() => {
                   navigator.clipboard
                     .writeText(parkUrls)
@@ -209,7 +209,7 @@ export default function AdvisorySummaryView({
 
               <button
                 type="button"
-                className="adv-copy bcgov-button bcgov-normal-white"
+                className="act-copy bcgov-button bcgov-normal-white"
                 onClick={() => {
                   navigator.clipboard
                     .writeText(siteUrls)

--- a/frontend/src/router/pages/advisories/advisorySummary/AdvisorySummary.css
+++ b/frontend/src/router/pages/advisories/advisorySummary/AdvisorySummary.css
@@ -1,11 +1,11 @@
-.adv-copy {
+.act-copy {
   border-radius: 5px !important;
   margin: 16px 0 !important;
   border: none;
 }
 
 .launchIcon,
-.adv-copy svg {
+.act-copy svg {
   width: 20px !important;
   height: 20px !important;
   margin-top: -2px !important;
@@ -15,14 +15,14 @@
   margin-left: 8px;
 }
 
-.adv-copy svg {
+.act-copy svg {
   color: var(--color-blue) !important;
 }
 
-.adv-summary .row {
+.act-summary .row {
   margin: 5px 0px !important;
 }
 
-.adv-right {
+.act-right {
   text-align: right !important;
 }

--- a/frontend/src/router/pages/advisories/advisorySummary/AdvisorySummary.css
+++ b/frontend/src/router/pages/advisories/advisorySummary/AdvisorySummary.css
@@ -1,11 +1,11 @@
-.ad-copy {
+.adv-copy {
   border-radius: 5px !important;
   margin: 16px 0 !important;
   border: none;
 }
 
 .launchIcon,
-.ad-copy svg {
+.adv-copy svg {
   width: 20px !important;
   height: 20px !important;
   margin-top: -2px !important;
@@ -15,14 +15,14 @@
   margin-left: 8px;
 }
 
-.ad-copy svg {
+.adv-copy svg {
   color: var(--color-blue) !important;
 }
 
-.ad-summary .row {
+.adv-summary .row {
   margin: 5px 0px !important;
 }
 
-.ad-right {
+.adv-right {
   text-align: right !important;
 }

--- a/frontend/src/router/pages/advisories/advisorySummary/AdvisorySummary.jsx
+++ b/frontend/src/router/pages/advisories/advisorySummary/AdvisorySummary.jsx
@@ -360,12 +360,12 @@ export default function AdvisorySummary() {
                   </button>
                 </div>
                 {!showOriginalAdvisory && (
-                  <div className="adv-summary mt-4">
+                  <div className="act-summary mt-4">
                     {confirmationText && (
                       <Alert variant="success">{confirmationText}</Alert>
                     )}
                     {isCurrentlyPublished && (
-                      <div className="adv-right mt-4">
+                      <div className="act-right mt-4">
                         <button
                           type="button"
                           className="btn btn-link p-0"
@@ -378,7 +378,7 @@ export default function AdvisorySummary() {
                         </button>
                       </div>
                     )}
-                    <div className="mt-5 container-fluid g-0 adv-form">
+                    <div className="mt-5 container-fluid g-0 act-form">
                       <div className="row g-0 title">
                         <div className="col-md-8 col-12">
                           <p className="mb-1">
@@ -429,9 +429,9 @@ export default function AdvisorySummary() {
                   </div>
                 )}
                 {showOriginalAdvisory && originalIsLoaded && (
-                  <div className="container-fluid adv-summary col-lg-9 col-md-12 col-12">
+                  <div className="container-fluid act-summary col-lg-9 col-md-12 col-12">
                     <div className="row">
-                      <div className="col-lg-12 col-md-12 col-12 adv-right">
+                      <div className="col-lg-12 col-md-12 col-12 act-right">
                         <button
                           type="button"
                           className="btn btn-link p-0"

--- a/frontend/src/router/pages/advisories/advisorySummary/AdvisorySummary.jsx
+++ b/frontend/src/router/pages/advisories/advisorySummary/AdvisorySummary.jsx
@@ -360,12 +360,12 @@ export default function AdvisorySummary() {
                   </button>
                 </div>
                 {!showOriginalAdvisory && (
-                  <div className="ad-summary mt-4">
+                  <div className="adv-summary mt-4">
                     {confirmationText && (
                       <Alert variant="success">{confirmationText}</Alert>
                     )}
                     {isCurrentlyPublished && (
-                      <div className="ad-right mt-4">
+                      <div className="adv-right mt-4">
                         <button
                           type="button"
                           className="btn btn-link p-0"
@@ -378,7 +378,7 @@ export default function AdvisorySummary() {
                         </button>
                       </div>
                     )}
-                    <div className="mt-5 container-fluid g-0 ad-form">
+                    <div className="mt-5 container-fluid g-0 adv-form">
                       <div className="row g-0 title">
                         <div className="col-md-8 col-12">
                           <p className="mb-1">
@@ -429,9 +429,9 @@ export default function AdvisorySummary() {
                   </div>
                 )}
                 {showOriginalAdvisory && originalIsLoaded && (
-                  <div className="container-fluid ad-summary col-lg-9 col-md-12 col-12">
+                  <div className="container-fluid adv-summary col-lg-9 col-md-12 col-12">
                     <div className="row">
-                      <div className="col-lg-12 col-md-12 col-12 ad-right">
+                      <div className="col-lg-12 col-md-12 col-12 adv-right">
                         <button
                           type="button"
                           className="btn btn-link p-0"

--- a/frontend/src/router/pages/advisories/page.scss
+++ b/frontend/src/router/pages/advisories/page.scss
@@ -179,7 +179,7 @@
     width: 100% !important;
   }
 
-  .adv-helper-text {
+  .act-helper-text {
     margin-top: 4px;
     font-size: 0.875rem;
     color: var(--typography-color-secondary);

--- a/frontend/src/router/pages/advisories/page.scss
+++ b/frontend/src/router/pages/advisories/page.scss
@@ -179,7 +179,7 @@
     width: 100% !important;
   }
 
-  .ad-helper-text {
+  .adv-helper-text {
     margin-top: 4px;
     font-size: 0.875rem;
     color: var(--typography-color-secondary);

--- a/frontend/src/router/pages/advisories/parkSearch/ParkSearch.jsx
+++ b/frontend/src/router/pages/advisories/parkSearch/ParkSearch.jsx
@@ -250,9 +250,9 @@ export default function ParkSearch() {
           {!isLoading && (
             <>
               <form>
-                <div className="container-fluid adv-form">
+                <div className="container-fluid act-form">
                   <div className="row mt20">
-                    <div className="col-lg-6 col-md-8 col-sm-12 adv-auto-margin">
+                    <div className="col-lg-6 col-md-8 col-sm-12 act-auto-margin">
                       <Select
                         options={protectedAreas}
                         value={protectedAreas.filter(
@@ -268,7 +268,7 @@ export default function ParkSearch() {
                     </div>
                   </div>
                   <div className="row mt20">
-                    <div className="col-lg-6 col-md-8 col-sm-12 adv-auto-margin">
+                    <div className="col-lg-6 col-md-8 col-sm-12 act-auto-margin">
                       <Select
                         options={regions}
                         value={region}
@@ -284,7 +284,7 @@ export default function ParkSearch() {
                     </div>
                   </div>
                   <div className="row">
-                    <div className="col-lg-6 col-md-8 col-sm-12 adv-auto-margin">
+                    <div className="col-lg-6 col-md-8 col-sm-12 act-auto-margin">
                       <Select
                         options={filteredSections}
                         value={section}
@@ -300,7 +300,7 @@ export default function ParkSearch() {
                     </div>
                   </div>
                   <div className="row">
-                    <div className="col-lg-6 col-md-8 col-sm-12 adv-auto-margin">
+                    <div className="col-lg-6 col-md-8 col-sm-12 act-auto-margin">
                       <Select
                         options={filteredManagementAreas}
                         value={managementArea}
@@ -320,7 +320,7 @@ export default function ParkSearch() {
               {parkList.length > 0 && (
                 <div className="container">
                   <div className="row mt20">
-                    <div className="col-lg-10 col-md-12 col-sm-12 adv-auto-margin">
+                    <div className="col-lg-10 col-md-12 col-sm-12 act-auto-margin">
                       <ListGroup as="div">
                         <ListGroup.Item className="da-list-header" as="div">
                           Park name

--- a/frontend/src/router/pages/advisories/parkSearch/ParkSearch.jsx
+++ b/frontend/src/router/pages/advisories/parkSearch/ParkSearch.jsx
@@ -250,9 +250,9 @@ export default function ParkSearch() {
           {!isLoading && (
             <>
               <form>
-                <div className="container-fluid ad-form">
+                <div className="container-fluid adv-form">
                   <div className="row mt20">
-                    <div className="col-lg-6 col-md-8 col-sm-12 ad-auto-margin">
+                    <div className="col-lg-6 col-md-8 col-sm-12 adv-auto-margin">
                       <Select
                         options={protectedAreas}
                         value={protectedAreas.filter(
@@ -268,7 +268,7 @@ export default function ParkSearch() {
                     </div>
                   </div>
                   <div className="row mt20">
-                    <div className="col-lg-6 col-md-8 col-sm-12 ad-auto-margin">
+                    <div className="col-lg-6 col-md-8 col-sm-12 adv-auto-margin">
                       <Select
                         options={regions}
                         value={region}
@@ -284,7 +284,7 @@ export default function ParkSearch() {
                     </div>
                   </div>
                   <div className="row">
-                    <div className="col-lg-6 col-md-8 col-sm-12 ad-auto-margin">
+                    <div className="col-lg-6 col-md-8 col-sm-12 adv-auto-margin">
                       <Select
                         options={filteredSections}
                         value={section}
@@ -300,7 +300,7 @@ export default function ParkSearch() {
                     </div>
                   </div>
                   <div className="row">
-                    <div className="col-lg-6 col-md-8 col-sm-12 ad-auto-margin">
+                    <div className="col-lg-6 col-md-8 col-sm-12 adv-auto-margin">
                       <Select
                         options={filteredManagementAreas}
                         value={managementArea}
@@ -320,7 +320,7 @@ export default function ParkSearch() {
               {parkList.length > 0 && (
                 <div className="container">
                   <div className="row mt20">
-                    <div className="col-lg-10 col-md-12 col-sm-12 ad-auto-margin">
+                    <div className="col-lg-10 col-md-12 col-sm-12 adv-auto-margin">
                       <ListGroup as="div">
                         <ListGroup.Item className="da-list-header" as="div">
                           Park name


### PR DESCRIPTION
### Jira Ticket

CMS-1683

### Description

Some aggressive ad-blockers may hide parts of the Advisories portal UI because some elements are named “ad-text”, “ad-button” etc.

This PR changes the prefix on CSS classes from  `ad-` to `act-` and removes CSS classes that were not referenced in code or markup. 
