### PR TITLE
CMS-1759: Tweak Summary pg action menu styles

### DIFF
--- a/frontend/src/components/advisories/shared/summaryActionButton/SummaryActionButton.jsx
+++ b/frontend/src/components/advisories/shared/summaryActionButton/SummaryActionButton.jsx
@@ -16,6 +16,44 @@ const ACTION_MENU_POPPER_CONFIG = {
   strategy: "fixed",
   modifiers: [
     {
+      // Match the menu's width to the container width on smaller screens
+      name: "minWidthMatchReference",
+      enabled: true,
+      phase: "beforeWrite",
+      requires: ["computeStyles"],
+      // Sets the min-width of the menu to match the form's width
+      fn({ state }) {
+        if (window.innerWidth < 1200) {
+          // Get width of the .act-form container
+          const formContainer = document.querySelector(".act-form");
+
+          if (formContainer) {
+            state.styles.popper.minWidth = `${formContainer.offsetWidth}px`;
+          }
+        } else {
+          state.styles.popper.minWidth = "";
+        }
+      },
+      // Calculates the min-width for the menu before the first Popper update, and on resize
+      effect({ state }) {
+        if (window.innerWidth < 1200) {
+          const formContainer = document.querySelector(".act-form");
+
+          if (formContainer) {
+            state.elements.popper.style.minWidth = `${formContainer.offsetWidth}px`;
+          }
+        } else {
+          state.elements.popper.style.minWidth = "";
+        }
+
+        return () => {
+          state.elements.popper.style.minWidth = "";
+        };
+      },
+    },
+
+    {
+      // Keep the menu inside the viewport as it scrolls
       name: "preventOverflow",
       options: {
         altAxis: true,

--- a/frontend/src/components/advisories/shared/summaryActionButton/SummaryActionButton.jsx
+++ b/frontend/src/components/advisories/shared/summaryActionButton/SummaryActionButton.jsx
@@ -16,38 +16,38 @@ const ACTION_MENU_POPPER_CONFIG = {
   strategy: "fixed",
   modifiers: [
     {
-      // Match the menu's width to the container width on smaller screens
-      name: "minWidthMatchReference",
+      // Match the menu width to the container width on smaller screens
+      name: "widthMatchReference",
       enabled: true,
       phase: "beforeWrite",
       requires: ["computeStyles"],
-      // Sets the min-width of the menu to match the form's width
+      // Sets the menu width to match the form's width
       fn({ state }) {
         if (window.innerWidth < 1200) {
           // Get width of the .act-form container
           const formContainer = document.querySelector(".act-form");
 
           if (formContainer) {
-            state.styles.popper.minWidth = `${formContainer.offsetWidth}px`;
+            state.styles.popper.width = `${formContainer.offsetWidth}px`;
           }
         } else {
-          state.styles.popper.minWidth = "";
+          state.styles.popper.width = "";
         }
       },
-      // Calculates the min-width for the menu before the first Popper update, and on resize
+      // Sets initial width before first Popper compute and cleans up on teardown
       effect({ state }) {
         if (window.innerWidth < 1200) {
           const formContainer = document.querySelector(".act-form");
 
           if (formContainer) {
-            state.elements.popper.style.minWidth = `${formContainer.offsetWidth}px`;
+            state.elements.popper.style.width = `${formContainer.offsetWidth}px`;
           }
         } else {
-          state.elements.popper.style.minWidth = "";
+          state.elements.popper.style.width = "";
         }
 
         return () => {
-          state.elements.popper.style.minWidth = "";
+          state.elements.popper.style.width = "";
         };
       },
     },

--- a/frontend/src/components/advisories/shared/summaryActionButton/SummaryActionButton.scss
+++ b/frontend/src/components/advisories/shared/summaryActionButton/SummaryActionButton.scss
@@ -8,5 +8,6 @@
   // Increase vertical padding to provide > ~44px tappable area
   .dropdown-item {
     padding-block: 0.75rem;
+    white-space: normal;
   }
 }

--- a/frontend/src/components/advisories/shared/summaryActionButton/SummaryActionButton.scss
+++ b/frontend/src/components/advisories/shared/summaryActionButton/SummaryActionButton.scss
@@ -1,4 +1,10 @@
 .summary-action-button {
+  // Override Bootstrap's default spacing and border colors
+  .dropdown-menu {
+    margin-top: 0.25rem;
+    border-color: var(--surface-color-border-medium);
+  }
+
   // Increase vertical padding to provide > ~44px tappable area
   .dropdown-item {
     padding-block: 0.75rem;


### PR DESCRIPTION
### Jira Ticket

CMS-1759

### Description
<!-- What did you change, and why? -->

Some changes to the popper menu styles for the "Summary action buttons" dropdown component:

- match the width of the menu to the width of the form container
- made the grey border color darker to match Figma
<img width="1114" height="424" alt="image" src="https://github.com/user-attachments/assets/a65c5914-41d4-42ca-9e22-6c85a7b06ef1" />
