### PR TITLE
CMS-1732: Go back to dashboard if back link is clicked on advisory page

### DIFF
--- a/frontend/src/router/pages/advisories/advisory/Advisory.jsx
+++ b/frontend/src/router/pages/advisories/advisory/Advisory.jsx
@@ -1,5 +1,10 @@
 import { useState, useRef, useEffect, useContext, useMemo } from "react";
-import { Navigate, useParams, useSearchParams } from "react-router-dom";
+import {
+  Navigate,
+  useLocation,
+  useParams,
+  useSearchParams,
+} from "react-router-dom";
 import PropTypes from "prop-types";
 import "./Advisory.css";
 import moment from "moment";
@@ -22,7 +27,9 @@ import { ROLES } from "@/config/permissions";
 export default function Advisory({ mode }) {
   const { setError } = useContext(ErrorContext);
   const [searchParams] = useSearchParams();
+  const location = useLocation();
   const tabParam = searchParams.get("tab");
+  const fromSummary = location.state?.fromSummary === true;
 
   const [revisionNumber, setRevisionNumber] = useState();
   const [standardMessages, setStandardMessages] = useState([]);
@@ -713,10 +720,10 @@ export default function Advisory({ mode }) {
   }, [advisoryStatus, allAdvisoryStatuses]);
 
   function setToBack() {
-    if (mode === "create") {
-      setToDashboard(true);
-    } else {
+    if (mode === "update" && fromSummary) {
       setIsConfirmation(true);
+    } else {
+      setToDashboard(true);
     }
   }
 
@@ -1236,9 +1243,9 @@ export default function Advisory({ mode }) {
                 >
                   <FontAwesomeIcon icon={faArrowLeft} className="me-1" />
                   Back to{" "}
-                  {mode === "create"
-                    ? "advisories and closures dashboard"
-                    : "advisory / closure preview"}
+                  {mode === "update" && fromSummary
+                    ? "advisory / closure preview"
+                    : "advisories and closures dashboard"}
                 </button>
                 <h2 className="mt-5 mb-0">
                   {mode === "create" ? "Create" : "Edit"} advisory / closure

--- a/frontend/src/router/pages/advisories/advisorySummary/AdvisorySummary.jsx
+++ b/frontend/src/router/pages/advisories/advisorySummary/AdvisorySummary.jsx
@@ -442,7 +442,7 @@ export default function AdvisorySummary() {
   }
 
   if (toUpdate) {
-    return <Navigate to={updateAdvisoryUrl} />;
+    return <Navigate to={updateAdvisoryUrl} state={{ fromSummary: true }} />;
   }
 
   if (toError) {


### PR DESCRIPTION
### Jira Ticket

CMS-1732

### Description
<!-- What did you change, and why? -->
-  When a user goes to the edit page from the preview page:
    - The back link text should be “Back to advisory / closure preview”
    - It should go back to the preview page
- When a user goes to the edit page by clicking "Edit" from the All/Review tab:
  - The back link text should be "Back to advisories and closures dashboard"
  - It should go back to the All/Review tab
