### PR TITLE
CMS-1756: Rework advisory history timeline display logic

### DIFF
--- a/frontend/src/components/advisories/composite/advisoryHistory/AdvisoryHistory.jsx
+++ b/frontend/src/components/advisories/composite/advisoryHistory/AdvisoryHistory.jsx
@@ -4,10 +4,10 @@ import "./AdvisoryHistory.css";
 import { format } from "date-fns";
 import { useAuth } from "react-oidc-context";
 import useCms from "@/hooks/useCms";
-import { dateCompare } from "@/lib/advisories/utils/AppUtil";
+import { advisoryHistoryCompare } from "@/lib/advisories/utils/AppUtil";
 
 function formatTimestamp(date) {
-  const datePart = format(date, "MMM d, yyyy");
+  const datePart = format(date, "MMMM d, yyyy");
   const timePart = format(date, "h:mm aaa");
 
   return `${datePart} at ${timePart}`;
@@ -44,7 +44,6 @@ export default function AdvisoryHistory({
               actorName,
               displayText,
               displayDate: formatTimestamp(ts),
-              dateToCompare: ts,
             });
           }
 
@@ -60,33 +59,59 @@ export default function AdvisoryHistory({
               }
 
               if (ad.revisionNumber === 1) {
-                let actor = ad.createdByName || "";
+                let creatorName = ad.createdByName || "";
                 let text = "drafted";
                 let includeRequestedBy = false;
 
                 if (status === "PUB") {
-                  actor = ad.publishedByName || "";
-                  text = "published";
+                  if (
+                    ad.publishedByName &&
+                    ad.publishedByName === ad.createdByName
+                  ) {
+                    creatorName = ad.publishedByName;
+                    text = "created and published";
+                  } else if (ad.publishedByName) {
+                    creatorName = ad.createdByName;
+                    text = "created";
+                    pushHistory({
+                      revisionNumber: ad.revisionNumber,
+                      displayText: "published",
+                      actorName:
+                        ad.publishedByName === "system"
+                          ? "system based on posting date"
+                          : ad.publishedByName,
+                      date: ad.publishedDate || ad.modifiedDate,
+                    });
+                  }
                 }
 
                 if (status === "SCH") {
-                  actor = ad.modifiedByName || "";
+                  creatorName = ad.modifiedByName || ad.createdByName || "";
                   text = "scheduled";
                 }
 
-                let actorName = actor || "";
+                if (status === "HQR") {
+                  creatorName = ad.modifiedByName || ad.createdByName || "";
+                  text = "submitted";
+                }
 
-                if (actor && actor !== ad.submittedByName) {
+                let requesterName = "";
+
+                if (
+                  creatorName &&
+                  ad.submittedByName &&
+                  creatorName !== ad.submittedByName
+                ) {
                   includeRequestedBy = true;
-                  actorName = ad.submittedByName || "";
+                  requesterName = ad.submittedByName || "";
                 }
 
                 pushHistory({
                   revisionNumber: ad.revisionNumber,
                   displayText: includeRequestedBy
-                    ? `${text} by ${actor} requested`
+                    ? `${text} by ${creatorName} requested`
                     : text,
-                  actorName,
+                  actorName: requesterName || creatorName,
                   date: ad.modifiedDate || ad.createdDate,
                 });
               } else {
@@ -100,13 +125,24 @@ export default function AdvisoryHistory({
                 }
 
                 if (status === "PUB") {
+                  if (ad.publishedByName !== ad.modifiedByName) {
+                    pushHistory({
+                      revisionNumber: ad.revisionNumber,
+                      displayText: "updated",
+                      actorName: ad.modifiedByName,
+                      date: ad.modifiedDate,
+                    });
+                  }
                   pushHistory({
                     revisionNumber: ad.revisionNumber,
-                    displayText: "published",
+                    displayText:
+                      ad.publishedByName !== ad.modifiedByName
+                        ? "published"
+                        : "updated and published",
                     actorName:
                       ad.publishedByName === "system"
                         ? "system based on posting date"
-                        : statusActorName,
+                        : ad.publishedByName,
                     date: ad.publishedDate || ad.modifiedDate,
                   });
                 }
@@ -123,19 +159,10 @@ export default function AdvisoryHistory({
                   });
                 }
 
-                if (status === "HQR") {
+                if (status === "HQR" || status === "DFT") {
                   pushHistory({
                     revisionNumber: ad.revisionNumber,
                     displayText: "updated",
-                    actorName: ad.modifiedByName,
-                    date: ad.modifiedDate,
-                  });
-                }
-
-                if (status === "DFT") {
-                  pushHistory({
-                    revisionNumber: ad.revisionNumber,
-                    displayText: "drafted",
                     actorName: ad.modifiedByName,
                     date: ad.modifiedDate,
                   });
@@ -152,7 +179,7 @@ export default function AdvisoryHistory({
               }
             });
 
-            advisoriesHistory.sort(dateCompare);
+            advisoriesHistory.sort(advisoryHistoryCompare);
             setAdvisoryHistory([...advisoriesHistory]);
           }
         },

--- a/frontend/src/components/advisories/composite/advisoryHistory/AdvisoryHistory.jsx
+++ b/frontend/src/components/advisories/composite/advisoryHistory/AdvisoryHistory.jsx
@@ -142,7 +142,7 @@ export default function AdvisoryHistory({
                     actorName:
                       ad.publishedByName === "system"
                         ? "system based on posting date"
-                        : ad.publishedByName,
+                        : statusActorName,
                     date: ad.publishedDate || ad.modifiedDate,
                   });
                 }

--- a/frontend/src/lib/advisories/utils/AppUtil.js
+++ b/frontend/src/lib/advisories/utils/AppUtil.js
@@ -19,12 +19,28 @@ export function labelCompare(a, b) {
   return 0;
 }
 
-export function dateCompare(a, b) {
-  if (a.dateToCompare > b.dateToCompare) {
+export function advisoryHistoryCompare(a, b) {
+  if (a.revisionNumber > b.revisionNumber) {
     return -1;
   }
-  if (a.dateToCompare < b.dateToCompare) {
+  if (a.revisionNumber < b.revisionNumber) {
     return 1;
   }
+
+  const displayTextPriority = {
+    reviewed: 1,
+    published: 2,
+  };
+
+  const aPriority = displayTextPriority[a.displayText] || 3;
+  const bPriority = displayTextPriority[b.displayText] || 3;
+
+  if (aPriority < bPriority) {
+    return -1;
+  }
+  if (aPriority > bPriority) {
+    return 1;
+  }
+
   return 0;
 }


### PR DESCRIPTION
### Jira Ticket

CMS-1756

### Description

Reworked the advisory history timeline in the UI to better reflect the published version archive model. Changes include decoupled update/publish rows for revision 1 and subsequent revisions, corrected sort order, system publish/unpublish labels, a submitted actor for HQR status, and a fix for month display.

The original history view was designed against a Figma that didn't match the actual data structure. This rework presents the audit data as accurately as possible given that the source behaves like a publication archive rather than a traditional event log.

There's a markdown file attached to the Jira ticket called `AdvisoryHistory-implementation-notes.md` which explains the implementation. 

