### PR TITLE
CMS-1704: Add "Discard changes?" confirmations to Advisory form

### DIFF
--- a/frontend/src/components/TouchMenu.jsx
+++ b/frontend/src/components/TouchMenu.jsx
@@ -1,19 +1,11 @@
 import useAccess from "@/hooks/useAccess";
 import classNames from "classnames";
 import PropTypes from "prop-types";
+import { NavLink } from "react-router-dom";
 import "./TouchMenu.scss";
 import navItems from "./shared/navItems";
 
-export default function TouchMenu({
-  show = true,
-  closeMenu,
-  logOut,
-  userName,
-}) {
-  function onLogoutClick() {
-    closeMenu();
-    logOut();
-  }
+export default function TouchMenu({ show = true, closeMenu, userName }) {
 
   const { hasAnyRole } = useAccess();
 
@@ -37,16 +29,16 @@ export default function TouchMenu({
             </li>
           ))}
         <li className="nav-item">
-          {/* Full width logout button with the user's name */}
-          <button
-            type="button"
+          {/* Full width logout link with the user's name */}
+          <NavLink
+            to="/logout"
             className="btn btn-text w-100 text-start nav-link"
-            onClick={onLogoutClick}
+            onClick={closeMenu}
           >
             <span className="text-dark">{userName}</span>
             <br />
             Logout
-          </button>
+          </NavLink>
         </li>
       </ul>
     </div>
@@ -57,6 +49,5 @@ export default function TouchMenu({
 TouchMenu.propTypes = {
   show: PropTypes.bool,
   closeMenu: PropTypes.func.isRequired,
-  logOut: PropTypes.func.isRequired,
   userName: PropTypes.string,
 };

--- a/frontend/src/components/advisories/composite/advisoryAreaPicker/AdvisoryAreaPicker.jsx
+++ b/frontend/src/components/advisories/composite/advisoryAreaPicker/AdvisoryAreaPicker.jsx
@@ -19,6 +19,7 @@ import { getParkRelations } from "@/lib/advisories/utils/CmsDataUtil";
 
 export default function AdvisoryAreaPicker({
   mode,
+  markChanged,
   data: {
     recreationResources,
     selectedRecreationResources,
@@ -219,6 +220,9 @@ export default function AdvisoryAreaPicker({
     const parks = protectedAreas.filter((p) => newList.has(p.value));
 
     setSelectedProtectedAreas(parks);
+
+    // Tell the page component that the form changed to enable the "Unsaved changes" prompt
+    markChanged();
   }
 
   const customSelectStyles = {
@@ -260,7 +264,11 @@ export default function AdvisoryAreaPicker({
           <RecreationResourcePicker
             options={recreationResources}
             value={selectedRecreationResources}
-            onChange={setSelectedRecreationResources}
+            onChange={() => {
+              setSelectedRecreationResources();
+              // Tell the page component that the form changed to enable the "Unsaved changes" prompt
+              markChanged();
+            }}
             onBlur={() => {
               validateRequiredAffectedResources(advisoryData.affectedResources);
             }}
@@ -287,6 +295,9 @@ export default function AdvisoryAreaPicker({
               } else {
                 handleRemoveProtectedArea(e);
               }
+
+              // Tell the page component that the form changed to enable the "Unsaved changes" prompt
+              markChanged();
             }}
             placeholder="Search or select BC Parks park(s)"
             isMulti
@@ -499,6 +510,7 @@ export default function AdvisoryAreaPicker({
 
 AdvisoryAreaPicker.propTypes = {
   mode: PropTypes.string,
+  markChanged: PropTypes.func.isRequired,
   data: PropTypes.shape({
     recreationResources: PropTypes.array.isRequired,
     selectedRecreationResources: PropTypes.array,

--- a/frontend/src/components/advisories/composite/advisoryAreaPicker/AdvisoryAreaPicker.jsx
+++ b/frontend/src/components/advisories/composite/advisoryAreaPicker/AdvisoryAreaPicker.jsx
@@ -264,8 +264,8 @@ export default function AdvisoryAreaPicker({
           <RecreationResourcePicker
             options={recreationResources}
             value={selectedRecreationResources}
-            onChange={() => {
-              setSelectedRecreationResources();
+            onChange={(selected) => {
+              setSelectedRecreationResources(selected);
               // Tell the page component that the form changed to enable the "Unsaved changes" prompt
               markChanged();
             }}

--- a/frontend/src/components/advisories/composite/advisoryForm/AdvisoryForm.jsx
+++ b/frontend/src/components/advisories/composite/advisoryForm/AdvisoryForm.jsx
@@ -508,6 +508,7 @@ export default function AdvisoryForm({
         <h3>Affected resource(s)</h3>
         <AdvisoryAreaPicker
           mode={mode}
+          markChanged={markChanged}
           data={{
             recreationResources,
             selectedRecreationResources,

--- a/frontend/src/components/advisories/composite/advisoryForm/AdvisoryForm.jsx
+++ b/frontend/src/components/advisories/composite/advisoryForm/AdvisoryForm.jsx
@@ -44,6 +44,8 @@ import DraftButton from "@/components/advisories/composite/advisoryForm/DraftBut
 
 export default function AdvisoryForm({
   mode,
+  markChanged,
+  registerSaveDraftHandler,
   data: {
     listingRank,
     setListingRank,
@@ -172,6 +174,8 @@ export default function AdvisoryForm({
   const [displayedDateError, setDisplayedDateError] = useState("");
   const [selectedDisplayedDateOption, setSelectedDisplayedDateOption] =
     useState("");
+  // Keep a stable callable for parent registration while always executing latest form state.
+  const saveDraftHandlerRef = useRef(async () => false);
 
   // Reveal event dates in update mode if there are any
   useEffect(() => {
@@ -414,29 +418,39 @@ export default function AdvisoryForm({
    * Saves the advisory as a draft in the CMS (with "Draft" status).
    * The backend middleware determines whether this is an in-place update
    * or a new revision when the current advisory is published.
-   * @returns {void}
+   * @returns {Promise<boolean>} true when save succeeds, false otherwise.
    */
   async function handleSaveDraft() {
     // Don't submit if validation fails
     if (!validAdvisoryData(advisoryData, linksRef, mode, linkErrorsStatus))
-      return;
+      return false;
 
     // Don't submit again if a request is in progress
-    if (isSavingDraft) return;
+    if (isSavingDraft) return false;
 
     // Get the Strapi data for the "Draft" advisory status from its code
     const draftStatus = advisoryStatuses.find(
       (status) => status.code === "DFT",
     );
 
+    if (!draftStatus) return false;
+
     if (mode === "update") {
       // Update advisory with "Draft" status
-      await updateAdvisory(draftStatus);
-    } else {
-      // Create advisory with "Draft" status
-      await createAdvisory(draftStatus);
+      return Boolean(await updateAdvisory(draftStatus));
     }
+    // Create advisory with "Draft" status
+    return Boolean(await createAdvisory(draftStatus));
   }
+
+  saveDraftHandlerRef.current = handleSaveDraft;
+
+  useEffect(() => {
+    if (!registerSaveDraftHandler) return;
+
+    // Parent can call this when the exit dialog chooses "Save draft".
+    registerSaveDraftHandler(async () => saveDraftHandlerRef.current());
+  }, [registerSaveDraftHandler]);
 
   /**
    * Creates or updates the advisory without submitting for review. For users who can publish directly.
@@ -489,7 +503,7 @@ export default function AdvisoryForm({
   }
 
   return (
-    <form className="advisory-form">
+    <form className="advisory-form" onChange={markChanged}>
       <section>
         <h3>Affected resource(s)</h3>
         <AdvisoryAreaPicker
@@ -547,7 +561,10 @@ export default function AdvisoryForm({
             id="resource-status"
             options={accessStatuses}
             value={accessStatuses.filter((e) => e.value === accessStatus)}
-            onChange={(e) => setAccessStatus(e ? e.value : 0)}
+            onChange={(e) => {
+              setAccessStatus(e ? e.value : 0);
+              markChanged();
+            }}
             placeholder="Search or select resource status"
             className="bcgov-select"
           />
@@ -569,7 +586,10 @@ export default function AdvisoryForm({
               id="event-type"
               options={eventTypes}
               value={eventTypes.filter((e) => e.value === eventType)}
-              onChange={(e) => setEventType(e ? e.value : 0)}
+              onChange={(e) => {
+                setEventType(e ? e.value : 0);
+                markChanged();
+              }}
               placeholder="Search or select an event type"
               className="bcgov-select"
               onBlur={() => {
@@ -622,6 +642,7 @@ export default function AdvisoryForm({
                   key={u.value}
                   onClick={() => {
                     setUrgency(u.value);
+                    markChanged();
                   }}
                   className={
                     urgency === u.value ? `btn-urgency-${u.sequence}` : ""
@@ -678,6 +699,7 @@ export default function AdvisoryForm({
             value={selectedStandardMessages}
             onChange={(e) => {
               setSelectedStandardMessages(e);
+              markChanged();
             }}
             placeholder="Search or select standard message(s)"
             className="bcgov-select"
@@ -701,7 +723,10 @@ export default function AdvisoryForm({
           <CKEditor
             id="custom-message"
             value={description}
-            onChange={setDescription}
+            onChange={(value) => {
+              setDescription(value);
+              markChanged();
+            }}
           />
         </Form.Group>
 
@@ -756,6 +781,7 @@ export default function AdvisoryForm({
                     options={linkTypes}
                     onChange={(e) => {
                       updateLink(idx, "type", e.value);
+                      markChanged();
                     }}
                     value={linkTypes.filter((o) => o.value === l.type)}
                     className="bcgov-select"
@@ -788,6 +814,7 @@ export default function AdvisoryForm({
                   }}
                   onClick={() => {
                     removeLink(idx);
+                    markChanged();
                   }}
                 >
                   <FontAwesomeIcon icon={faXmark} />
@@ -844,6 +871,7 @@ export default function AdvisoryForm({
                         });
                       }
                       updateLink(idx, "url", "");
+                      markChanged();
                     }}
                     className="clear-url-btn"
                     aria-label="Clear URL"
@@ -874,6 +902,7 @@ export default function AdvisoryForm({
                       onClick={(e) => {
                         e.stopPropagation();
                         updateLink(idx, "file", "");
+                        markChanged();
                         validateLink(l, idx, "file", setLinkFileErrors);
                       }}
                       className="clear-url-btn"
@@ -891,6 +920,7 @@ export default function AdvisoryForm({
                       accept=".jpg,.gif,.png,.gif,.pdf"
                       onChange={(e) => {
                         handleFileCapture(e.target.files, idx);
+                        markChanged();
                       }}
                     />
                     <Btn
@@ -924,6 +954,7 @@ export default function AdvisoryForm({
                   e.target.files,
                   linksRef.current.length > 0 ? linksRef.current.length - 1 : 0,
                 );
+                markChanged();
               }}
             />
             <label htmlFor="file-upload" className="mb-0">
@@ -934,10 +965,12 @@ export default function AdvisoryForm({
                 onKeyDown={(e) => {
                   if (e.key === "Enter") {
                     addLink("file");
+                    markChanged();
                   }
                 }}
                 onClick={() => {
                   addLink("file");
+                  markChanged();
                 }}
               >
                 + Upload file
@@ -950,10 +983,12 @@ export default function AdvisoryForm({
               onKeyDown={(e) => {
                 if (e.key === "Enter") {
                   addLink("url");
+                  markChanged();
                 }
               }}
               onClick={() => {
                 addLink("url");
+                markChanged();
               }}
             >
               Add URL
@@ -990,6 +1025,7 @@ export default function AdvisoryForm({
                     selected={advisoryDate}
                     onChange={(date) => {
                       handleAdvisoryDateChange(date);
+                      markChanged();
                     }}
                     fixedHeight
                     dateFormat="MMMM d, yyyy"
@@ -1023,7 +1059,10 @@ export default function AdvisoryForm({
                     <DatePicker
                       id="post-start-time"
                       selected={advisoryDate}
-                      onChange={(date) => handleAdvisoryDateChange(date)}
+                      onChange={(date) => {
+                        handleAdvisoryDateChange(date);
+                        markChanged();
+                      }}
                       showTimeSelect
                       showTimeSelectOnly
                       timeIntervals={15}
@@ -1068,6 +1107,7 @@ export default function AdvisoryForm({
                     selected={expiryDate}
                     onChange={(date) => {
                       setExpiryDate(date);
+                      markChanged();
                     }}
                     fixedHeight
                     dateFormat="MMMM d, yyyy"
@@ -1104,6 +1144,7 @@ export default function AdvisoryForm({
                       selected={expiryDate}
                       onChange={(date) => {
                         setExpiryDate(date);
+                        markChanged();
                       }}
                       showTimeSelect
                       showTimeSelectOnly
@@ -1139,6 +1180,7 @@ export default function AdvisoryForm({
                       selected={updatedDate}
                       onChange={(date) => {
                         setUpdatedDate(date);
+                        markChanged();
                       }}
                       fixedHeight
                       dateFormat="MMMM d, yyyy"
@@ -1171,6 +1213,7 @@ export default function AdvisoryForm({
                         selected={updatedDate}
                         onChange={(date) => {
                           setUpdatedDate(date);
+                          markChanged();
                         }}
                         showTimeSelect
                         showTimeSelectOnly
@@ -1201,7 +1244,9 @@ export default function AdvisoryForm({
             <button
               type="button"
               className="btn mt-2 btn-link btn-boolean with-icon"
-              onClick={() => setShowEventDates(true)}
+              onClick={() => {
+                setShowEventDates(true);
+              }}
             >
               Add event dates
               <FontAwesomeIcon icon={faChevronDown} />
@@ -1238,6 +1283,7 @@ export default function AdvisoryForm({
                         selected={startDate}
                         onChange={(date) => {
                           setStartDate(date);
+                          markChanged();
                         }}
                         fixedHeight
                         dateFormat="MMMM d, yyyy"
@@ -1268,7 +1314,10 @@ export default function AdvisoryForm({
                         <DatePicker
                           id="event-start-time"
                           selected={startDate}
-                          onChange={(date) => setStartDate(date)}
+                          onChange={(date) => {
+                            setStartDate(date);
+                            markChanged();
+                          }}
                           showTimeSelect
                           showTimeSelectOnly
                           timeIntervals={15}
@@ -1313,6 +1362,7 @@ export default function AdvisoryForm({
                         selected={endDate}
                         onChange={(date) => {
                           setEndDate(date);
+                          markChanged();
                         }}
                         fixedHeight
                         dateFormat="MMMM d, yyyy"
@@ -1349,7 +1399,10 @@ export default function AdvisoryForm({
                         <DatePicker
                           id="event-end-time"
                           selected={endDate}
-                          onChange={(date) => setEndDate(date)}
+                          onChange={(date) => {
+                            setEndDate(date);
+                            markChanged();
+                          }}
                           showTimeSelect
                           showTimeSelectOnly
                           timeIntervals={15}
@@ -1377,7 +1430,9 @@ export default function AdvisoryForm({
               <button
                 type="button"
                 className="btn mt-2 btn-link btn-boolean with-icon"
-                onClick={() => setShowEventDates(false)}
+                onClick={() => {
+                  setShowEventDates(false);
+                }}
               >
                 Hide event dates
                 <FontAwesomeIcon icon={faChevronUp} />
@@ -1405,6 +1460,7 @@ export default function AdvisoryForm({
               defaultValue={getDisplayedDate()}
               onChange={(e) => {
                 setSelectedDisplayedDateOption(e.value);
+                markChanged();
               }}
               className="bcgov-select"
               onBlur={() => {
@@ -1508,7 +1564,10 @@ export default function AdvisoryForm({
               aria-label="Public safety related"
             >
               <Btn
-                onClick={() => setIsSafetyRelated(true)}
+                onClick={() => {
+                  setIsSafetyRelated(true);
+                  markChanged();
+                }}
                 className={
                   isSafetyRelated === true ? "btn-safety-selected" : ""
                 }
@@ -1520,7 +1579,10 @@ export default function AdvisoryForm({
                 Yes
               </Btn>
               <Btn
-                onClick={() => setIsSafetyRelated(false)}
+                onClick={() => {
+                  setIsSafetyRelated(false);
+                  markChanged();
+                }}
                 className={
                   isSafetyRelated === false ? "btn-safety-selected" : ""
                 }
@@ -1552,7 +1614,10 @@ export default function AdvisoryForm({
                 value={advisoryStatuses.filter(
                   (a) => a.value === advisoryStatus,
                 )}
-                onChange={(e) => setAdvisoryStatus(e ? e.value : null)}
+                onChange={(e) => {
+                  setAdvisoryStatus(e ? e.value : null);
+                  markChanged();
+                }}
                 placeholder="Search or select an advisory status"
                 className="bcgov-select"
                 isClearable
@@ -1590,6 +1655,7 @@ export default function AdvisoryForm({
                     checked={isAfterHourPublish}
                     onChange={() => {
                       setIsAfterHourPublish(true);
+                      markChanged();
                     }}
                     value="Publish"
                     name="after-hour-submission"
@@ -1609,6 +1675,7 @@ export default function AdvisoryForm({
                     checked={!isAfterHourPublish}
                     onChange={() => {
                       setIsAfterHourPublish(false);
+                      markChanged();
                     }}
                     value="Review"
                     name="after-hour-submission"
@@ -1647,6 +1714,8 @@ export default function AdvisoryForm({
 
 AdvisoryForm.propTypes = {
   mode: PropTypes.string.isRequired,
+  markChanged: PropTypes.func.isRequired,
+  registerSaveDraftHandler: PropTypes.func,
   data: PropTypes.shape({
     listingRank: PropTypes.number,
     setListingRank: PropTypes.func.isRequired,

--- a/frontend/src/components/advisories/composite/advisoryForm/UnsavedChangesDialog.jsx
+++ b/frontend/src/components/advisories/composite/advisoryForm/UnsavedChangesDialog.jsx
@@ -1,0 +1,65 @@
+import PropTypes from "prop-types";
+import Modal from "react-bootstrap/Modal";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faTrash, faTriangleExclamation } from "@fa-kit/icons/classic/regular";
+import "./UnsavedChangesDialog.scss";
+
+/*
+ * Modal dialog prompt to appear when the user attempts to navigate away from a form with unsaved changes.
+ * Three resolution options: Save draft, Discard draft, or Cancel (close the dialog and return to the form).
+ */
+
+export default function UnsavedChangesDialog({
+  onClose,
+  onDiscard,
+  onSaveDraft,
+  isOpen,
+  children = null,
+}) {
+  return (
+    <Modal
+      centered
+      dialogClassName="confirmation-dialog-wrap"
+      contentClassName="unsaved-changes-dialog-modal"
+      show={isOpen}
+      onHide={onClose}
+    >
+      <Modal.Header closeButton>
+        <Modal.Title>
+          <FontAwesomeIcon
+            className="text-danger me-2"
+            icon={faTriangleExclamation}
+          />
+          Save changes?
+        </Modal.Title>
+      </Modal.Header>
+
+      <Modal.Body>
+        {children ?? (
+          <p>
+            Unsaved changes will be permanently deleted if you do not save them.
+          </p>
+        )}
+      </Modal.Body>
+
+      <div className="modal-footer">
+        <button type="button" className="btn text-danger" onClick={onDiscard}>
+          <FontAwesomeIcon className="me-2" icon={faTrash} />
+          Discard draft
+        </button>
+
+        <button type="button" className="btn btn-primary" onClick={onSaveDraft}>
+          Save draft
+        </button>
+      </div>
+    </Modal>
+  );
+}
+
+UnsavedChangesDialog.propTypes = {
+  onClose: PropTypes.func.isRequired,
+  onDiscard: PropTypes.func.isRequired,
+  onSaveDraft: PropTypes.func.isRequired,
+  isOpen: PropTypes.bool.isRequired,
+  children: PropTypes.node,
+};

--- a/frontend/src/components/advisories/composite/advisoryForm/UnsavedChangesDialog.scss
+++ b/frontend/src/components/advisories/composite/advisoryForm/UnsavedChangesDialog.scss
@@ -1,0 +1,5 @@
+.unsaved-changes-dialog-modal {
+  &.modal-content {
+    border: none;
+  }
+}

--- a/frontend/src/hooks/useUnsavedChangesDialog.js
+++ b/frontend/src/hooks/useUnsavedChangesDialog.js
@@ -1,0 +1,111 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+const ACTIONS = {
+  DISCARD: "discard",
+  SAVE: "save",
+  CLOSE: "close",
+};
+
+/*
+ Hook for managing the "Unsaved changes" dialog component,
+ which is shown when the user attempts to navigate away with unsaved changes
+*/
+
+export default function useUnsavedChangesDialog(onSaveDraft) {
+  // Visibility state for the dialog
+  const [isOpen, setIsOpen] = useState(false);
+
+  // Ref to track whether the dialog is currently open to prevent multiple prompts from stacking
+  const isOpenRef = useRef(false);
+
+  // Ref to hold the resolve function of the current dialog promise, so it can be resolved by the dialog's action buttons
+  const resolvePromiseRef = useRef(null);
+
+  // Resolves whichever action the user chose and resets the dialog state
+  // so the next blocked navigation can open a fresh prompt.
+  const resolveDialog = useCallback((action) => {
+    const resolve = resolvePromiseRef.current;
+
+    resolvePromiseRef.current = null;
+    isOpenRef.current = false;
+    setIsOpen(false);
+
+    if (resolve) {
+      resolve(action);
+    }
+  }, []);
+
+  // Opens the dialog and returns a promise that resolves when the user chooses
+  // save, discard, or close.
+  const open = useCallback(async () => {
+    if (isOpenRef.current) {
+      return ACTIONS.CLOSE;
+    }
+
+    isOpenRef.current = true;
+    setIsOpen(true);
+
+    return new Promise((resolve) => {
+      resolvePromiseRef.current = resolve;
+    });
+  }, []);
+
+  // Waits for the user's choice and converts it into a simple navigation
+  // decision for the caller.
+  // Returns true when navigation should proceed, or false to stay on the form.
+  const confirmNavigation = useCallback(async () => {
+    const action = await open();
+
+    // Discard draft: proceed with the blocked navigation without saving
+    if (action === ACTIONS.DISCARD) {
+      return true;
+    }
+
+    // Save draft: attempt to save a draft, and only proceed if the save was successful
+    if (action === ACTIONS.SAVE) {
+      return Boolean(await onSaveDraft());
+    }
+
+    // Close dialog: do not proceed with navigation
+    return false;
+  }, [onSaveDraft, open]);
+
+  // Handles closing the dialog without saving or discarding.
+  // Just resolves the dialog promise as a "close" action and stays on the form.
+  const handleClose = useCallback(() => {
+    resolveDialog(ACTIONS.CLOSE);
+  }, [resolveDialog]);
+
+  // Handles closing the dialog and discarding changes.
+  // Resolves the dialog promise as a "discard" action.
+  const handleDiscard = useCallback(() => {
+    resolveDialog(ACTIONS.DISCARD);
+  }, [resolveDialog]);
+
+  // Handles closing the "Unsaved changes" dialog and saving a draft.
+  // Resolves the dialog promise as a "save" action.
+  const handleSaveDraft = useCallback(() => {
+    resolveDialog(ACTIONS.SAVE);
+  }, [resolveDialog]);
+
+  useEffect(
+    () => () => {
+      // Make sure any pending prompt promise is settled if the page unmounts.
+      if (resolvePromiseRef.current) {
+        resolvePromiseRef.current(ACTIONS.CLOSE);
+        resolvePromiseRef.current = null;
+      }
+    },
+    [],
+  );
+
+  return {
+    confirmNavigation,
+    props: {
+      isOpen,
+      onClose: handleClose,
+      onDiscard: handleDiscard,
+      onSaveDraft: handleSaveDraft,
+    },
+  };
+}

--- a/frontend/src/lib/advisories/validators/AdvisoryValidator.js
+++ b/frontend/src/lib/advisories/validators/AdvisoryValidator.js
@@ -55,9 +55,9 @@ export function validateRequiredAffectedResources({
 }) {
   setError("");
 
-  // Check that at least one of the two fields has a value
+  // Check that at least one of the two fields has a selected value
   const hasValue = [...protectedAreaFields, ...recreationResourcesFields].some(
-    (values) => values.length > 0,
+    (values) => Array.isArray(values) && values.length > 0,
   );
 
   if (hasValue) return true;

--- a/frontend/src/router/ProtectedRoute.jsx
+++ b/frontend/src/router/ProtectedRoute.jsx
@@ -10,18 +10,32 @@ import ALLOWED_IDPS from "@/constants/allowedIdps";
 const frontendBaseUrl = getEnv("VITE_FRONTEND_BASE_URL");
 
 /**
+ * Prevents auth utility routes from becoming post-login destinations.
+ * Replaces "/login" and "/logout" with "/" to avoid redirect loops.
+ * @param {string} pathname Current route pathname
+ * @returns {string} Sanitized pathname safe for post-login redirect storage
+ */
+function sanitizePostLoginPath(pathname) {
+  // Replace login/logout to avoid redirect loops
+  if (pathname === "/login" || pathname === "/logout") return "/";
+
+  return pathname;
+}
+
+/**
  * Returns the original destination URL after login, removing the temporary idp helper param.
  * @param {Object} location The location object from react-router, containing pathname, search, and hash
  * @returns {string} The cleaned absolute URL for post-login redirect
  */
 function getPostLoginRedirectUrl(location) {
   const query = new URLSearchParams(location.search);
+  const sanitizedPathname = sanitizePostLoginPath(location.pathname);
 
   query.delete("idp");
   const cleanedSearch = query.toString();
 
   return new URL(
-    `${location.pathname}${cleanedSearch ? `?${cleanedSearch}` : ""}${location.hash}`,
+    `${sanitizedPathname}${cleanedSearch ? `?${cleanedSearch}` : ""}${location.hash}`,
     frontendBaseUrl,
   ).toString();
 }

--- a/frontend/src/router/index.jsx
+++ b/frontend/src/router/index.jsx
@@ -4,6 +4,7 @@ import AccessControlledRoute from "./AccessControlledRoute";
 import EditAndReview from "./pages/EditAndReview";
 import PublishPage from "./pages/PublishPage";
 import ExportPage from "./pages/ExportPage";
+import LogoutPage from "./pages/LogoutPage";
 import MainLayout from "./layouts/MainLayout";
 import MainLayoutPublic from "./layouts/MainLayoutPublic";
 import LandingPageTabs from "./layouts/LandingPageTabs";
@@ -61,6 +62,11 @@ const RouterConfig = createBrowserRouter([
       {
         path: "error",
         element: <ErrorPage />,
+      },
+
+      {
+        path: "logout",
+        element: <LogoutPage />,
       },
 
       // Advisories and closures - All

--- a/frontend/src/router/layouts/MainLayout.jsx
+++ b/frontend/src/router/layouts/MainLayout.jsx
@@ -1,5 +1,5 @@
 import { useMemo, useState, useEffect } from "react";
-import { Outlet } from "react-router-dom";
+import { Link, Outlet } from "react-router-dom";
 import "./MainLayout.scss";
 import useAccess from "@/hooks/useAccess";
 import { useApiGet } from "@/hooks/useApi";
@@ -17,7 +17,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCircleExclamation } from "@fa-kit/icons/classic/regular";
 
 export default function MainLayout() {
-  const { logOut, isAuthenticated } = useAccess();
+  const { isAuthenticated } = useAccess();
   const globalFlashMessage = useFlashMessage();
 
   // Fetch the user name to display in the header
@@ -85,13 +85,9 @@ export default function MainLayout() {
                 <div className="user-controls d-none d-lg-flex text-white align-items-center ms-auto">
                   <div className="user-name me-3">{userName}</div>
 
-                  <button
-                    type="button"
-                    onClick={logOut}
-                    className="btn btn-text text-white"
-                  >
+                  <Link to="/logout" className="btn btn-text text-white">
                     Logout
-                  </button>
+                  </Link>
                 </div>
 
                 <button
@@ -110,7 +106,6 @@ export default function MainLayout() {
           <TouchMenu
             show={showTouchMenu}
             closeMenu={() => setShowTouchMenu(false)}
-            logOut={logOut}
             userName={userName}
           />
 

--- a/frontend/src/router/pages/LogoutPage.jsx
+++ b/frontend/src/router/pages/LogoutPage.jsx
@@ -1,0 +1,17 @@
+import { useEffect } from "react";
+import useAccess from "@/hooks/useAccess";
+import LoadingBar from "@/components/LoadingBar";
+
+export default function LogoutPage() {
+  const { logOut } = useAccess();
+
+  useEffect(() => {
+    logOut();
+  }, [logOut]);
+
+  return (
+    <div className="container mt-3">
+      <LoadingBar />
+    </div>
+  );
+}

--- a/frontend/src/router/pages/advisories/advisory/Advisory.jsx
+++ b/frontend/src/router/pages/advisories/advisory/Advisory.jsx
@@ -1,7 +1,15 @@
-import { useState, useRef, useEffect, useContext, useMemo } from "react";
+import {
+  useState,
+  useRef,
+  useEffect,
+  useContext,
+  useMemo,
+  useCallback,
+} from "react";
 import {
   Navigate,
   useLocation,
+  useBlocker,
   useParams,
   useSearchParams,
 } from "react-router-dom";
@@ -21,6 +29,9 @@ import qs from "qs";
 import useAccess from "@/hooks/useAccess";
 import useAdvisoryRole from "@/hooks/advisories/useAdvisoryRole";
 import useCms from "@/hooks/useCms";
+import useUnsavedChangesDialog from "@/hooks/useUnsavedChangesDialog";
+import useNavigationGuard from "@/hooks/useNavigationGuard";
+import UnsavedChangesDialog from "@/components/advisories/composite/advisoryForm/UnsavedChangesDialog";
 import ErrorContext from "@/contexts/ErrorContext";
 import { ROLES } from "@/config/permissions";
 
@@ -97,6 +108,7 @@ export default function Advisory({ mode }) {
   const [confirmationText, setConfirmationText] = useState("");
   const [isSavingDraft, setIsSavingDraft] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [dataChanged, setDataChanged] = useState(false);
   const linksRef = useRef([]);
   const advisoryDateRef = useRef(moment().tz("America/Vancouver").toDate());
   const [advisoryId, setAdvisoryId] = useState();
@@ -131,6 +143,81 @@ export default function Advisory({ mode }) {
   const auth = useAuth();
   const initialized = !auth.isLoading;
   const isAuthenticated = auth.isAuthenticated;
+
+  // Use a route blocker to show a confirmation dialog when the user attempts to navigate away with unsaved changes
+  const blocker = useBlocker(dataChanged);
+  // Ref to track if the route blocker is currently active, to prevent multiple blocker flows from stacking if more navigation is attempted while the dialog is open
+  const isBlockerActive = useRef(false);
+
+  // AdvisoryForm registers its save-draft function here so the "Unsaved changes" dialog can call it
+  const saveDraftHandlerRef = useRef(null);
+
+  // Callback for AdvisoryForm to register its save-draft handler function, so the "Unsaved changes" dialog can call it
+  const registerSaveDraftHandler = useCallback((handler) => {
+    saveDraftHandlerRef.current = handler;
+  }, []);
+
+  // Calls the registered save-draft handler from the AdvisoryForm and returns whether the save was successful.
+  // Saving can fail due to network errors, or validation errors in the form data.
+  // On success, proceed with navigation. On failure, stay on the form.
+  const saveDraftFromForm = useCallback(async () => {
+    const saveDraftHandler = saveDraftHandlerRef.current;
+
+    if (!saveDraftHandler) {
+      return false;
+    }
+
+    return Boolean(await saveDraftHandler());
+  }, []);
+
+  // Use the custom hook to manage the "Unsaved changes" dialog and get the function to trigger it,
+  // along with the props for the dialog component
+  const {
+    confirmNavigation: confirmUnsavedChangesNavigation,
+    props: unsavedChangesDialogProps,
+  } = useUnsavedChangesDialog(saveDraftFromForm);
+
+  // Set dataChanged to true when any of the form fields change, to enable the navigation guard
+  const markChanged = useCallback(() => {
+    setDataChanged(true);
+  }, []);
+
+  useNavigationGuard(dataChanged);
+
+  // Block internal route transitions while there are unsaved changes.
+  // beforeunload is still handled by useNavigationGuard for browser-level exits.
+  useEffect(() => {
+    if (blocker.state !== "blocked" || isBlockerActive.current) {
+      return;
+    }
+
+    // Lock this blocked transition until the router confirms it has been
+    // resolved so we do not start a second prompt flow for the same attempt.
+    isBlockerActive.current = true;
+
+    (async () => {
+      // Wait for the user's choice in the "Unsaved changes" dialog and proceed with navigation accordingly
+      const shouldProceed = await confirmUnsavedChangesNavigation();
+
+      if (shouldProceed) {
+        setDataChanged(false);
+        blocker.proceed();
+        return;
+      }
+
+      if (blocker.state === "blocked") {
+        blocker.reset();
+      }
+    })();
+  }, [blocker, confirmUnsavedChangesNavigation]);
+
+  // Keep the blocked-navigation lock until the router confirms the transition is unblocked.
+  // This prevents a second modal from opening on the same blocked navigation attempt.
+  useEffect(() => {
+    if (blocker.state === "unblocked") {
+      isBlockerActive.current = false;
+    }
+  }, [blocker.state]);
 
   // In "update" mode, track when the original data from the CMS is loaded
   // to prevent re-fetching
@@ -719,7 +806,18 @@ export default function Advisory({ mode }) {
     return null;
   }, [advisoryStatus, allAdvisoryStatuses]);
 
-  function setToBack() {
+  async function setToBack() {
+    if (dataChanged) {
+      // Show the "Unsaved changes" dialog and wait for the user's response before navigating back
+      const shouldProceed = await confirmUnsavedChangesNavigation();
+
+      if (!shouldProceed) {
+        return;
+      }
+
+      setDataChanged(false);
+    }
+
     if (mode === "update" && fromSummary) {
       setIsConfirmation(true);
     } else {
@@ -1060,6 +1158,7 @@ export default function Advisory({ mode }) {
       });
 
       setAdvisoryId(advisory.documentId);
+      setDataChanged(false);
       setIsSubmitting(false);
       setIsSavingDraft(false);
       setConfirmationTextForStatus(status.code);
@@ -1177,6 +1276,7 @@ export default function Advisory({ mode }) {
       });
 
       setAdvisoryId(advisory.documentId);
+      setDataChanged(false);
       setIsSubmitting(false);
       setIsSavingDraft(false);
       setConfirmationTextForStatus(status.code);
@@ -1237,9 +1337,7 @@ export default function Advisory({ mode }) {
                 <button
                   type="button"
                   className="btn btn-link btn-back mt-4"
-                  onClick={() => {
-                    setToBack();
-                  }}
+                  onClick={setToBack}
                 >
                   <FontAwesomeIcon icon={faArrowLeft} className="me-1" />
                   Back to{" "}
@@ -1268,6 +1366,8 @@ export default function Advisory({ mode }) {
               </div>
               <AdvisoryForm
                 mode={mode}
+                markChanged={markChanged}
+                registerSaveDraftHandler={registerSaveDraftHandler}
                 data={{
                   listingRank,
                   setListingRank,
@@ -1361,6 +1461,13 @@ export default function Advisory({ mode }) {
                   setFormError,
                 }}
               />
+
+              <UnsavedChangesDialog {...unsavedChangesDialogProps}>
+                <p>
+                  Changes for this advisory / closure will be permanently
+                  deleted if you do not save them.
+                </p>
+              </UnsavedChangesDialog>
             </>
           )}
         </div>


### PR DESCRIPTION
### Jira Ticket

CMS-1704

### Description
<!-- What did you change, and why? -->

This branch adds similar confirmation dialogs to ACT to the ones used on DOOT. 

- Added local state to track whether the form has been changed since the page loaded. I hoped I could listen for "onChange" events on the form element and catch any form events that bubble up, but the React Bootstrap components and the React-Select components don't fire normal events that bubble up, so I had to also add a bunch of manual "markChanged()" function calls on the existing event handlers. Not ideal, but minimally invasive. I think it's fine until we refactor this form to use something like react-hook-form! 😝 
- If there are changes and the user tries to close the tab or navigate outside of the app (using the back/forward browser buttons, for example), I hooked up the same useNavigationGuard  hook used on DOOT so it will behave the same there.
- If there are changes and the user tries to follow an internal link (from the sidebar or the footer), I added a navigation blocker to show a confirmation dialog that prompts them to save or discard their draft.
- I changed the logout button to a nav link and added a /logout page that simply runs auth.logout() so we could intercept it with the nav blocker.

Confirmed with UX:
- If the user dismisses the modal by clicking "X", it stays on the form 
- If the user clicks "Save draft" and there are validation errors that prevent it from saving, it stays on the page to let them fix the errors 
- If the user clicks "Save draft" and there are no errors, it saves the draft and continues to their destination page
- If the user clicks "Discard draft", it doesn't save and continues to the destination page