### PR TITLE
CMS-1730: Update advisory icon in review tab

### DIFF
--- a/frontend/src/constants/reviewStatus.js
+++ b/frontend/src/constants/reviewStatus.js
@@ -1,5 +1,5 @@
 // NEW: Advisories that have never been reviewed (no reviewedDate), the status is either HQR, SCH, or PUB
-// UPDATED: Advisories that have never been reviewed (no reviewedDate), but then updated (modifiedDate > createdAt), the status is either HQR or SCH
+// UPDATED: Advisories that have never been reviewed (no reviewedDate), but then updated (modifiedDate > createdAt), the status is either HQR, SCH, or PUB
 // EXPIRING: Advisories with an expiryDate within the next week
 // EXPIRED: Advisories with an expiryDate in the past, and the status is UNP
 // ENDED: Advisories with an endDate in the past

--- a/frontend/src/lib/advisories/utils/AdvisoryDataUtil.js
+++ b/frontend/src/lib/advisories/utils/AdvisoryDataUtil.js
@@ -28,11 +28,9 @@ function buildAdvisoryReviewStatuses(publicAdvisory, now) {
     !reviewedDate.isValid() &&
     !reviewedByName;
 
-  // Updated advisory, not posted
+  // Updated advisory, posted and not posted, and not yet reviewed, but modified after creation
   const isUpdated =
-    ["HQR", "SCH"].includes(statusCode) &&
-    modifiedDate.isValid() &&
-    modifiedDate.isAfter(createdAt);
+    isNew && modifiedDate.isValid() && modifiedDate.isAfter(createdAt);
 
   // Expiry date approaching within a week
   const isExpiring =


### PR DESCRIPTION
### Jira Ticket

CMS-1730

### Description
<!-- What did you change, and why? -->
- Confirmed that contributors can publish and update advisories without a review. As a result, I included the `PUB` status in the `isUpdated` condition.
- Doc: https://apps.nrs.gov.bc.ca/int/confluence/display/BCPRS/Review+tab+icons