### PR TITLE
CMS-1759: Add summary action button overflow menu component

### DIFF
--- a/frontend/src/components/advisories/composite/advisoryHistory/AdvisoryHistory.jsx
+++ b/frontend/src/components/advisories/composite/advisoryHistory/AdvisoryHistory.jsx
@@ -108,5 +108,5 @@ export default function AdvisoryHistory({ advisoryNumber, revisionNumber }) {
 
 AdvisoryHistory.propTypes = {
   advisoryNumber: PropTypes.number.isRequired,
-  revisionNumber: PropTypes.number,
+  revisionNumber: PropTypes.number.isRequired,
 };

--- a/frontend/src/components/advisories/shared/summaryActionButton/SummaryActionButton.jsx
+++ b/frontend/src/components/advisories/shared/summaryActionButton/SummaryActionButton.jsx
@@ -1,0 +1,103 @@
+import { useState } from "react";
+import PropTypes from "prop-types";
+import classNames from "classnames";
+import Dropdown from "react-bootstrap/Dropdown";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faChevronDown } from "@fa-kit/icons/classic/solid";
+import { faCircleCheck, faEyeSlash } from "@fa-kit/icons/classic/regular";
+
+import "./SummaryActionButton.scss";
+
+// Overflow menu for actions on the Advisory summary page.
+// Similar to TableActionButton, but displays in place of separate buttons on smaller screens.
+
+const ACTION_MENU_POPPER_CONFIG = {
+  strategy: "fixed",
+  modifiers: [
+    {
+      name: "preventOverflow",
+      options: {
+        altAxis: true,
+        tether: false,
+      },
+    },
+  ],
+};
+
+export default function SummaryActionButton({
+  canUnpublish = false,
+  onUnpublish,
+  canMarkReviewed = false,
+  onMarkReviewed,
+  className = "",
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  function action(callback) {
+    setIsOpen(false);
+    callback();
+  }
+
+  // Don't allow root-close to reopen the dropdown immediately after it's closed
+  function handleToggle(nextIsOpen, _event, metadata) {
+    if (!nextIsOpen && !isOpen && metadata?.source === "rootClose") {
+      return;
+    }
+
+    setIsOpen(nextIsOpen);
+  }
+
+  return (
+    <div
+      className={classNames(
+        "action-button",
+        "summary-action-button",
+        className,
+      )}
+    >
+      <Dropdown
+        show={isOpen}
+        onToggle={handleToggle}
+        className="action-button__dropdown-button d-flex"
+      >
+        <Dropdown.Toggle
+          className="bcgov-button flex-grow-1"
+          id="action-button"
+        >
+          <span>Actions</span>
+          <FontAwesomeIcon
+            icon={faChevronDown}
+            className="action-button__icon ms-2"
+            aria-label="Actions"
+          />
+        </Dropdown.Toggle>
+
+        <Dropdown.Menu renderOnMount popperConfig={ACTION_MENU_POPPER_CONFIG}>
+          <Dropdown.Item
+            disabled={!canUnpublish}
+            onClick={() => action(onUnpublish)}
+          >
+            <FontAwesomeIcon icon={faEyeSlash} />
+            Unpublish
+          </Dropdown.Item>
+
+          <Dropdown.Item
+            disabled={!canMarkReviewed}
+            onClick={() => action(onMarkReviewed)}
+          >
+            <FontAwesomeIcon icon={faCircleCheck} />
+            Mark reviewed
+          </Dropdown.Item>
+        </Dropdown.Menu>
+      </Dropdown>
+    </div>
+  );
+}
+
+SummaryActionButton.propTypes = {
+  canUnpublish: PropTypes.bool,
+  canMarkReviewed: PropTypes.bool,
+  onMarkReviewed: PropTypes.func,
+  onUnpublish: PropTypes.func.isRequired,
+  className: PropTypes.string,
+};

--- a/frontend/src/components/advisories/shared/summaryActionButton/SummaryActionButton.jsx
+++ b/frontend/src/components/advisories/shared/summaryActionButton/SummaryActionButton.jsx
@@ -97,7 +97,7 @@ export default function SummaryActionButton({
 SummaryActionButton.propTypes = {
   canUnpublish: PropTypes.bool,
   canMarkReviewed: PropTypes.bool,
-  onMarkReviewed: PropTypes.func,
+  onMarkReviewed: PropTypes.func.isRequired,
   onUnpublish: PropTypes.func.isRequired,
   className: PropTypes.string,
 };

--- a/frontend/src/components/advisories/shared/summaryActionButton/SummaryActionButton.jsx
+++ b/frontend/src/components/advisories/shared/summaryActionButton/SummaryActionButton.jsx
@@ -5,6 +5,7 @@ import Dropdown from "react-bootstrap/Dropdown";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faChevronDown } from "@fa-kit/icons/classic/solid";
 import { faCircleCheck, faEyeSlash } from "@fa-kit/icons/classic/regular";
+import { Loader } from "@/components/advisories/shared/loader/Loader";
 
 import "./SummaryActionButton.scss";
 
@@ -30,6 +31,7 @@ export default function SummaryActionButton({
   canMarkReviewed = false,
   onMarkReviewed,
   className = "",
+  isRequestingCms = false,
 }) {
   const [isOpen, setIsOpen] = useState(false);
 
@@ -70,11 +72,17 @@ export default function SummaryActionButton({
             className="action-button__icon ms-2"
             aria-label="Actions"
           />
+
+          {isRequestingCms && (
+            <div className="bcgov-loader-show">
+              <Loader />
+            </div>
+          )}
         </Dropdown.Toggle>
 
         <Dropdown.Menu renderOnMount popperConfig={ACTION_MENU_POPPER_CONFIG}>
           <Dropdown.Item
-            disabled={!canUnpublish}
+            disabled={!canUnpublish || isRequestingCms}
             onClick={() => action(onUnpublish)}
           >
             <FontAwesomeIcon icon={faEyeSlash} />
@@ -82,7 +90,7 @@ export default function SummaryActionButton({
           </Dropdown.Item>
 
           <Dropdown.Item
-            disabled={!canMarkReviewed}
+            disabled={!canMarkReviewed || isRequestingCms}
             onClick={() => action(onMarkReviewed)}
           >
             <FontAwesomeIcon icon={faCircleCheck} />
@@ -100,4 +108,5 @@ SummaryActionButton.propTypes = {
   onMarkReviewed: PropTypes.func.isRequired,
   onUnpublish: PropTypes.func.isRequired,
   className: PropTypes.string,
+  isRequestingCms: PropTypes.bool,
 };

--- a/frontend/src/components/advisories/shared/summaryActionButton/SummaryActionButton.jsx
+++ b/frontend/src/components/advisories/shared/summaryActionButton/SummaryActionButton.jsx
@@ -70,7 +70,7 @@ export default function SummaryActionButton({
           <FontAwesomeIcon
             icon={faChevronDown}
             className="action-button__icon ms-2"
-            aria-label="Actions"
+            aria-hidden="true"
           />
 
           {isRequestingCms && (

--- a/frontend/src/components/advisories/shared/summaryActionButton/SummaryActionButton.scss
+++ b/frontend/src/components/advisories/shared/summaryActionButton/SummaryActionButton.scss
@@ -1,0 +1,6 @@
+.summary-action-button {
+  // Increase vertical padding to provide > ~44px tappable area
+  .dropdown-item {
+    padding-block: 0.75rem;
+  }
+}

--- a/frontend/src/router/pages/advisories/advisorySummary/AdvisorySummary.jsx
+++ b/frontend/src/router/pages/advisories/advisorySummary/AdvisorySummary.jsx
@@ -6,6 +6,7 @@ import {
   useSearchParams,
 } from "react-router-dom";
 import { format } from "date-fns";
+import classNames from "classnames";
 import ErrorContext from "@/contexts/ErrorContext";
 import CmsDataContext from "@/contexts/CmsDataContext";
 import FlashMessageContext from "@/contexts/FlashMessageContext";
@@ -28,6 +29,7 @@ import { getLinkTypes } from "@/lib/advisories/utils/CmsDataUtil";
 import { getAdvisoryStatuses } from "@/lib/advisories/utils/CmsDataUtil";
 import AdvisorySummaryView from "@/components/advisories/composite/advisorySummaryView/AdvisorySummaryView";
 import StatusBadge from "@/components/StatusBadge";
+import SummaryActionButton from "@/components/advisories/shared/summaryActionButton/SummaryActionButton";
 import useAccess from "@/hooks/useAccess";
 import useAdvisoryMarkReviewed from "@/hooks/advisories/useAdvisoryMarkReviewed";
 import useAdvisoryUnpublish from "@/hooks/advisories/useAdvisoryUnpublish";
@@ -485,21 +487,43 @@ export default function AdvisorySummary() {
                         </div>
                       </div>
 
-                      <div className="actions mb-4 d-flex gap-2 align-items-start justify-content-center justify-content-xl-end flex-wrap flex-xl-nowrap">
+                      <div className="actions mb-4 d-flex gap-2 align-items-start justify-content-xl-end flex-wrap flex-xl-nowrap">
                         {isApprover && (
-                          <Button
-                            label="Mark reviewed"
-                            styling="btn-outline-primary btn flex-shrink-0"
-                            disabled={isRequestingCms}
-                            onClick={handleMarkReviewed}
-                            hasLoader={isMarkingReviewed}
-                            leftIcon={<FontAwesomeIcon icon={faCircleCheck} />}
-                          />
+                          <>
+                            {/* On smaller screens, show Unpublish and Mark reviewed together in an overflow menu */}
+                            <SummaryActionButton
+                              className="d-xl-none flex-grow-1"
+                              canUnpublish={canUnpublish}
+                              onUnpublish={handleUnpublish}
+                              canMarkReviewed={isApprover}
+                              onMarkReviewed={handleMarkReviewed}
+                            />
+
+                            {/* On larger screens, show Unpublish and Mark reviewed as separate buttons */}
+                            <Button
+                              label="Mark reviewed"
+                              styling="btn-outline-primary btn flex-grow-1 flex-xl-shrink-0 d-none d-xl-block"
+                              disabled={isRequestingCms}
+                              onClick={handleMarkReviewed}
+                              hasLoader={isMarkingReviewed}
+                              leftIcon={
+                                <FontAwesomeIcon icon={faCircleCheck} />
+                              }
+                            />
+                          </>
                         )}
 
                         <Button
                           label="Unpublish"
-                          styling="btn-outline-primary btn flex-shrink-0"
+                          styling={classNames(
+                            "btn-outline-primary",
+                            "btn",
+                            "flex-grow-1",
+                            "flex-xl-shrink-0",
+                            // If the user can mark reviewed, hide the unpublish button on smaller screens
+                            // and show an overflow menu instead,
+                            isApprover ? "d-none d-xl-block" : "",
+                          )}
                           disabled={isRequestingCms || !canUnpublish}
                           onClick={handleUnpublish}
                           hasLoader={isUnpublishing}
@@ -508,7 +532,7 @@ export default function AdvisorySummary() {
 
                         <Button
                           label="Edit"
-                          styling="btn-primary btn flex-shrink-0"
+                          styling="btn-primary btn flex-grow-1 flex-xl-shrink-0"
                           disabled={isRequestingCms}
                           onClick={() => {
                             setToUpdate(true);

--- a/frontend/src/router/pages/advisories/advisorySummary/AdvisorySummary.jsx
+++ b/frontend/src/router/pages/advisories/advisorySummary/AdvisorySummary.jsx
@@ -497,6 +497,7 @@ export default function AdvisorySummary() {
                               onUnpublish={handleUnpublish}
                               canMarkReviewed={isApprover}
                               onMarkReviewed={handleMarkReviewed}
+                              isRequestingCms={isRequestingCms}
                             />
 
                             {/* On larger screens, show Unpublish and Mark reviewed as separate buttons */}


### PR DESCRIPTION
### Jira Ticket

CMS-1759

### Description
<!-- What did you change, and why? -->

This branch adds a "SummaryActionButton" component on the Advisory summary page. It's a copy of the "Action" dropdown from the dashboard/review tables, but tweaked to display larger, and with different options. It serves as an overflow menu on smaller screens, showing the "Mark reviewed" and "Unpublish" options instead of two buttons, side-by-side.

"Unpublish" always shows, but if "Mark reviewed" is showing (with ACT Approver permission), then the two buttons combine into this dropdown on smaller screens.

And here, smaller means less than "XL" 