### PR TITLE
CMS-1613: Add canSpan2Years feature date validation

### DIFF
--- a/frontend/src/components/DateRangeFields.jsx
+++ b/frontend/src/components/DateRangeFields.jsx
@@ -133,6 +133,7 @@ export default function DateRangeFields({
   dateRangeAnnuals,
   updateDateRangeAnnual,
   optional = false,
+  canSpan2Years = false,
 }) {
   const { elements } = useValidationContext();
   // Constants
@@ -197,7 +198,13 @@ export default function DateRangeFields({
   } else {
     // Regular seasons
     minDate = new Date(operatingYear, 0, 1); // Jan 1 of the season's operating year
-    maxDate = new Date(operatingYear, 11, 31); // Dec 31 of the season's operating year
+
+    // Some features can have dates that span 2 years, so adjust the max allowed date
+    if (canSpan2Years) {
+      maxDate = new Date(operatingYear + 1, 11, 31); // Dec 31 of the year after the operating year
+    } else {
+      maxDate = new Date(operatingYear, 11, 31); // Dec 31 of the season's operating year
+    }
   }
 
   return (
@@ -277,4 +284,5 @@ DateRangeFields.propTypes = {
   dateRangeAnnuals: PropTypes.arrayOf(PropTypes.object).isRequired,
   updateDateRangeAnnual: PropTypes.func.isRequired,
   optional: PropTypes.bool,
+  canSpan2Years: PropTypes.bool,
 };

--- a/frontend/src/components/SeasonForms/AreaSeasonForm.jsx
+++ b/frontend/src/components/SeasonForms/AreaSeasonForm.jsx
@@ -88,6 +88,7 @@ function FeatureFormSectionComponent({
             dateRangeAnnuals={dateRangeAnnuals}
             updateDateRangeAnnual={updateDateRangeAnnual}
             optional={isDateTypeOptional(dateType.dateTypeNumber, "feature")}
+            canSpan2Years={feature.datesCanSpan2Years}
           />
         </div>
       ))}
@@ -117,6 +118,7 @@ FeatureFormSectionComponent.propTypes = {
     dateable: PropTypes.shape({
       dateRanges: PropTypes.arrayOf(dateRangeShape),
     }),
+    datesCanSpan2Years: PropTypes.bool.isRequired,
   }).isRequired,
   featureDateTypes: PropTypes.arrayOf(
     PropTypes.shape({

--- a/frontend/src/components/SeasonForms/FeatureSeasonForm.jsx
+++ b/frontend/src/components/SeasonForms/FeatureSeasonForm.jsx
@@ -178,6 +178,7 @@ function FormSection({ dateTypes, feature, season, previousSeasonDates }) {
             dateRangeAnnuals={dateRangeAnnuals}
             updateDateRangeAnnual={updateDateRangeAnnual}
             optional={isDateTypeOptional(dateType.dateTypeNumber, "feature")}
+            canSpan2Years={feature.datesCanSpan2Years}
           />
 
           <ErrorSlot element={elements.dateableSection(feature.dateableId)} />

--- a/frontend/src/hooks/useValidation/rules/dateInOperatingYear.js
+++ b/frontend/src/hooks/useValidation/rules/dateInOperatingYear.js
@@ -1,4 +1,4 @@
-import { getYear } from "date-fns";
+import { isWithinInterval } from "date-fns";
 
 /**
  * Validates that the date ranges are within the operating year.
@@ -16,19 +16,41 @@ export default function dateInOperatingYear(seasonData, context) {
     // Skip winter dates, since they all break this rule
     if (dateRange.dateType.name === "Winter fee") return;
 
-    if (dateRange.startDate && getYear(dateRange.startDate) !== operatingYear) {
+    // Create a date interval to check against the dates
+    const minAllowedDate = new Date(operatingYear, 0, 1);
+    let maxAllowedDate = new Date(operatingYear, 11, 31);
+    let yearErrorMessage = `Enter dates for ${operatingYear} only`;
+
+    // Some features can have dates that span 2 years, so adjust the max allowed date
+    if (dateRange.datesCanSpan2Years) {
+      maxAllowedDate = new Date(operatingYear + 1, 11, 31);
+      yearErrorMessage = `Enter dates for ${operatingYear}–${operatingYear + 1} only`;
+    }
+
+    const allowedDateInterval = {
+      start: minAllowedDate,
+      end: maxAllowedDate,
+    };
+
+    if (
+      dateRange.startDate &&
+      !isWithinInterval(dateRange.startDate, allowedDateInterval)
+    ) {
       context.addError(
-        // Show the error below the end date field
+        // Show the error below the start date field
         elements.dateField(dateRange.id || dateRange.tempId, "startDate"),
-        `Enter dates for ${operatingYear} only`,
+        yearErrorMessage,
       );
     }
 
-    if (dateRange.endDate && getYear(dateRange.endDate) !== operatingYear) {
+    if (
+      dateRange.endDate &&
+      !isWithinInterval(dateRange.endDate, allowedDateInterval)
+    ) {
       context.addError(
         // Show the error below the end date field
         elements.dateField(dateRange.id || dateRange.tempId, "endDate"),
-        `Enter dates for ${operatingYear} only`,
+        yearErrorMessage,
       );
     }
   });

--- a/frontend/src/hooks/useValidation/useValidation.js
+++ b/frontend/src/hooks/useValidation/useValidation.js
@@ -126,11 +126,11 @@ function validate(seasonData, seasonContext) {
     const { feature } = current;
 
     // Add feature metadata for validation rules that need it
-    const dateRangesWithFeatureType = feature.dateable.dateRanges.map(
+    const dateRangesWithMetadata = feature.dateable.dateRanges.map(
       (dateRange) => addFeatureMetadataToDateRange(feature, dateRange),
     );
 
-    dateRanges.push(...dateRangesWithFeatureType);
+    dateRanges.push(...dateRangesWithMetadata);
   }
 
   validationContext.dateRanges = dateRanges;

--- a/frontend/src/hooks/useValidation/useValidation.js
+++ b/frontend/src/hooks/useValidation/useValidation.js
@@ -43,13 +43,25 @@ const elements = {
 };
 
 /**
- * Adds the Strapi Feature Type number to a date range object as `featureTypeNumber`
- * @param {number} featureTypeNumber The Strapi Feature Type number to add to the date range
+ * Adds feature metadata to a date range object for validation purposes.
+ * - featureTypeNumber: The Strapi Feature Type number
+ * - datesCanSpan2Years: A flag for whether the feature's dates can span 2 years
+ * @param {Object} feature The feature object containing metadata
  * @param {Object} dateRange The date range object
- * @returns {Object} The date range object with the added `featureTypeNumber` property
+ * @returns {Object} The date range object with added feature metadata
  */
-function addFeatureTypeToDateRange(featureTypeNumber, dateRange) {
-  return { ...dateRange, featureTypeNumber };
+function addFeatureMetadataToDateRange(feature, dateRange) {
+  return {
+    ...dateRange,
+
+    // Add the Strapi Feature Type number to the date range for validation rules that need it
+    // (Winter fee/Tier 1 and 2 rules)
+    featureTypeNumber: feature.featureType.featureTypeNumber,
+
+    // Add a flag for whether the feature's dates can span 2 years, for validation rules that need it
+    // ("Date in operating year")
+    datesCanSpan2Years: feature.datesCanSpan2Years,
+  };
 }
 
 /**
@@ -104,11 +116,8 @@ function validate(seasonData, seasonContext) {
     // just include all feature-level dates within the parkArea.
     const featureDateRanges = current.parkArea.features.flatMap((feature) =>
       feature.dateable.dateRanges.map((dateRange) =>
-        // Add feature type for validation rules that need it (Winter fee/Tier 1 and 2 rules)
-        addFeatureTypeToDateRange(
-          feature.featureType.featureTypeNumber,
-          dateRange,
-        ),
+        // Add feature metadata for validation rules that need it
+        addFeatureMetadataToDateRange(feature, dateRange),
       ),
     );
 
@@ -116,13 +125,9 @@ function validate(seasonData, seasonContext) {
   } else if (level === "feature") {
     const { feature } = current;
 
-    // Add feature type for validation rules that need it (Winter fee/Tier 1 and 2 rules)
+    // Add feature metadata for validation rules that need it
     const dateRangesWithFeatureType = feature.dateable.dateRanges.map(
-      (dateRange) =>
-        addFeatureTypeToDateRange(
-          feature.featureType.featureTypeNumber,
-          dateRange,
-        ),
+      (dateRange) => addFeatureMetadataToDateRange(feature, dateRange),
     );
 
     dateRanges.push(...dateRangesWithFeatureType);


### PR DESCRIPTION
CMS-1613: Add canSpan2Years prop to DateRangeFields

### Jira Ticket

CMS-1613

### Description
<!-- What did you change, and why? -->

Added the frontend changes for the Feature.datesCanSpan2Years field added in #597 

If the flag is set on the Feature, all of its DateRanges will be validated differently: Instead of checking that they're inside the operating year, they'll be checked against a 2-year interval (operating year, and the year after that)

To do this, I added a `canSpan2Years` prop to the DateRangeFields component so the calendar picker allows the user to pick dates in the next year, and I added the `datesCanSpan2Years` field to the validation context object to affect the "dateInOperatingYear" validation logic.

This will merge into the "span 2 years" base branch with the DB changes, but that branch will not be merged until after UAT. I just split these PRs up for ease of reviewing.