### PR TITLE
CMS-1786: Bump GitHub Actions to latest major versions

### DIFF
--- a/.github/workflows/build-dev.yaml
+++ b/.github/workflows/build-dev.yaml
@@ -16,7 +16,7 @@ jobs:
       IMAGE_NAME: frontend-${{ github.ref_name }}
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set env
         run: |
@@ -29,7 +29,7 @@ jobs:
           oc: "4.14"
 
       - name: Login to OpenShift Container Repository
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{vars.OPENSHIFT_EXTERNAL_REPOSITORY}}
           username: ${{vars.OPENSHIFT_SA_USERNAME}}
@@ -61,7 +61,7 @@ jobs:
       IMAGE_NAME: backend-${{ github.ref_name }}
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set env
         run: |
@@ -69,7 +69,7 @@ jobs:
           echo "REGISTRY_IMAGE=${{ vars.OPENSHIFT_EXTERNAL_REPOSITORY }}/${{ vars.OPENSHIFT_LICENSE_PLATE }}-tools/${{ env.IMAGE_NAME }}" >> $GITHUB_ENV
 
       - name: Login to OpenShift Container Repository
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{vars.OPENSHIFT_EXTERNAL_REPOSITORY}}
           username: ${{vars.OPENSHIFT_SA_USERNAME}}

--- a/.github/workflows/build-dev.yaml
+++ b/.github/workflows/build-dev.yaml
@@ -16,7 +16,7 @@ jobs:
       IMAGE_NAME: frontend-${{ github.ref_name }}
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set env
         run: |
@@ -61,7 +61,7 @@ jobs:
       IMAGE_NAME: backend-${{ github.ref_name }}
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set env
         run: |

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Attempt to checkout tag
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.releaseTag }}
 

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Attempt to checkout tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.releaseTag }}
 

--- a/.github/workflows/deploy-test.yaml
+++ b/.github/workflows/deploy-test.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Attempt to checkout tag
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.releaseTag }}
 

--- a/.github/workflows/deploy-test.yaml
+++ b/.github/workflows/deploy-test.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Attempt to checkout tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.releaseTag }}
 

--- a/.github/workflows/deploy-training.yaml
+++ b/.github/workflows/deploy-training.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Attempt to checkout tag
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.releaseTag }}
 

--- a/.github/workflows/deploy-training.yaml
+++ b/.github/workflows/deploy-training.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Attempt to checkout tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.releaseTag }}
 

--- a/.github/workflows/on-tag-push.yaml
+++ b/.github/workflows/on-tag-push.yaml
@@ -15,7 +15,7 @@ jobs:
     steps:
       # Check out the commit to access its SHA hash and tags
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-tags: true
           ref: ${{ github.ref }}


### PR DESCRIPTION
### Jira Ticket

CMS-1786

### Description
This change updates GitHub actions to the latest major versions in anticipation of actions being forced onto Node 24 on June 2, 2026.

