### PR TITLE
CMS-1804: Display both park and resource if an advisory has both

### DIFF
--- a/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.jsx
+++ b/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.jsx
@@ -970,17 +970,17 @@ export default function AdvisoryDashboard({
             );
           }
 
-          // Display parks and recreation resources
-          const resources = rowData.recreationResources ?? [];
+          // Display parks and rec resources
+          const recResources = rowData.recreationResources ?? [];
           const parks = rowData.protectedAreas ?? [];
-          const resourcesCount = resources.length;
+          const recResourcesCount = recResources.length;
           const parksCount = parks.length;
-          const displayedResources = resources.slice(0, displayCount);
+          const displayedRecResources = recResources.slice(0, displayCount);
           const displayedProtectedAreas = parks.slice(0, displayCount);
 
-          if (resourcesCount > 0 || parksCount > 0) {
+          if (recResourcesCount > 0 || parksCount > 0) {
             const resourceLabels = [
-              ...displayedResources.map((r) =>
+              ...displayedRecResources.map((r) =>
                 r.recResourceId
                   ? `${r.resourceName} (${r.recResourceId})`
                   : r.resourceName,
@@ -989,7 +989,7 @@ export default function AdvisoryDashboard({
             ];
 
             const remainingCount =
-              Math.max(resourcesCount - displayedResources.length, 0) +
+              Math.max(recResourcesCount - displayedRecResources.length, 0) +
               Math.max(parksCount - displayedProtectedAreas.length, 0);
 
             return (

--- a/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.jsx
+++ b/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.jsx
@@ -970,65 +970,49 @@ export default function AdvisoryDashboard({
             );
           }
 
-          // park advisories
-          const parksCount = rowData.protectedAreas.length;
-          const displayedProtectedAreas = rowData.protectedAreas.slice(
-            0,
-            displayCount,
-          );
+          // Display parks and recreation resources
+          const resources = rowData.recreationResources ?? [];
+          const parks = rowData.protectedAreas ?? [];
+          const resourcesCount = resources.length;
+          const parksCount = parks.length;
+          const displayedResources = resources.slice(0, displayCount);
+          const displayedProtectedAreas = parks.slice(0, displayCount);
 
-          if (parksCount > 0) {
+          if (resourcesCount > 0 || parksCount > 0) {
+            const resourceLabels = [
+              ...displayedResources.map((r) =>
+                r.recResourceId
+                  ? `${r.resourceName} (${r.recResourceId})`
+                  : r.resourceName,
+              ),
+              ...displayedProtectedAreas.map((p) => p.protectedAreaName),
+            ];
+
+            const remainingCount =
+              Math.max(resourcesCount - displayedResources.length, 0) +
+              Math.max(parksCount - displayedProtectedAreas.length, 0);
+
             return (
               <div>
-                {displayedProtectedAreas.map((p, i) => (
-                  <span key={i}>
-                    {p.protectedAreaName}
-                    {displayedProtectedAreas.length - 1 > i && ", "}
+                {resourceLabels.map((label, index) => (
+                  <span key={`${label}-${index}`}>
+                    {label}
+                    {resourceLabels.length - 1 > index && ", "}
                   </span>
                 ))}
-                {parksCount > displayCount && (
+                {remainingCount > 0 && (
                   <CountBadge
-                    label={`+${parksCount - displayCount}`}
+                    label={`+${remainingCount}`}
                     documentId={rowData.documentId}
                     title={rowData.title}
-                    tooltipText={formatCountBadge(
-                      parksCount - displayCount,
-                      "resource",
-                    )}
+                    tooltipText={formatCountBadge(remainingCount, "resource")}
                   />
                 )}
               </div>
             );
           }
 
-          // RST closures
-          const resourcesCount = rowData.recreationResources.length;
-          const displayedResources = rowData.recreationResources.slice(
-            0,
-            displayCount,
-          );
-
-          return (
-            <div>
-              {displayedResources.map((r, i) => (
-                <span key={i}>
-                  {r.resourceName} {`(${r.recResourceId})`}
-                  {displayedResources.length - 1 > i && ", "}
-                </span>
-              ))}
-              {resourcesCount > displayCount && (
-                <CountBadge
-                  label={`+${resourcesCount - displayCount}`}
-                  documentId={rowData.documentId}
-                  title={rowData.title}
-                  tooltipText={formatCountBadge(
-                    resourcesCount - displayCount,
-                    "resource",
-                  )}
-                />
-              )}
-            </div>
-          );
+          return null;
         },
       },
       {

--- a/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.jsx
+++ b/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.jsx
@@ -975,29 +975,27 @@ export default function AdvisoryDashboard({
           const parks = rowData.protectedAreas ?? [];
           const recResourcesCount = recResources.length;
           const parksCount = parks.length;
-          const displayedRecResources = recResources.slice(0, displayCount);
-          const displayedProtectedAreas = parks.slice(0, displayCount);
+          const associatedResources = [
+            ...recResources.map((recResource) =>
+              recResource.recResourceId
+                ? `${recResource.resourceName} (${recResource.recResourceId})`
+                : recResource.resourceName,
+            ),
+            ...parks.map((park) => park.protectedAreaName),
+          ];
+          const displayedResources = associatedResources.slice(0, displayCount);
+          const remainingCount = Math.max(
+            associatedResources.length - displayCount,
+            0,
+          );
 
           if (recResourcesCount > 0 || parksCount > 0) {
-            const resourceLabels = [
-              ...displayedRecResources.map((r) =>
-                r.recResourceId
-                  ? `${r.resourceName} (${r.recResourceId})`
-                  : r.resourceName,
-              ),
-              ...displayedProtectedAreas.map((p) => p.protectedAreaName),
-            ];
-
-            const remainingCount =
-              Math.max(recResourcesCount - displayedRecResources.length, 0) +
-              Math.max(parksCount - displayedProtectedAreas.length, 0);
-
             return (
               <div>
-                {resourceLabels.map((label, index) => (
-                  <span key={`${label}-${index}`}>
-                    {label}
-                    {resourceLabels.length - 1 > index && ", "}
+                {displayedResources.map((resource, index) => (
+                  <span key={`${resource}-${index}`}>
+                    {resource}
+                    {displayedResources.length - 1 > index && ", "}
                   </span>
                 ))}
                 {remainingCount > 0 && (


### PR DESCRIPTION
### Jira Ticket

CMS-1804

### Description
<!-- What did you change, and why? -->
- Displayed both parks and resources in the Associated resources column if an advisory has both
