### PR TITLE
CMS-1756: Update history display

### DIFF
--- a/frontend/src/components/advisories/composite/advisoryHistory/AdvisoryHistory.jsx
+++ b/frontend/src/components/advisories/composite/advisoryHistory/AdvisoryHistory.jsx
@@ -7,7 +7,7 @@ import useCms from "@/hooks/useCms";
 import { dateCompare } from "@/lib/advisories/utils/AppUtil";
 
 function formatTimestamp(date) {
-  const datePart = format(date, "MMMM dd, yyyy");
+  const datePart = format(date, "MMM d, yyyy");
   const timePart = format(date, "h:mm aaa");
 
   return `${datePart} at ${timePart}`;
@@ -177,9 +177,8 @@ export default function AdvisoryHistory({
             key={`revision-${ah.revisionNumber}-idx-${index}`}
             className="mb-2"
           >
-            Revision number {ah.revisionNumber} {ah.displayText}{" "}
-            {ah.actorName ? <> by {ah.actorName} on </> : null}{" "}
-            <span className="text-nowrap">{ah.displayDate}</span>
+            {ah.displayDate} {"\u2013"} Revision {ah.revisionNumber}{" "}
+            {ah.displayText} {ah.actorName ? <> by {ah.actorName}</> : null}
           </div>
         ))}
     </div>

--- a/frontend/src/components/advisories/composite/advisoryHistory/AdvisoryHistory.jsx
+++ b/frontend/src/components/advisories/composite/advisoryHistory/AdvisoryHistory.jsx
@@ -6,7 +6,18 @@ import { useAuth } from "react-oidc-context";
 import useCms from "@/hooks/useCms";
 import { dateCompare } from "@/lib/advisories/utils/AppUtil";
 
