### PR TITLE
CMS-1742: Update nav item labels and allowed roles

### DIFF
--- a/frontend/src/components/shared/navItems.jsx
+++ b/frontend/src/components/shared/navItems.jsx
@@ -9,19 +9,19 @@ const navItems = [
     allowedRoles: [ROLES.ADVISORY_SUBMITTER, ROLES.ADVISORY_APPROVER],
   },
   {
-    label: "Park Access Status",
+    label: "Park access status",
     Tag: NavLink,
     to: "/park-access-status",
-    allowedRoles: [ROLES.ADVISORY_SUBMITTER, ROLES.ADVISORY_APPROVER],
+    allowedRoles: [ROLES.BCPARKS_USER],
   },
   {
-    label: "Activities & Facilities",
+    label: "Activities and facilities",
     Tag: NavLink,
     to: "/activities-and-facilities",
     allowedRoles: [ROLES.ADVISORY_APPROVER],
   },
   {
-    label: "Dates of Operation",
+    label: "Dates management",
     Tag: NavLink,
     to: "/dates/",
     allowedRoles: [ROLES.DOOT_USER],

--- a/frontend/src/router/index.jsx
+++ b/frontend/src/router/index.jsx
@@ -78,9 +78,7 @@ const RouterConfig = createBrowserRouter([
       {
         path: "advisories-and-closures/review",
         element: (
-          <AccessControlledRoute
-            allowedRoles={[ROLES.ADVISORY_APPROVER]}
-          >
+          <AccessControlledRoute allowedRoles={[ROLES.ADVISORY_APPROVER]}>
             <AdvisoryReviewDashboard />
           </AccessControlledRoute>
         ),
@@ -124,9 +122,7 @@ const RouterConfig = createBrowserRouter([
       {
         path: "park-access-status",
         element: (
-          <AccessControlledRoute
-            allowedRoles={[ROLES.ADVISORY_SUBMITTER, ROLES.ADVISORY_APPROVER]}
-          >
+          <AccessControlledRoute allowedRoles={[ROLES.BCPARKS_USER]}>
             <ParkAccessStatus />
           </AccessControlledRoute>
         ),


### PR DESCRIPTION
### Jira Ticket

CMS-1742

### Description
<!-- What did you change, and why? -->

Updated the display labels for the nav menu items, and adjusted the `allowedRoles` for Park access status, so users must have the BC Parks User role to see that one and access the page.