### PR TITLE
CMS-1613: Add datesCanSpan2Years to Feature sync script

### DIFF
--- a/backend/migrations/20260601120000-add-dates-can-span-2-years-to-feature.js
+++ b/backend/migrations/20260601120000-add-dates-can-span-2-years-to-feature.js
@@ -1,0 +1,16 @@
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    // Add the new column to the Features table
+    await queryInterface.addColumn("Features", "datesCanSpan2Years", {
+      type: Sequelize.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    });
+  },
+
+  // Remove the column from the Features table
+  async down(queryInterface, Sequelize) {
+    await queryInterface.removeColumn("Features", "datesCanSpan2Years");
+  },
+};

--- a/backend/models/feature.js
+++ b/backend/models/feature.js
@@ -77,6 +77,12 @@ export default (sequelize) => {
         defaultValue: false,
       },
 
+      datesCanSpan2Years: {
+        type: DataTypes.BOOLEAN,
+        allowNull: false,
+        defaultValue: false,
+      },
+
       orcsFeatureNumber: {
         type: DataTypes.STRING,
         allowNull: true,

--- a/backend/strapi-sync/import-features/README.md
+++ b/backend/strapi-sync/import-features/README.md
@@ -6,26 +6,27 @@ Imports and updates `Feature` records from Strapi's `park-feature` collection by
 
 - Fetches park feature data from Strapi using sync utilities
 - Matches existing DOOT features by comparing Strapi `orcsFeatureNumber` with DOOT `orcsFeatureNumber`
-- Sets the `parkId` field in DOOT Feature by matching Strapi `protectedArea.orcs` to DOOT `park.orcs`
-- Sets the `featureTypeId` relation by matching Strapi `parkFeature.featureTypeId` to DOOT `featureType.strapiId`.
+- Sets the `parkId` field in DOOT Feature by matching Strapi `protectedArea.orcs` to DOOT `Park.orcs`
+- Sets the `featureTypeId` relation by matching Strapi `parkFeatureType.featureTypeId` to DOOT `FeatureType.featureTypeNumber`.
 - Sets the `parkAreaId` relation by matching Strapi `parkArea.orcsAreaNumber` to DOOT `parkArea.orcsAreaNumber`.
 - Creates or updates feature records with name, active status, reservation system flags, and park relation
 - Uses efficient Map-based lookup for fast matching between systems
 
 **Data mapping:**
 
-| Strapi Field                    | DOOT Field              | Notes                                        |
-| ------------------------------- | ----------------------- | -------------------------------------------- |
-| `parkFeatureName`               | `name`                  | Feature name                                 |
-| `orcsFeatureNumber`             | `orcsFeatureNumber`     | Used for matching existing records           |
-| `isActive`                      | `active`                | Defaults to `true` if not provided           |
-| `inReservationSystem`           | `inReservationSystem`   | Defaults to `false` if not provided          |
-| `hasReservations`               | `hasReservations`       | Defaults to `false` if not provided          |
-| `hasBackcountryPermits`         | `hasBackcountryPermits` | Defaults to `false` if not provided          |
-| `hasDates`                      | `hasDates`              | Defaults to `false` if not provided          |
-| `parkFeatureType.featureTypeId` | `featureTypeId`         | DOOT Feature Type, matched by well-known key |
-| `protectedArea.orcs`            | `parkId`                | DOOT Park, matched by well-known key         |
-| `parkArea.orcsAreaNumber`       | `parkAreaId`            | DOOT Park Area, matched by well-known key    |
+| Strapi Field                    | DOOT Field              | Notes                                         |
+| ------------------------------- | ----------------------- | --------------------------------------------- |
+| `parkFeatureName`               | `name`                  | Feature name                                  |
+| `orcsFeatureNumber`             | `orcsFeatureNumber`     | Used for matching existing records            |
+| `isActive`                      | `active`                | Defaults to `false` if not provided           |
+| `inReservationSystem`           | `inReservationSystem`   | Defaults to `false` if not provided           |
+| `hasReservations`               | `hasReservations`       | Defaults to `false` if not provided           |
+| `hasBackcountryPermits`         | `hasBackcountryPermits` | Defaults to `false` if not provided           |
+| `hasDates`                      | `hasDates`              | Defaults to `false` if not provided           |
+| `datesCanSpan2Years`            | `datesCanSpan2Years`    | Required boolean from Strapi (`true`/`false`) |
+| `parkFeatureType.featureTypeId` | `featureTypeId`         | DOOT Feature Type, matched by well-known key  |
+| `protectedArea.orcs`            | `parkId`                | DOOT Park, matched by well-known key          |
+| `parkArea.orcsAreaNumber`       | `parkAreaId`            | DOOT Park Area, matched by well-known key     |
 
 ## Transaction Safety
 

--- a/backend/strapi-sync/import-features/import-features.js
+++ b/backend/strapi-sync/import-features/import-features.js
@@ -106,6 +106,7 @@ export default async function importStrapiFeatures(transaction = null) {
         hasReservations,
         hasBackcountryPermits,
         hasDates,
+        datesCanSpan2Years,
         protectedArea,
         parkArea,
         parkFeatureType,
@@ -164,12 +165,13 @@ export default async function importStrapiFeatures(transaction = null) {
 
       const dootFeatureToSave = {
         name: parkFeatureName,
-        orcsFeatureNumber: orcsFeatureNumber,
+        orcsFeatureNumber,
         active: isActive ?? false,
         inReservationSystem: inReservationSystem ?? false,
         hasReservations: hasReservations ?? false,
         hasBackcountryPermits: hasBackcountryPermits ?? false,
         hasDates: hasDates ?? false,
+        datesCanSpan2Years,
         parkId,
         parkAreaId,
         featureTypeId,

--- a/frontend/src/components/DateRangeFields.jsx
+++ b/frontend/src/components/DateRangeFields.jsx
@@ -133,6 +133,7 @@ export default function DateRangeFields({
   dateRangeAnnuals,
   updateDateRangeAnnual,
   optional = false,
+  canSpan2Years = false,
 }) {
   const { elements } = useValidationContext();
   // Constants
@@ -197,7 +198,13 @@ export default function DateRangeFields({
   } else {
     // Regular seasons
     minDate = new Date(operatingYear, 0, 1); // Jan 1 of the season's operating year
-    maxDate = new Date(operatingYear, 11, 31); // Dec 31 of the season's operating year
+
+    // Some features can have dates that span 2 years, so adjust the max allowed date
+    if (canSpan2Years) {
+      maxDate = new Date(operatingYear + 1, 11, 31); // Dec 31 of the year after the operating year
+    } else {
+      maxDate = new Date(operatingYear, 11, 31); // Dec 31 of the season's operating year
+    }
   }
 
   return (
@@ -277,4 +284,5 @@ DateRangeFields.propTypes = {
   dateRangeAnnuals: PropTypes.arrayOf(PropTypes.object).isRequired,
   updateDateRangeAnnual: PropTypes.func.isRequired,
   optional: PropTypes.bool,
+  canSpan2Years: PropTypes.bool,
 };

--- a/frontend/src/components/SeasonForms/AreaSeasonForm.jsx
+++ b/frontend/src/components/SeasonForms/AreaSeasonForm.jsx
@@ -88,6 +88,7 @@ function FeatureFormSectionComponent({
             dateRangeAnnuals={dateRangeAnnuals}
             updateDateRangeAnnual={updateDateRangeAnnual}
             optional={isDateTypeOptional(dateType.dateTypeNumber, "feature")}
+            canSpan2Years={feature.datesCanSpan2Years}
           />
         </div>
       ))}
@@ -117,6 +118,7 @@ FeatureFormSectionComponent.propTypes = {
     dateable: PropTypes.shape({
       dateRanges: PropTypes.arrayOf(dateRangeShape),
     }),
+    datesCanSpan2Years: PropTypes.bool.isRequired,
   }).isRequired,
   featureDateTypes: PropTypes.arrayOf(
     PropTypes.shape({

--- a/frontend/src/components/SeasonForms/FeatureSeasonForm.jsx
+++ b/frontend/src/components/SeasonForms/FeatureSeasonForm.jsx
@@ -178,6 +178,7 @@ function FormSection({ dateTypes, feature, season, previousSeasonDates }) {
             dateRangeAnnuals={dateRangeAnnuals}
             updateDateRangeAnnual={updateDateRangeAnnual}
             optional={isDateTypeOptional(dateType.dateTypeNumber, "feature")}
+            canSpan2Years={feature.datesCanSpan2Years}
           />
 
           <ErrorSlot element={elements.dateableSection(feature.dateableId)} />

--- a/frontend/src/hooks/useValidation/rules/dateInOperatingYear.js
+++ b/frontend/src/hooks/useValidation/rules/dateInOperatingYear.js
@@ -1,4 +1,4 @@
-import { getYear } from "date-fns";
+import { isWithinInterval } from "date-fns";
 
 /**
  * Validates that the date ranges are within the operating year.
@@ -16,19 +16,41 @@ export default function dateInOperatingYear(seasonData, context) {
     // Skip winter dates, since they all break this rule
     if (dateRange.dateType.name === "Winter fee") return;
 
-    if (dateRange.startDate && getYear(dateRange.startDate) !== operatingYear) {
+    // Create a date interval to check against the dates
+    const minAllowedDate = new Date(operatingYear, 0, 1);
+    let maxAllowedDate = new Date(operatingYear, 11, 31);
+    let yearErrorMessage = `Enter dates for ${operatingYear} only`;
+
+    // Some features can have dates that span 2 years, so adjust the max allowed date
+    if (dateRange.datesCanSpan2Years) {
+      maxAllowedDate = new Date(operatingYear + 1, 11, 31);
+      yearErrorMessage = `Enter dates for ${operatingYear}–${operatingYear + 1} only`;
+    }
+
+    const allowedDateInterval = {
+      start: minAllowedDate,
+      end: maxAllowedDate,
+    };
+
+    if (
+      dateRange.startDate &&
+      !isWithinInterval(dateRange.startDate, allowedDateInterval)
+    ) {
       context.addError(
-        // Show the error below the end date field
+        // Show the error below the start date field
         elements.dateField(dateRange.id || dateRange.tempId, "startDate"),
-        `Enter dates for ${operatingYear} only`,
+        yearErrorMessage,
       );
     }
 
-    if (dateRange.endDate && getYear(dateRange.endDate) !== operatingYear) {
+    if (
+      dateRange.endDate &&
+      !isWithinInterval(dateRange.endDate, allowedDateInterval)
+    ) {
       context.addError(
         // Show the error below the end date field
         elements.dateField(dateRange.id || dateRange.tempId, "endDate"),
-        `Enter dates for ${operatingYear} only`,
+        yearErrorMessage,
       );
     }
   });

--- a/frontend/src/hooks/useValidation/useValidation.js
+++ b/frontend/src/hooks/useValidation/useValidation.js
@@ -43,13 +43,25 @@ const elements = {
 };
 
 /**
- * Adds the Strapi Feature Type number to a date range object as `featureTypeNumber`
- * @param {number} featureTypeNumber The Strapi Feature Type number to add to the date range
+ * Adds feature metadata to a date range object for validation purposes.
+ * - featureTypeNumber: The Strapi Feature Type number
+ * - datesCanSpan2Years: A flag for whether the feature's dates can span 2 years
+ * @param {Object} feature The feature object containing metadata
  * @param {Object} dateRange The date range object
- * @returns {Object} The date range object with the added `featureTypeNumber` property
+ * @returns {Object} The date range object with added feature metadata
  */
-function addFeatureTypeToDateRange(featureTypeNumber, dateRange) {
-  return { ...dateRange, featureTypeNumber };
+function addFeatureMetadataToDateRange(feature, dateRange) {
+  return {
+    ...dateRange,
+
+    // Add the Strapi Feature Type number to the date range for validation rules that need it
+    // (Winter fee/Tier 1 and 2 rules)
+    featureTypeNumber: feature.featureType.featureTypeNumber,
+
+    // Add a flag for whether the feature's dates can span 2 years, for validation rules that need it
+    // ("Date in operating year")
+    datesCanSpan2Years: feature.datesCanSpan2Years,
+  };
 }
 
 /**
@@ -104,11 +116,8 @@ function validate(seasonData, seasonContext) {
     // just include all feature-level dates within the parkArea.
     const featureDateRanges = current.parkArea.features.flatMap((feature) =>
       feature.dateable.dateRanges.map((dateRange) =>
-        // Add feature type for validation rules that need it (Winter fee/Tier 1 and 2 rules)
-        addFeatureTypeToDateRange(
-          feature.featureType.featureTypeNumber,
-          dateRange,
-        ),
+        // Add feature metadata for validation rules that need it
+        addFeatureMetadataToDateRange(feature, dateRange),
       ),
     );
 
@@ -116,16 +125,12 @@ function validate(seasonData, seasonContext) {
   } else if (level === "feature") {
     const { feature } = current;
 
-    // Add feature type for validation rules that need it (Winter fee/Tier 1 and 2 rules)
-    const dateRangesWithFeatureType = feature.dateable.dateRanges.map(
-      (dateRange) =>
-        addFeatureTypeToDateRange(
-          feature.featureType.featureTypeNumber,
-          dateRange,
-        ),
+    // Add feature metadata for validation rules that need it
+    const dateRangesWithMetadata = feature.dateable.dateRanges.map(
+      (dateRange) => addFeatureMetadataToDateRange(feature, dateRange),
     );
 
-    dateRanges.push(...dateRangesWithFeatureType);
+    dateRanges.push(...dateRangesWithMetadata);
   }
 
   validationContext.dateRanges = dateRanges;


### PR DESCRIPTION
### Jira Ticket

CMS-1613

### Description
<!-- What did you change, and why? -->

This branch adds a non-nullable boolean field called `datesCanSpan2Years` to the Feature model in the DOOT DB, and updates the Strapi sync script to pull the values from the [Strapi field with the same name](https://github.com/bcgov/bcparks.ca/pull/1845).

Marked "Do not merge" while UAT is happening but ready for review whenever. I'll follow up in another PR with the validation changes.

Created and added the v2.5.0 tag for this ticket after our re-shuffling this week 👍 Let me know if it should be something else.

For local testing: remember to run `npm run migrate` and `npm run cron-task` to add the new db field and populate it from Strapi