### PR TITLE
CMS-1760: Update preview header

### DIFF
--- a/frontend/src/hooks/advisories/useAdvisoryMarkReviewed.js
+++ b/frontend/src/hooks/advisories/useAdvisoryMarkReviewed.js
@@ -59,7 +59,7 @@ export default function useAdvisoryMarkReviewed({
       const reviewedStatus = resolveReviewedStatus(rowData, advisoryStatuses);
       const isApproving = rowData.advisoryStatus?.code === "HQR";
 
-      if (isApproving && !reviewedStatus?.documentId) {
+      if (!reviewedStatus) {
         openMarkReviewedError(
           "Could not resolve the new status for the reviewed advisory.",
         );
@@ -68,12 +68,7 @@ export default function useAdvisoryMarkReviewed({
 
       try {
         await cmsPut(`public-advisory-audits/${rowData.documentId}`, {
-          data: buildReviewPayload(
-            reviewedStatus?.code,
-            reviewedStatus?.documentId,
-            reviewedByName,
-            isApproving,
-          ),
+          data: buildReviewPayload(reviewedStatus, reviewedByName, isApproving),
         });
 
         openMarkReviewedSuccess(`${rowData.title} was marked as reviewed.`);

--- a/frontend/src/hooks/advisories/useAdvisoryMarkReviewed.js
+++ b/frontend/src/hooks/advisories/useAdvisoryMarkReviewed.js
@@ -1,7 +1,6 @@
 import { useCallback } from "react";
 import { isFuture, isValid, parseISO } from "date-fns";
 
-import { ADVISORY_QUERY } from "@/constants/advisoryQuery";
 import { buildReviewPayload } from "@/lib/advisories/utils/AdvisoryReviewPayload";
 import useCms from "@/hooks/useCms";
 
@@ -53,29 +52,27 @@ export default function useAdvisoryMarkReviewed({
   openMarkReviewedSuccess,
   onSuccess,
 }) {
-  const { cmsGet, cmsPut } = useCms();
+  const { cmsPut } = useCms();
 
   return useCallback(
     async (rowData) => {
       const reviewedStatus = resolveReviewedStatus(rowData, advisoryStatuses);
+      const isApproving = rowData.advisoryStatus?.code === "HQR";
 
-      if (!reviewedStatus?.documentId) {
+      if (isApproving && !reviewedStatus?.documentId) {
         openMarkReviewedError(
-          "Could not resolve the status for the reviewed advisory.",
+          "Could not resolve the new status for the reviewed advisory.",
         );
         return;
       }
 
       try {
-        const advisoryData = await cmsGet(
-          `public-advisory-audits/${rowData.documentId}?${ADVISORY_QUERY}`,
-        );
-
         await cmsPut(`public-advisory-audits/${rowData.documentId}`, {
           data: buildReviewPayload(
-            advisoryData,
-            reviewedStatus.documentId,
+            reviewedStatus?.code,
+            reviewedStatus?.documentId,
             reviewedByName,
+            isApproving,
           ),
         });
 
@@ -90,7 +87,6 @@ export default function useAdvisoryMarkReviewed({
     },
     [
       advisoryStatuses,
-      cmsGet,
       cmsPut,
       reviewedByName,
       onSuccess,

--- a/frontend/src/lib/advisories/utils/AdvisoryReviewPayload.js
+++ b/frontend/src/lib/advisories/utils/AdvisoryReviewPayload.js
@@ -1,31 +1,32 @@
 /**
  * Build the review payload
- * @param {string} reviewedStatusCode The code of the reviewed status
- * @param {string} reviewedStatusDocumentId The documentId of the reviewed status
+ * @param {Object} newAdvisoryStatus The effective advisory status after review is complete
  * @param {string} reviewedByName The current user's name (from auth.user?.profile?.name)
  * @param {boolean} isApproving True when HQR transitions to PUB or SCH, false otherwise
  * @returns {Object} Minimal payload containing only fields updated by mark reviewed
  */
 export function buildReviewPayload(
-  reviewedStatusCode,
-  reviewedStatusDocumentId,
+  newAdvisoryStatus,
   reviewedByName,
   isApproving = false,
 ) {
   const reviewedDate = new Date().toISOString();
+
+  // always update reviewedByName and reviewedDate
   const payload = {
     reviewedByName,
     reviewedDate,
   };
 
+  // special cases for transitioning from HQR to PUB or SCH
   if (isApproving) {
-    payload.advisoryStatus = reviewedStatusDocumentId;
+    payload.advisoryStatus = newAdvisoryStatus.documentId;
 
-    if (reviewedStatusCode === "PUB") {
+    if (newAdvisoryStatus.code === "PUB") {
       payload.publishedByName = reviewedByName;
       payload.publishedDate = reviewedDate;
     }
-    if (reviewedStatusCode === "SCH") {
+    if (newAdvisoryStatus.code === "SCH") {
       payload.modifiedByName = reviewedByName;
       payload.modifiedDate = reviewedDate;
     }

--- a/frontend/src/lib/advisories/utils/AdvisoryReviewPayload.js
+++ b/frontend/src/lib/advisories/utils/AdvisoryReviewPayload.js
@@ -1,68 +1,35 @@
-import moment from "moment";
-
-/**
- * Maps an array of CMS relation objects to an array of their documentIds.
- * @param {Array|null} items Array of CMS objects with a documentId property, or null
- * @returns {Array<string>} Array of documentId strings
- */
-function mapDocumentIds(items) {
-  return (items || []).map((item) => item.documentId);
-}
-
 /**
  * Build the review payload
- * @param {Object} advisoryData The full advisory record fetched from CMS
- * @param {string} reviewedStatusId The documentId of the reviewed status
+ * @param {string} reviewedStatusCode The code of the reviewed status
+ * @param {string} reviewedStatusDocumentId The documentId of the reviewed status
  * @param {string} reviewedByName The current user's name (from auth.user?.profile?.name)
- * @returns {Object} The normalized payload ready for cmsPut
+ * @param {boolean} isApproving True when HQR transitions to PUB or SCH, false otherwise
+ * @returns {Object} Minimal payload containing only fields updated by mark reviewed
  */
 export function buildReviewPayload(
-  advisoryData,
-  reviewedStatusId,
+  reviewedStatusCode,
+  reviewedStatusDocumentId,
   reviewedByName,
+  isApproving = false,
 ) {
-  const reviewedDate = moment().toISOString();
-
-  return {
-    title: advisoryData.title,
-    description: advisoryData.description,
-    revisionNumber: advisoryData.revisionNumber,
-    isSafetyRelated: advisoryData.isSafetyRelated,
-    listingRank: advisoryData.listingRank,
-    note: advisoryData.note,
-    submittedByName: advisoryData.submittedByName,
-    updatedDate: advisoryData.updatedDate,
-    modifiedDate: reviewedDate,
-    modifiedByName: reviewedByName,
-    modifiedByRole: "approver",
-    advisoryDate: advisoryData.advisoryDate,
-    effectiveDate: advisoryData.effectiveDate,
-    endDate: advisoryData.endDate,
-    expiryDate: advisoryData.expiryDate,
-    accessStatus: advisoryData.accessStatus?.documentId || null,
-    eventType: advisoryData.eventType?.documentId || null,
-    urgency: advisoryData.urgency?.documentId || null,
-    standardMessages: mapDocumentIds(advisoryData.standardMessages),
-    protectedAreas: mapDocumentIds(advisoryData.protectedAreas),
-    advisoryStatus: reviewedStatusId,
-    links: mapDocumentIds(advisoryData.links),
-    regions: mapDocumentIds(advisoryData.regions),
-    sections: mapDocumentIds(advisoryData.sections),
-    managementAreas: mapDocumentIds(advisoryData.managementAreas),
-    sites: mapDocumentIds(advisoryData.sites),
-    fireCentres: mapDocumentIds(advisoryData.fireCentres),
-    fireZones: mapDocumentIds(advisoryData.fireZones),
-    naturalResourceDistricts: mapDocumentIds(
-      advisoryData.naturalResourceDistricts,
-    ),
-    recreationResources: mapDocumentIds(advisoryData.recreationResources),
-    isAdvisoryDateDisplayed: advisoryData.isAdvisoryDateDisplayed,
-    isEffectiveDateDisplayed: advisoryData.isEffectiveDateDisplayed,
-    isEndDateDisplayed: advisoryData.isEndDateDisplayed,
-    isUpdatedDateDisplayed: advisoryData.isUpdatedDateDisplayed,
+  const reviewedDate = new Date().toISOString();
+  const payload = {
     reviewedByName,
     reviewedDate,
-    publishedAt: advisoryData.publishedAt,
-    isLatestRevision: advisoryData.isLatestRevision,
   };
+
+  if (isApproving) {
+    payload.advisoryStatus = reviewedStatusDocumentId;
+
+    if (reviewedStatusCode === "PUB") {
+      payload.publishedByName = reviewedByName;
+      payload.publishedDate = reviewedDate;
+    }
+    if (reviewedStatusCode === "SCH") {
+      payload.modifiedByName = reviewedByName;
+      payload.modifiedDate = reviewedDate;
+    }
+  }
+
+  return payload;
 }

--- a/frontend/src/router/pages/advisories/advisorySummary/AdvisorySummary.jsx
+++ b/frontend/src/router/pages/advisories/advisorySummary/AdvisorySummary.jsx
@@ -315,20 +315,25 @@ export default function AdvisorySummary() {
       : baseUrl;
   }, [documentId, tabParam]);
 
+  // Helper function to build a timestamp string with an actor name
+  const buildTimestampString = useCallback((prefix, actorName, timestamp) => {
+    if (!timestamp) return "";
+    const formattedDate = format(timestamp, "EEE, MMMM dd, yyyy h:mm aaa");
+    const actorSuffix = actorName ? ` by ${actorName}` : "";
+
+    return `${prefix} ${formattedDate}${actorSuffix}`;
+  }, []);
+
   // Formatted string for "Last updated..." timestamp
   const lastUpdatedString = useMemo(() => {
     if (!advisory.modifiedDate) return null;
 
-    const modifiedDate = format(
+    return buildTimestampString(
+      "Last updated",
+      advisory.modifiedByName,
       advisory.modifiedDate,
-      "EEE, MMMM dd, yyyy h:mm aaa",
     );
-    const modifiedByName = advisory.modifiedByName
-      ? ` by ${advisory.modifiedByName}`
-      : "";
-
-    return `Last updated ${modifiedDate}${modifiedByName}`;
-  }, [advisory.modifiedDate, advisory.modifiedByName]);
+  }, [advisory.modifiedDate, advisory.modifiedByName, buildTimestampString]);
 
   // Formatted string for "Posted..." timestamp, if any
   const postingDateString = useMemo(() => {
@@ -337,10 +342,27 @@ export default function AdvisorySummary() {
     // Only display for published or scheduled advisories
     if (advisoryStatusCode !== "SCH" && advisoryStatusCode !== "PUB") return "";
 
-    const prefix = advisoryStatusCode === "PUB" ? "Posted" : "Posting";
+    const prefix =
+      advisoryStatusCode === "PUB" ? "Posted" : "Scheduled posting";
 
-    return `${prefix} ${format(advisory.advisoryDate, "EEE, MMMM dd, yyyy h:mm aaa")}`;
-  }, [advisory.advisoryDate, advisoryStatusCode]);
+    return buildTimestampString(prefix, null, advisory.advisoryDate);
+  }, [advisory.advisoryDate, advisoryStatusCode, buildTimestampString]);
+
+  // Formatted string for "Reviewed..." timestamp, if any
+  const reviewedDateString = useMemo(() => {
+    if (!advisory.reviewedDate) return null;
+
+    // don't show reviewed info if it's the same as the modified info
+    if (advisory.reviewedByName === advisory.modifiedByName) {
+      return null;
+    }
+
+    return buildTimestampString(
+      "Reviewed",
+      advisory.reviewedByName,
+      advisory.reviewedDate,
+    );
+  }, [advisory.reviewedDate, advisory.reviewedByName, advisory.modifiedByName, buildTimestampString]);
 
   // Determine if the advisory can be unpublished
   const canUnpublish = useMemo(() => {
@@ -480,7 +502,11 @@ export default function AdvisorySummary() {
                             <p className="mb-2">{postingDateString}</p>
                           )}
 
-                          {lastUpdatedString && <p>{lastUpdatedString}</p>}
+                          {lastUpdatedString && (
+                            <p className="mb-2">{lastUpdatedString}</p>
+                          )}
+
+                          {reviewedDateString && <p>{reviewedDateString}</p>}
                         </div>
                       </div>
 


### PR DESCRIPTION
### Jira Ticket

CMS-1760

### Description
- Add `reviewedByName` and `reviewedDate` to the preview page header
  - This only shows if the reviewer is a different person than the Posted or Scheduled posting line above.
- Updated the label for scheduled advisory dates to "Scheduled posting" instead of just "Posting"
- Moved some repeated string formatting logic to a helper function.

Also fixed an issue from #571 where the `useAdvisoryMarkReviewed` payload contained unnecessary data. A Strapi PUT request only needs to include fields that are being updated. Part of the payload was the `modifiedByName` and `modifiedDate` fields which should be different than the reviewedByName and reviewedDate but #571 made it so they were always the same, breaking a display condition in this PR noted here: https://github.com/bcgov/bcparks-staff-portal/pull/596#discussion_r3343392342

