### PR TITLE
CMS-1786: Bump GitHub Actions to latest major versions - part 2

### DIFF
--- a/.github/workflows/build-dev.yaml
+++ b/.github/workflows/build-dev.yaml
@@ -26,7 +26,8 @@ jobs:
       - name: Install OpenShift CLI tools
         uses: redhat-actions/openshift-tools-installer@v1
         with:
-          oc: "4.14"
+          oc: "4.16"
+          skip_cache: true
 
       - name: Login to OpenShift Container Repository
         uses: docker/login-action@v4
@@ -36,7 +37,7 @@ jobs:
           password: ${{secrets.OPENSHIFT_SA_PASSWORD}}
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "18"
 
@@ -91,7 +92,8 @@ jobs:
       - name: Install OpenShift CLI tools
         uses: redhat-actions/openshift-tools-installer@v1
         with:
-          oc: "4.14"
+          oc: "4.16"
+          skip_cache: true
 
       - name: Login OpenShift
         uses: redhat-actions/oc-login@v1

--- a/.github/workflows/deploy-alpha-test.yaml
+++ b/.github/workflows/deploy-alpha-test.yaml
@@ -14,7 +14,8 @@ jobs:
       - name: Install OpenShift CLI tools
         uses: redhat-actions/openshift-tools-installer@v1
         with:
-          oc: "4.14"
+          oc: "4.16"
+          skip_cache: true
 
       - name: Login OpenShift
         uses: redhat-actions/oc-login@v1

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -30,7 +30,8 @@ jobs:
       - name: Install OpenShift CLI tools
         uses: redhat-actions/openshift-tools-installer@v1
         with:
-          oc: "4.14"
+          oc: "4.16"
+          skip_cache: true
 
       - name: Login OpenShift
         uses: redhat-actions/oc-login@v1

--- a/.github/workflows/deploy-test.yaml
+++ b/.github/workflows/deploy-test.yaml
@@ -30,7 +30,8 @@ jobs:
       - name: Install OpenShift CLI tools
         uses: redhat-actions/openshift-tools-installer@v1
         with:
-          oc: "4.14"
+          oc: "4.16"
+          skip_cache: true
 
       - name: Login OpenShift
         uses: redhat-actions/oc-login@v1

--- a/.github/workflows/deploy-training.yaml
+++ b/.github/workflows/deploy-training.yaml
@@ -30,7 +30,8 @@ jobs:
       - name: Install OpenShift CLI tools
         uses: redhat-actions/openshift-tools-installer@v1
         with:
-          oc: "4.14"
+          oc: "4.16"
+          skip_cache: true
 
       - name: Login OpenShift
         uses: redhat-actions/oc-login@v1

--- a/.github/workflows/on-tag-push.yaml
+++ b/.github/workflows/on-tag-push.yaml
@@ -28,7 +28,8 @@ jobs:
       - name: Install OpenShift CLI tools
         uses: redhat-actions/openshift-tools-installer@v1
         with:
-          oc: "4.14"
+          oc: "4.16"
+          skip_cache: true
 
       - name: Login OpenShift
         uses: redhat-actions/oc-login@v1


### PR DESCRIPTION
### Jira Ticket

CMS-1786

### Description
One action was missed in #578

This PR also disables caching for `openshift-tools-installer` because the cache was resulting in warnings. 

The oc version is also updated from 4.14 to 4.16 to match the Gold and Silver clusters

