### PR TITLE
CMS-1802: Change archived to unpublished

### DIFF
--- a/frontend/src/components/StatusBadge.scss
+++ b/frontend/src/components/StatusBadge.scss
@@ -20,8 +20,7 @@
     &.status-published {
       background-color: var(--primary-light-blue, #c7e3fd) !important;
     }
-    &.status-unpublished,
-    &.status-archived {
+    &.status-unpublished {
       background-color: var(--secondary-light-brown-01, #f2f0eb) !important;
     }
   }

--- a/frontend/src/components/advisories/shared/filterStatus/FilterStatus.jsx
+++ b/frontend/src/components/advisories/shared/filterStatus/FilterStatus.jsx
@@ -36,8 +36,8 @@ export default function FilterStatus({
   onClearProgramArea,
   selectedTableFilters,
   onClearTableFilter,
-  showArchived,
-  onClearShowArchived,
+  showUnpublished,
+  onClearShowUnpublished,
   hasAnyFilters,
   onClearAll,
 }) {
@@ -93,8 +93,11 @@ export default function FilterStatus({
           />
         ))}
 
-        {showArchived && (
-          <FilterBadge label="Show archived" onRemove={onClearShowArchived} />
+        {showUnpublished && (
+          <FilterBadge
+            label="Show unpublished"
+            onRemove={onClearShowUnpublished}
+          />
         )}
 
         {hasAnyFilters && (
@@ -157,8 +160,8 @@ FilterStatus.propTypes = {
     }),
   ),
   onClearTableFilter: PropTypes.func.isRequired,
-  showArchived: PropTypes.bool.isRequired,
-  onClearShowArchived: PropTypes.func.isRequired,
+  showUnpublished: PropTypes.bool.isRequired,
+  onClearShowUnpublished: PropTypes.func.isRequired,
   hasAnyFilters: PropTypes.bool.isRequired,
   onClearAll: PropTypes.func.isRequired,
 };

--- a/frontend/src/components/advisories/shared/filterStatus/FilterStatus.jsx
+++ b/frontend/src/components/advisories/shared/filterStatus/FilterStatus.jsx
@@ -95,7 +95,7 @@ export default function FilterStatus({
 
         {showUnpublished && (
           <FilterBadge
-            label="Show unpublished"
+            label="Include unpublished"
             onRemove={onClearShowUnpublished}
           />
         )}

--- a/frontend/src/lib/advisories/utils/AdvisoryDataUtil.js
+++ b/frontend/src/lib/advisories/utils/AdvisoryDataUtil.js
@@ -3,10 +3,6 @@ import "moment-timezone";
 import { REVIEW_STATUS } from "@/constants/reviewStatus";
 
 const oneWeekDays = 7;
-const standardInactiveAdvisoryWindowDays = 30;
-const standardInactiveAdvisoryCutoffDate = moment()
-  .subtract(standardInactiveAdvisoryWindowDays, "days")
-  .format("YYYY-MM-DD");
 
 function buildAdvisoryReviewStatuses(publicAdvisory, now) {
   const reviewStatuses = [];
@@ -89,10 +85,6 @@ export function updatePublicAdvisories(publicAdvisories, managementAreas) {
       });
       publicAdvisory.regions = regionsWithParkCount;
     }
-
-    publicAdvisory.archived =
-      publicAdvisory.advisoryStatus.code === "UNP" &&
-      publicAdvisory.updatedAt < standardInactiveAdvisoryCutoffDate;
 
     return publicAdvisory;
   });

--- a/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.jsx
+++ b/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.jsx
@@ -63,7 +63,7 @@ import {
   clearDistrictFilter as clearDistrictFilterHandler,
   clearParkFilter as clearParkFilterHandler,
   clearRegionFilter as clearRegionFilterHandler,
-  clearShowArchivedFilter as clearShowArchivedFilterHandler,
+  clearShowUnpublishedFilter as clearShowUnpublishedFilterHandler,
   clearTableFilter as clearTableFilterHandler,
   getPageFilterValue,
   handlePageMultiSelectChange as handlePageMultiSelectChangeHandler,
@@ -293,13 +293,13 @@ export default function AdvisoryDashboard({
     });
   }, 75);
 
-  // Persist showArchived in sessionStorage
+  // Persist showUnpublished in sessionStorage
   // Use separate keys for All vs Review tabs so each maintains independent state
-  const showArchivedStorageKey = isReviewDashboard
-    ? "showArchivedReview"
-    : "showArchived";
-  const [showArchived, setShowArchived] = useSessionStorage(
-    showArchivedStorageKey,
+  const showUnpublishedStorageKey = isReviewDashboard
+    ? "showUnpublishedReview"
+    : "showUnpublished";
+  const [showUnpublished, setShowUnpublished] = useSessionStorage(
+    showUnpublishedStorageKey,
     false,
   );
 
@@ -448,9 +448,9 @@ export default function AdvisoryDashboard({
     });
   }
 
-  function clearShowArchivedFilter() {
-    clearShowArchivedFilterHandler({
-      setShowArchived,
+  function clearShowUnpublishedFilter() {
+    clearShowUnpublishedFilterHandler({
+      setShowUnpublished,
       resetToFirstPage,
     });
   }
@@ -464,7 +464,7 @@ export default function AdvisoryDashboard({
       setSelectedRegionId,
       setSelectedPark,
       setSelectedParkId,
-      setShowArchived,
+      setShowUnpublished,
       setTableFilterValues,
       resetToFirstPage,
       setStoredFilters,
@@ -601,7 +601,7 @@ export default function AdvisoryDashboard({
     setError,
   ]);
 
-  // Fetch one page of advisories whenever page, pageSize, or showArchived changes.
+  // Fetch one page of advisories whenever page, pageSize, or showUnpublished changes.
   useEffect(() => {
     let isMounted = true;
 
@@ -610,10 +610,6 @@ export default function AdvisoryDashboard({
       setPublicAdvisories([]);
 
       try {
-        const unpublishedCutoffDate = moment()
-          .subtract(30, "days")
-          .format("YYYY-MM-DD");
-
         // Build server-side filter params from column filter values and region/park dropdowns
         const userFilterClauses = buildFilter(
           debouncedTableFilterValues,
@@ -628,20 +624,9 @@ export default function AdvisoryDashboard({
         // Filters applied to server queries, regardless of user-selected filters
         const sharedBaseFilters = [{ isLatestRevision: true }];
 
-        // When not showing archived advisories, filter out unpublished advisories older than 30 days
-        if (!showArchived) {
-          sharedBaseFilters.push({
-            $or: [
-              // Always include all non-unpublished advisories
-              { advisoryStatus: { code: { $ne: "UNP" } } },
-              {
-                $and: [
-                  { advisoryStatus: { code: { $eq: "UNP" } } },
-                  { updatedAt: { $gt: unpublishedCutoffDate } },
-                ],
-              },
-            ],
-          });
+        // When not showing unpublished advisories, exclude all unpublished advisories
+        if (!showUnpublished) {
+          sharedBaseFilters.push({ advisoryStatus: { code: { $ne: "UNP" } } });
         }
 
         // Build filter sets for fetching data with and without user-selected filters
@@ -800,7 +785,7 @@ export default function AdvisoryDashboard({
     selectedRegionId,
     selectedProgramArea,
     setError,
-    showArchived,
+    showUnpublished,
     sortConfig,
     isReviewDashboard,
     debouncedTableFilterValues,
@@ -921,9 +906,7 @@ export default function AdvisoryDashboard({
           textAlign: "left",
         },
         render(rowData) {
-          const statusCode = rowData.archived
-            ? "ARCHIVED"
-            : rowData.advisoryStatus?.code;
+          const statusCode = rowData.advisoryStatus?.code;
           const hasUnpublishedStatus =
             isReviewDashboard &&
             rowData.reviewStatuses?.includes(REVIEW_STATUS.UNPUBLISHED);
@@ -1110,43 +1093,39 @@ export default function AdvisoryDashboard({
           );
         },
       },
-      ...(isReviewDashboard
-        ? [
-            {
-              field: "modifiedDate",
-              title: "Last updated",
-              render(rowData) {
-                if (rowData.modifiedDate) {
-                  const hasUpdatedStatus = rowData.reviewStatuses?.includes(
-                    REVIEW_STATUS.UPDATED,
-                  );
+      {
+        field: "modifiedDate",
+        title: "Last updated",
+        render(rowData) {
+          if (rowData.modifiedDate) {
+            const hasUpdatedStatus =
+              isReviewDashboard &&
+              rowData.reviewStatuses?.includes(REVIEW_STATUS.UPDATED);
 
-                  return (
-                    <span className="d-inline-flex align-items-center gap-1">
-                      {hasUpdatedStatus && (
-                        <ReviewIcon
-                          reviewStatus={REVIEW_STATUS.UPDATED}
-                          rowId={rowData.documentId}
-                          icon={faCircleSmall}
-                        />
-                      )}
-                      <span
-                        className={classNames({
-                          [`review-status--${REVIEW_STATUS.UPDATED.toLowerCase()}`]:
-                            hasUpdatedStatus,
-                        })}
-                      >
-                        {moment(rowData.modifiedDate).format("YYYY/MM/DD")}
-                      </span>
-                    </span>
-                  );
-                }
+            return (
+              <span className="d-inline-flex align-items-center gap-1">
+                {hasUpdatedStatus && (
+                  <ReviewIcon
+                    reviewStatus={REVIEW_STATUS.UPDATED}
+                    rowId={rowData.documentId}
+                    icon={faCircleSmall}
+                  />
+                )}
+                <span
+                  className={classNames({
+                    [`review-status--${REVIEW_STATUS.UPDATED.toLowerCase()}`]:
+                      hasUpdatedStatus,
+                  })}
+                >
+                  {moment(rowData.modifiedDate).format("YYYY/MM/DD")}
+                </span>
+              </span>
+            );
+          }
 
-                return null;
-              },
-            },
-          ]
-        : []),
+          return null;
+        },
+      },
       {
         field: "advisoryDate",
         title: "Posting date",
@@ -1406,21 +1385,20 @@ export default function AdvisoryDashboard({
           <div className="row">
             <div className="col-12">
               <Form.Check
-                className="advisory-archived-toggle mt-3"
+                className="advisory-unpublished-toggle mt-3"
                 type="checkbox"
-                id="show-archived"
-                checked={showArchived}
+                id="show-unpublished"
+                checked={showUnpublished}
                 onChange={(e) => {
-                  setShowArchived(e.target.checked);
+                  setShowUnpublished(e.target.checked);
                   resetToFirstPage();
                 }}
                 label={
                   <span>
-                    Show advisories and closures that have not been updated in
-                    30 days
+                    Include unpublished advisories and closures
                     <LightTooltip
                       arrow
-                      title={t("dashboard.showArchived.tooltip")}
+                      title={t("dashboard.showUnpublished.tooltip")}
                     >
                       <FontAwesomeIcon
                         icon={faCircleQuestion}
@@ -1445,14 +1423,14 @@ export default function AdvisoryDashboard({
           onClearProgramArea={clearProgramAreaFilter}
           selectedTableFilters={activeTableFilters}
           onClearTableFilter={clearTableFilter}
-          showArchived={showArchived}
-          onClearShowArchived={clearShowArchivedFilter}
+          showUnpublished={showUnpublished}
+          onClearShowUnpublished={clearShowUnpublishedFilter}
           hasAnyFilters={
             selectedDistrict.length > 0 ||
             selectedRegion.length > 0 ||
             selectedPark.length > 0 ||
             selectedProgramArea !== null ||
-            showArchived ||
+            showUnpublished ||
             activeTableFilters.length > 0
           }
           onClearAll={clearAllFilters}

--- a/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.jsx
+++ b/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.jsx
@@ -624,8 +624,8 @@ export default function AdvisoryDashboard({
         // Filters applied to server queries, regardless of user-selected filters
         const sharedBaseFilters = [{ isLatestRevision: true }];
 
-        // When not showing unpublished advisories, exclude all unpublished advisories
-        if (!showUnpublished) {
+        // On the "All" tab, optionally exclude unpublished advisories
+        if (!isReviewDashboard && !showUnpublished) {
           sharedBaseFilters.push({ advisoryStatus: { code: { $ne: "UNP" } } });
         }
 
@@ -1284,7 +1284,13 @@ export default function AdvisoryDashboard({
   const emptyState = showNoItemsToReviewMessage ? (
     <ReviewEmptyState />
   ) : (
-    <div>No records to display.</div>
+    <div>
+      <p>No records to display.</p>
+      <p className="fs-6">
+        Try adjusting your filters or check ‘Include unpublished advisories and
+        closures’ to see more results.
+      </p>
+    </div>
   );
 
   return (

--- a/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.scss
+++ b/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.scss
@@ -27,7 +27,7 @@
     white-space: nowrap;
   }
 
-  .advisory-archived-toggle input {
+  .advisory-unpublished-toggle input {
     width: 1.25rem;
     height: 1.25rem;
   }

--- a/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.scss
+++ b/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.scss
@@ -30,6 +30,7 @@
   .advisory-unpublished-toggle input {
     width: 1.25rem;
     height: 1.25rem;
+    margin-right: 0.5rem;
   }
 
   .filter-row {

--- a/frontend/src/router/pages/advisories/advisoryDashboard/advisoryDashboardFilterHandlers.js
+++ b/frontend/src/router/pages/advisories/advisoryDashboard/advisoryDashboardFilterHandlers.js
@@ -377,19 +377,22 @@ export function clearTableFilter({
 }
 
 /**
- * Clears the show archived filter.
+ * Clears the show unpublished filter.
  * @param {Object} params Configuration object
- * @param {Function} params.setShowArchived State setter for show archived toggle
+ * @param {Function} params.setShowUnpublished State setter for show unpublished toggle
  * @param {Function} params.resetToFirstPage Function to reset pagination to first page
  * @returns {void}
  */
-export function clearShowArchivedFilter({ setShowArchived, resetToFirstPage }) {
-  setShowArchived(false);
+export function clearShowUnpublishedFilter({
+  setShowUnpublished,
+  resetToFirstPage,
+}) {
+  setShowUnpublished(false);
   resetToFirstPage();
 }
 
 /**
- * Clears all filters (page, table, and archived).
+ * Clears all filters (page, table, and unpublished).
  * @param {Object} params Configuration object
  * @param {Function} params.setSelectedDistrict State setter for selected districts
  * @param {Function} params.setSelectedDistrictId State setter for selected district IDs
@@ -397,7 +400,7 @@ export function clearShowArchivedFilter({ setShowArchived, resetToFirstPage }) {
  * @param {Function} params.setSelectedRegionId State setter for selected region IDs
  * @param {Function} params.setSelectedPark State setter for selected parks
  * @param {Function} params.setSelectedParkId State setter for selected park IDs
- * @param {Function} params.setShowArchived State setter for show archived toggle
+ * @param {Function} params.setShowUnpublished State setter for show unpublished toggle
  * @param {Function} params.setTableFilterValues State setter for table filter values
  * @param {Function} params.resetToFirstPage Function to reset pagination to first page
  * @param {Function} params.setStoredFilters State setter for stored filters
@@ -411,7 +414,7 @@ export function clearAllFilters({
   setSelectedRegionId,
   setSelectedPark,
   setSelectedParkId,
-  setShowArchived,
+  setShowUnpublished,
   setTableFilterValues,
   resetToFirstPage,
   setStoredFilters,
@@ -423,7 +426,7 @@ export function clearAllFilters({
   setSelectedRegionId([]);
   setSelectedPark([]);
   setSelectedParkId([]);
-  setShowArchived(false);
+  setShowUnpublished(false);
   setTableFilterValues({});
   resetToFirstPage();
   setStoredFilters(defaultPageFilters);

--- a/frontend/src/ui-text/act.js
+++ b/frontend/src/ui-text/act.js
@@ -3,9 +3,9 @@ export default {
   // Structure: <Feature/area> -> <Component/section>
 
   dashboard: {
-    showArchived: {
+    showUnpublished: {
       tooltip:
-        "By default, advisories and closures that have not been modified in the last 30 days are hidden. Check this box to show all older advisories and closures.",
+        "By default, unpublished advisories and closures are hidden. Check this box to show all unpublished advisories and closures.",
     },
   },
 


### PR DESCRIPTION
### Jira Ticket

CMS-1802

### Description
<!-- What did you change, and why? -->
- In the default "All" tab, display all advisories except for unpublished advisories
- Display all unpublished advisories if the checkbox is clicked
- Added the "Last updated" column to the "All" tab
- Updated the text when there is no advisories
- Changed "archived" to "unpublished"