-export default function AdvisoryHistory({ advisoryNumber, revisionNumber }) {
+function formatTimestamp(date) {
+  const datePart = format(date, "MMMM dd, yyyy");
+  const timePart = format(date, "h:mm aaa");
+
+  return `${datePart} at ${timePart}`;
+}
+
+export default function AdvisoryHistory({
+  advisoryNumber,
+  latestRevisionNumber,
+  reviewedDate,
+}) {
   const [advisoryHistory, setAdvisoryHistory] = useState([]);
   const auth = useAuth();
   const { cmsGet } = useCms();
@@ -17,67 +28,130 @@ export default function AdvisoryHistory({ advisoryNumber, revisionNumber }) {
         (advisories) => {
           const advisoriesHistory = [];
 
+          function pushHistory({
+            revisionNumber,
+            actorName,
+            displayText,
+            date,
+          }) {
+            if (!date) return;
+            const ts = new Date(date).valueOf();
+
+            if (Number.isNaN(ts)) return;
+
+            advisoriesHistory.push({
+              revisionNumber,
+              actorName,
+              displayText,
+              displayDate: formatTimestamp(ts),
+              dateToCompare: ts,
+            });
+          }
+
           if (advisories && advisories.length > 0) {
             advisories.forEach((ad) => {
-              // Add review events to the history if they exist, or continue to look for other events
-              if (ad.reviewedByName && ad.reviewedDate) {
-                advisoriesHistory.push({
-                  revisionNumber: ad.revisionNumber,
-                  submitter: ad.reviewedByName,
-                  submittedTime: format(
-                    ad.reviewedDate,
-                    "MMMM dd, yyyy h:mm aaa",
-                  ),
-                  displayText: "Reviewed by",
-                  dateToCompare: new Date(ad.reviewedDate).valueOf(),
-                });
-              } else if (ad.modifiedByName && ad.modifiedByName === "system") {
-                const record = {
-                  revisionNumber: ad.revisionNumber,
-                  submitter: ad.modifiedByName,
-                  submittedTime: format(
-                    ad.modifiedDate,
-                    "MMMM dd, yyyy h:mm aaa",
-                  ),
-                  displayText: "Published by",
-                  dateToCompare: new Date(ad.modifiedDate).valueOf(),
-                };
+              const status = ad.advisoryStatus?.code || "";
+              let statusActorName = ad.modifiedByName;
 
-                if (ad.removalDate) {
-                  record.displayText = "Removed by";
+              if (status === "PUB") {
+                statusActorName = ad.publishedByName || ad.modifiedByName;
+              } else if (status === "UNP") {
+                statusActorName = ad.unpublishedByName || ad.modifiedByName;
+              }
+
+              if (ad.revisionNumber === 1) {
+                let actor = ad.createdByName || "";
+                let text = "drafted";
+                let includeRequestedBy = false;
+
+                if (status === "PUB") {
+                  actor = ad.publishedByName || "";
+                  text = "published";
                 }
-                advisoriesHistory.push(record);
-              } else if (!ad.modifiedDate && ad.createdDate) {
-                const record = {
-                  revisionNumber: ad.revisionNumber,
-                  submitter: ad.submittedByName,
-                  submittedTime: format(
-                    ad.createdDate,
-                    "MMMM dd, yyyy h:mm aaa",
-                  ),
-                  displayText: "Requested by",
-                  dateToCompare: new Date(ad.createdDate).valueOf(),
-                };
 
-                advisoriesHistory.push(record);
-              } else if (ad.modifiedDate) {
-                const record = {
-                  revisionNumber: ad.revisionNumber,
-                  submitter: ad.modifiedByName,
-                  submittedTime: format(
-                    ad.modifiedDate,
-                    "MMMM dd, yyyy h:mm aaa",
-                  ),
-                  displayText: "Updated by",
-                  dateToCompare: new Date(ad.modifiedDate).valueOf(),
-                };
+                if (status === "SCH") {
+                  actor = ad.modifiedByName || "";
+                  text = "scheduled";
+                }
 
-                advisoriesHistory.push(record);
+                let actorName = actor || "";
+
+                if (actor && actor !== ad.submittedByName) {
+                  includeRequestedBy = true;
+                  actorName = ad.submittedByName || "";
+                }
+
+                pushHistory({
+                  revisionNumber: ad.revisionNumber,
+                  displayText: includeRequestedBy
+                    ? `${text} by ${actor} requested`
+                    : text,
+                  actorName,
+                  date: ad.modifiedDate || ad.createdDate,
+                });
+              } else {
+                if (status === "SCH") {
+                  pushHistory({
+                    revisionNumber: ad.revisionNumber,
+                    displayText: "scheduled",
+                    actorName: ad.modifiedByName,
+                    date: ad.modifiedDate,
+                  });
+                }
+
+                if (status === "PUB") {
+                  pushHistory({
+                    revisionNumber: ad.revisionNumber,
+                    displayText: "published",
+                    actorName:
+                      ad.publishedByName === "system"
+                        ? "system based on posting date"
+                        : statusActorName,
+                    date: ad.publishedDate || ad.modifiedDate,
+                  });
+                }
+
+                if (status === "UNP") {
+                  pushHistory({
+                    revisionNumber: ad.revisionNumber,
+                    displayText: "unpublished",
+                    actorName:
+                      ad.unpublishedByName === "system"
+                        ? "system based on expiry date"
+                        : statusActorName,
+                    date: ad.unpublishedDate || ad.modifiedDate,
+                  });
+                }
+
+                if (status === "HQR") {
+                  pushHistory({
+                    revisionNumber: ad.revisionNumber,
+                    displayText: "updated",
+                    actorName: ad.modifiedByName,
+                    date: ad.modifiedDate,
+                  });
+                }
+
+                if (status === "DFT") {
+                  pushHistory({
+                    revisionNumber: ad.revisionNumber,
+                    displayText: "drafted",
+                    actorName: ad.modifiedByName,
+                    date: ad.modifiedDate,
+                  });
+                }
+              }
+
+              if (ad.reviewedByName && ad.reviewedByName !== statusActorName) {
+                pushHistory({
+                  revisionNumber: ad.revisionNumber,
+                  displayText: "reviewed",
+                  actorName: ad.reviewedByName,
+                  date: ad.reviewedDate,
+                });
               }
             });
 
-            // Keep the newest history item first regardless of whether it came from
-            // a review, publish, request, or update event
             advisoriesHistory.sort(dateCompare);
             setAdvisoryHistory([...advisoriesHistory]);
           }
@@ -87,19 +161,25 @@ export default function AdvisoryHistory({ advisoryNumber, revisionNumber }) {
   }, [
     advisoryNumber,
     // Re-fetch data if the revision number changes, which indicates new versions and history to display
-    revisionNumber,
+    latestRevisionNumber,
+    // Re-fetch when reviewed date changes without a revision bump
+    reviewedDate,
     auth.isAuthenticated,
     auth.isLoading,
     setAdvisoryHistory,
     cmsGet,
   ]);
   return (
-    <div className="act-history-container px-3">
+    <div className="act-history-container">
       {advisoryHistory.length > 0 &&
         advisoryHistory.map((ah, index) => (
-          <div key={index} className="row">
-            Revision number {ah.revisionNumber} {ah.displayText.toLowerCase()}{" "}
-            {ah.submitter} at {ah.submittedTime}
+          <div
+            key={`revision-${ah.revisionNumber}-idx-${index}`}
+            className="mb-2"
+          >
+            Revision number {ah.revisionNumber} {ah.displayText}{" "}
+            {ah.actorName ? <> by {ah.actorName} on </> : null}{" "}
+            <span className="text-nowrap">{ah.displayDate}</span>
           </div>
         ))}
     </div>
@@ -108,5 +188,6 @@ export default function AdvisoryHistory({ advisoryNumber, revisionNumber }) {
 
 AdvisoryHistory.propTypes = {
   advisoryNumber: PropTypes.number.isRequired,
-  revisionNumber: PropTypes.number.isRequired,
+  latestRevisionNumber: PropTypes.number.isRequired,
+  reviewedDate: PropTypes.string,
 };

--- a/frontend/src/components/advisories/composite/advisorySummaryView/AdvisorySummaryView.jsx
+++ b/frontend/src/components/advisories/composite/advisorySummaryView/AdvisorySummaryView.jsx
@@ -443,7 +443,7 @@ export default function AdvisorySummaryView({
         )}
       </section>
 
-      <section>
+      <section style={{ maxWidth: "inherit" }}>
         <h3>History</h3>
         <AdvisoryHistory
           latestRevisionNumber={advisory.revisionNumber}

--- a/frontend/src/components/advisories/composite/advisorySummaryView/AdvisorySummaryView.jsx
+++ b/frontend/src/components/advisories/composite/advisorySummaryView/AdvisorySummaryView.jsx
@@ -446,8 +446,9 @@ export default function AdvisorySummaryView({
       <section>
         <h3>History</h3>
         <AdvisoryHistory
-          revisionNumber={advisory.revisionNumber}
+          latestRevisionNumber={advisory.revisionNumber}
           advisoryNumber={advisory.advisoryNumber}
+          reviewedDate={advisory.reviewedDate}
         />
       </section>
     </>

--- a/frontend/src/components/advisories/shared/summaryActionButton/SummaryActionButton.jsx
+++ b/frontend/src/components/advisories/shared/summaryActionButton/SummaryActionButton.jsx
@@ -29,6 +29,7 @@ export default function SummaryActionButton({
   canUnpublish = false,
   onUnpublish,
   canMarkReviewed = false,
+  disableMarkReviewed = false,
   onMarkReviewed,
   className = "",
   isRequestingCms = false,
@@ -90,7 +91,9 @@ export default function SummaryActionButton({
           </Dropdown.Item>
 
           <Dropdown.Item
-            disabled={!canMarkReviewed || isRequestingCms}
+            disabled={
+              !canMarkReviewed || disableMarkReviewed || isRequestingCms
+            }
             onClick={() => action(onMarkReviewed)}
           >
             <FontAwesomeIcon icon={faCircleCheck} />
@@ -105,6 +108,7 @@ export default function SummaryActionButton({
 SummaryActionButton.propTypes = {
   canUnpublish: PropTypes.bool,
   canMarkReviewed: PropTypes.bool,
+  disableMarkReviewed: PropTypes.bool,
   onMarkReviewed: PropTypes.func.isRequired,
   onUnpublish: PropTypes.func.isRequired,
   className: PropTypes.string,

--- a/frontend/src/hooks/advisories/useAdvisoryMarkReviewed.js
+++ b/frontend/src/hooks/advisories/useAdvisoryMarkReviewed.js
@@ -68,7 +68,13 @@ export default function useAdvisoryMarkReviewed({
 
       try {
         await cmsPut(`public-advisory-audits/${rowData.documentId}`, {
-          data: buildReviewPayload(reviewedStatus, reviewedByName, isApproving),
+          data: buildReviewPayload(
+            reviewedStatus,
+            reviewedByName,
+            rowData.advisoryNumber,
+            rowData.revisionNumber,
+            isApproving,
+          ),
         });
 
         openMarkReviewedSuccess(`${rowData.title} was marked as reviewed.`);

--- a/frontend/src/lib/advisories/utils/AdvisoryReviewDashboardQuery.js
+++ b/frontend/src/lib/advisories/utils/AdvisoryReviewDashboardQuery.js
@@ -8,10 +8,6 @@ export default function buildReviewFilter({ isReviewDashboard }) {
   const now = moment().toISOString();
   const oneWeekFromNow = moment().add(7, "days").toISOString();
 
-  // Temporary condition to exclude advisories that haven't been created recently.
-  // @TODO: Remove this cutoff after migration verification is complete.
-  const oneMonthAgo = moment().subtract(1, "month").toISOString();
-
   return [
     {
       $and: [
@@ -98,12 +94,6 @@ export default function buildReviewFilter({ isReviewDashboard }) {
                 {
                   reviewedByName: {
                     $null: true,
-                  },
-                },
-                // Temporary condition
-                {
-                  createdAt: {
-                    $between: [oneMonthAgo, now],
                   },
                 },
               ],

--- a/frontend/src/lib/advisories/utils/AdvisoryReviewPayload.js
+++ b/frontend/src/lib/advisories/utils/AdvisoryReviewPayload.js
@@ -2,12 +2,16 @@
  * Build the review payload
  * @param {Object} newAdvisoryStatus The effective advisory status after review is complete
  * @param {string} reviewedByName The current user's name (from auth.user?.profile?.name)
+ * @param {number} advisoryNumber The advisory number
+ * @param {number} revisionNumber The revision number
  * @param {boolean} isApproving True when HQR transitions to PUB or SCH, false otherwise
- * @returns {Object} Minimal payload containing only fields updated by mark reviewed
+ * @returns {Object} Payload containing fields updated by mark reviewed plus identifiers needed by middleware
  */
 export function buildReviewPayload(
   newAdvisoryStatus,
   reviewedByName,
+  advisoryNumber,
+  revisionNumber,
   isApproving = false,
 ) {
   const reviewedDate = new Date().toISOString();
@@ -16,12 +20,13 @@ export function buildReviewPayload(
   const payload = {
     reviewedByName,
     reviewedDate,
+    advisoryStatus: newAdvisoryStatus.documentId,
+    advisoryNumber,
+    revisionNumber,
   };
 
   // special cases for transitioning from HQR to PUB or SCH
   if (isApproving) {
-    payload.advisoryStatus = newAdvisoryStatus.documentId;
-
     if (newAdvisoryStatus.code === "PUB") {
       payload.publishedByName = reviewedByName;
       payload.publishedDate = reviewedDate;

--- a/frontend/src/router/pages/advisories/advisorySummary/AdvisorySummary.jsx
+++ b/frontend/src/router/pages/advisories/advisorySummary/AdvisorySummary.jsx
@@ -364,7 +364,12 @@ export default function AdvisorySummary() {
       advisory.reviewedByName,
       advisory.reviewedDate,
     );
-  }, [advisory.reviewedDate, advisory.reviewedByName, advisory.modifiedByName, buildTimestampString]);
+  }, [
+    advisory.reviewedDate,
+    advisory.reviewedByName,
+    advisory.modifiedByName,
+    buildTimestampString,
+  ]);
 
   // Determine if the advisory can be unpublished
   const canUnpublish = useMemo(() => {
@@ -522,6 +527,7 @@ export default function AdvisorySummary() {
                               canUnpublish={canUnpublish}
                               onUnpublish={handleUnpublish}
                               canMarkReviewed={isApprover}
+                              disableMarkReviewed={!!advisory.reviewedByName}
                               onMarkReviewed={handleMarkReviewed}
                               isRequestingCms={isRequestingCms}
                             />
@@ -530,7 +536,9 @@ export default function AdvisorySummary() {
                             <Button
                               label="Mark reviewed"
                               styling="btn-outline-primary btn flex-grow-1 flex-xl-shrink-0 d-none d-xl-block"
-                              disabled={isRequestingCms}
+                              disabled={
+                                isRequestingCms || !!advisory.reviewedByName
+                              }
                               onClick={handleMarkReviewed}
                               hasLoader={isMarkingReviewed}
                               leftIcon={


### PR DESCRIPTION
### Jira Ticket

CMS-1756

### Description
- Updated the history display to match UI design
- Disable the "Mark reviewed" button on the summary page if the version is already reviewed.
- Fixed issue with AdvisoryReviewPayload not providing enough info to correctly trigger middleware
- Removed temporary condition from AdvisoryReviewDashboardQuery (following https://github.com/bcgov/bcparks.ca/pull/1854)
- Fixed behaviour so the history refreshes when the "Mark reviewed" button is clicked.