### PR TITLE
CMS-1671: Update primary action button text logic on ACT edit form

### DIFF
--- a/frontend/src/components/advisories/composite/advisoryForm/AdvisoryForm.jsx
+++ b/frontend/src/components/advisories/composite/advisoryForm/AdvisoryForm.jsx
@@ -1640,6 +1640,7 @@ export default function AdvisoryForm({
           <DraftButton onClick={handleSaveDraft} hasLoader={isSavingDraft} />
 
           <PrimaryActions
+            mode={mode}
             advisoryStatusCode={advisoryStatusCode}
             isUrgent={isAfterHourPublish}
             isApprover={isApprover}

--- a/frontend/src/components/advisories/composite/advisoryForm/AdvisoryForm.jsx
+++ b/frontend/src/components/advisories/composite/advisoryForm/AdvisoryForm.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useMemo } from "react";
 import PropTypes from "prop-types";
 import classNames from "classnames";
 import "./AdvisoryForm.scss";
@@ -169,6 +169,16 @@ export default function AdvisoryForm({
   const [displayedDateError, setDisplayedDateError] = useState("");
   const [selectedDisplayedDateOption, setSelectedDisplayedDateOption] =
     useState("");
+
+  // Get the advisory status code to determine the primary action button text
+  const currentAdvisoryStatusCode = useMemo(() => {
+    if (!advisoryStatus) return null;
+
+    return (
+      advisoryStatuses.find((status) => status.value === advisoryStatus)
+        ?.code ?? null
+    );
+  }, [advisoryStatus, advisoryStatuses]);
 
   // Reveal event dates in update mode if there are any
   useEffect(() => {
@@ -1639,7 +1649,7 @@ export default function AdvisoryForm({
           <DraftButton onClick={handleSaveDraft} hasLoader={isSavingDraft} />
 
           <PrimaryActions
-            mode={mode}
+            advisoryStatusCode={currentAdvisoryStatusCode}
             isUrgent={isAfterHourPublish}
             isApprover={isApprover}
             onPublish={handlePublish}
@@ -1726,6 +1736,7 @@ AdvisoryForm.propTypes = {
     updateLink: PropTypes.func.isRequired,
     addLink: PropTypes.func.isRequired,
     handleFileCapture: PropTypes.func.isRequired,
+    isApprover: PropTypes.bool,
     notes: PropTypes.string,
     setNotes: PropTypes.func.isRequired,
     submittedBy: PropTypes.string,

--- a/frontend/src/components/advisories/composite/advisoryForm/AdvisoryForm.jsx
+++ b/frontend/src/components/advisories/composite/advisoryForm/AdvisoryForm.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useMemo } from "react";
+import { useState, useEffect, useRef } from "react";
 import PropTypes from "prop-types";
 import classNames from "classnames";
 import "./AdvisoryForm.scss";
@@ -121,6 +121,7 @@ export default function AdvisoryForm({
     submittedBy,
     setSubmittedBy,
     advisoryStatuses,
+    advisoryStatusCode,
     advisoryStatus,
     setAdvisoryStatus,
     isStatHoliday,
@@ -169,16 +170,6 @@ export default function AdvisoryForm({
   const [displayedDateError, setDisplayedDateError] = useState("");
   const [selectedDisplayedDateOption, setSelectedDisplayedDateOption] =
     useState("");
-
-  // Get the advisory status code to determine the primary action button text
-  const currentAdvisoryStatusCode = useMemo(() => {
-    if (!advisoryStatus) return null;
-
-    return (
-      advisoryStatuses.find((status) => status.value === advisoryStatus)
-        ?.code ?? null
-    );
-  }, [advisoryStatus, advisoryStatuses]);
 
   // Reveal event dates in update mode if there are any
   useEffect(() => {
@@ -1570,7 +1561,7 @@ export default function AdvisoryForm({
                 value={advisoryStatuses.filter(
                   (a) => a.value === advisoryStatus,
                 )}
-                onChange={(e) => setAdvisoryStatus(e ? e.value : 0)}
+                onChange={(e) => setAdvisoryStatus(e ? e.value : null)}
                 placeholder="Search or select an advisory status"
                 className="bcgov-select"
                 isClearable
@@ -1649,7 +1640,7 @@ export default function AdvisoryForm({
           <DraftButton onClick={handleSaveDraft} hasLoader={isSavingDraft} />
 
           <PrimaryActions
-            advisoryStatusCode={currentAdvisoryStatusCode}
+            advisoryStatusCode={advisoryStatusCode}
             isUrgent={isAfterHourPublish}
             isApprover={isApprover}
             onPublish={handlePublish}
@@ -1742,6 +1733,7 @@ AdvisoryForm.propTypes = {
     submittedBy: PropTypes.string,
     setSubmittedBy: PropTypes.func.isRequired,
     advisoryStatuses: PropTypes.array.isRequired,
+    advisoryStatusCode: PropTypes.string,
     advisoryStatus: PropTypes.string,
     setAdvisoryStatus: PropTypes.func.isRequired,
     isStatHoliday: PropTypes.bool,

--- a/frontend/src/components/advisories/composite/advisoryForm/PrimaryActions.jsx
+++ b/frontend/src/components/advisories/composite/advisoryForm/PrimaryActions.jsx
@@ -5,6 +5,7 @@ import useAccess from "@/hooks/useAccess";
 import { ROLES } from "@/config/permissions";
 
 export default function PrimaryActions({
+  mode,
   advisoryStatusCode,
   isUrgent = false,
   isApprover = false,
@@ -22,13 +23,16 @@ export default function PrimaryActions({
     hasAnyRole([ROLES.ADVISORY_PUBLISH_WITHOUT_APPROVAL]);
 
   // Use the published/scheduled states to decide whether this action is creating or updating public content
-  const publishButtonLabel = useMemo(
-    () =>
-      advisoryStatusCode === "SCH" || advisoryStatusCode === "PUB"
-        ? "Update advisory / closure"
-        : "Create advisory / closure",
-    [advisoryStatusCode],
-  );
+  const publishButtonLabel = useMemo(() => {
+    if (
+      (advisoryStatusCode === "SCH" || advisoryStatusCode === "PUB") &&
+      mode !== "create"
+    ) {
+      return "Update advisory / closure";
+    }
+
+    return "Create advisory / closure";
+  }, [mode, advisoryStatusCode]);
 
   if (!canPublish) {
     // Show a button to submit for review if the user can't publish directly
@@ -54,6 +58,7 @@ export default function PrimaryActions({
 }
 
 PrimaryActions.propTypes = {
+  mode: PropTypes.string.isRequired,
   advisoryStatusCode: PropTypes.string,
   onPublish: PropTypes.func.isRequired,
   onSubmit: PropTypes.func.isRequired,

--- a/frontend/src/components/advisories/composite/advisoryForm/PrimaryActions.jsx
+++ b/frontend/src/components/advisories/composite/advisoryForm/PrimaryActions.jsx
@@ -1,10 +1,11 @@
+import { useMemo } from "react";
 import PropTypes from "prop-types";
 import { Button } from "@/components/advisories/shared/button/Button";
 import useAccess from "@/hooks/useAccess";
 import { ROLES } from "@/config/permissions";
 
 export default function PrimaryActions({
-  mode,
+  advisoryStatusCode,
   isUrgent = false,
   isApprover = false,
   onPublish,
@@ -20,17 +21,18 @@ export default function PrimaryActions({
     isApprover ||
     hasAnyRole([ROLES.ADVISORY_PUBLISH_WITHOUT_APPROVAL]);
 
-  if (mode === "create") {
-    return canPublish ? (
-      // Show a button to publish directly if the user has permission
-      <Button
-        label="Create advisory / closure"
-        styling="btn-primary btn"
-        onClick={onPublish}
-        hasLoader={isSubmitting}
-      />
-    ) : (
-      // Show a button to submit for review if the user can't publish directly
+  // Use the published/scheduled states to decide whether this action is creating or updating public content
+  const publishButtonLabel = useMemo(
+    () =>
+      advisoryStatusCode === "SCH" || advisoryStatusCode === "PUB"
+        ? "Update advisory / closure"
+        : "Create advisory / closure",
+    [advisoryStatusCode],
+  );
+
+  if (!canPublish) {
+    // Show a button to submit for review if the user can't publish directly
+    return (
       <Button
         label="Submit for review"
         styling="btn-primary btn"
@@ -40,31 +42,19 @@ export default function PrimaryActions({
     );
   }
 
-  if (mode === "update") {
-    return canPublish ? (
-      // Show a button to update directly if the user has permission
-      <Button
-        label="Update advisory / closure"
-        styling="btn-primary btn"
-        onClick={onPublish}
-        hasLoader={isSubmitting}
-      />
-    ) : (
-      // Show a button to submit for review if the user can't update directly
-      <Button
-        label="Submit for review"
-        styling="btn-primary btn"
-        onClick={onSubmit}
-        hasLoader={isSubmitting}
-      />
-    );
-  }
-
-  return null;
+  // Show a button to update directly if the user has permission
+  return (
+    <Button
+      label={publishButtonLabel}
+      styling="btn-primary btn"
+      onClick={onPublish}
+      hasLoader={isSubmitting}
+    />
+  );
 }
 
 PrimaryActions.propTypes = {
-  mode: PropTypes.string.isRequired,
+  advisoryStatusCode: PropTypes.string,
   onPublish: PropTypes.func.isRequired,
   onSubmit: PropTypes.func.isRequired,
   isSubmitting: PropTypes.bool,

--- a/frontend/src/router/pages/advisories/advisory/Advisory.jsx
+++ b/frontend/src/router/pages/advisories/advisory/Advisory.jsx
@@ -697,7 +697,7 @@ export default function Advisory({ mode }) {
     }
 
     // advisoryStatus can sometimes be a documentId string
-    // Find the document ID in the advisoryStatuses list
+    // Find the document ID in the allAdvisoryStatuses list
     if (typeof advisoryStatus === "string") {
       return (
         allAdvisoryStatuses.find((status) => status.value === advisoryStatus)

--- a/frontend/src/router/pages/advisories/advisory/Advisory.jsx
+++ b/frontend/src/router/pages/advisories/advisory/Advisory.jsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useContext } from "react";
+import { useState, useRef, useEffect, useContext, useMemo } from "react";
 import { Navigate, useParams } from "react-router-dom";
 import PropTypes from "prop-types";
 import "./Advisory.css";
@@ -53,6 +53,8 @@ export default function Advisory({ mode }) {
   const [urgencies, setUrgencies] = useState([]);
   const [urgency, setUrgency] = useState();
   const [advisoryStatuses, setAdvisoryStatuses] = useState([]);
+  // Unfiltered list of all advisory statuses from the CMS (for code lookup)
+  const [allAdvisoryStatuses, setAllAdvisoryStatuses] = useState([]);
   const [advisoryStatus, setAdvisoryStatus] = useState();
   const [linkTypes, setLinkTypes] = useState([]);
   const [links, setLinks] = useState([]);
@@ -580,6 +582,15 @@ export default function Advisory({ mode }) {
 
           setUrgencies([...newUrgencies]);
           const advisoryStatusData = res[12];
+          // Store the list of all advisory statuses before filtering
+          // so we can reference it later for status code lookup
+          const allStatuses = advisoryStatusData.map((s) => ({
+            code: s.code,
+            value: s.documentId,
+          }));
+
+          setAllAdvisoryStatuses(allStatuses);
+
           const restrictedAdvisoryStatusCodes = new Set(["UNP", "SCH"]);
           const desiredOrder = ["PUB", "UNP", "DFT", "SCH", "HQR"];
           const tempAdvisoryStatuses = advisoryStatusData.map((s) => {
@@ -673,6 +684,29 @@ export default function Advisory({ mode }) {
     getLinkTypes,
     getStandardMessages,
   ]);
+
+  // Get the advisory status code to determine the form action button text
+  const advisoryStatusCode = useMemo(() => {
+    // If advisoryStatus is not set, return null
+    if (!advisoryStatus) return null;
+
+    // advisoryStatus can sometimes be an object
+    // return the code property if it exists
+    if (typeof advisoryStatus === "object") {
+      return advisoryStatus.code ?? null;
+    }
+
+    // advisoryStatus can sometimes be a documentId string
+    // Find the document ID in the advisoryStatuses list
+    if (typeof advisoryStatus === "string") {
+      return (
+        allAdvisoryStatuses.find((status) => status.value === advisoryStatus)
+          ?.code ?? null
+      );
+    }
+
+    return null;
+  }, [advisoryStatus, allAdvisoryStatuses]);
 
   function setToBack() {
     if (mode === "create") {
@@ -1282,6 +1316,7 @@ export default function Advisory({ mode }) {
                   submittedBy,
                   setSubmittedBy,
                   advisoryStatuses,
+                  advisoryStatusCode,
                   advisoryStatus,
                   setAdvisoryStatus,
                   isStatHoliday,


### PR DESCRIPTION
### Jira Ticket

CMS-1671

### Description
<!-- What did you change, and why? -->

A small update to the advisory form submit buttons after a requirement was clarified:

> The ‘Update advisory / closure’ button should show only when the advisory is in scheduled or published state.

If something is a draft or pending review, the button should still say "Create advisory / closure" according to this rule.

Instead of only relying on `mode` ("create" or "update"), we're not checking the advisory status code to determine the button label.

You can test it as a SuperAdmin with the "Advisory status" dropdown where you can directly change the advisoryStatus value.