### PR TITLE
CMS-1754: Use specific empty state message on ACT review tab

### DIFF
--- a/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.jsx
+++ b/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.jsx
@@ -1267,14 +1267,23 @@ export default function AdvisoryDashboard({
     isReviewDashboard && !isLoading && comparisonTotalItems === 0;
 
   const emptyState = showNoItemsToReviewMessage ? (
+    // When there are no advisories to review, show an empty state message
     <ReviewEmptyState />
   ) : (
+    // When filters are causing an empty state, show a message
     <div>
       <p>No records to display.</p>
-      <p className="fs-6">
-        Try adjusting your filters or check ‘Include unpublished advisories and
-        closures’ to see more results.
-      </p>
+
+      {isReviewDashboard ? (
+        // The review dashboard has column filters only
+        <p className="fs-6">Try adjusting your filters to see more results.</p>
+      ) : (
+        // The main dashboard has both column filters and the "Include unpublished" toggle
+        <p className="fs-6">
+          Try adjusting your filters or check ‘Include unpublished advisories
+          and closures’ to see more results.
+        </p>
+      )}
     </div>
   );
 


### PR DESCRIPTION
### Jira Ticket

CMS-1754

### Description
<!-- What did you change, and why? -->

The empty state message in the ACT table was updated to mention clearing the filters. This is a quick tweak so the review page doesn't mention the "Show unpublished" checkbox, since it doesn't exist on that page.