### PR TITLE
CMS-1803: Simplify advisoryStatus code with a consistent object shape

### DIFF
--- a/frontend/src/components/advisories/composite/advisoryForm/AdvisoryForm.jsx
+++ b/frontend/src/components/advisories/composite/advisoryForm/AdvisoryForm.jsx
@@ -124,7 +124,6 @@ export default function AdvisoryForm({
     submittedByName,
     setSubmittedByName,
     advisoryStatuses,
-    advisoryStatusCode,
     advisoryStatus,
     setAdvisoryStatus,
     isStatHoliday,
@@ -1697,7 +1696,7 @@ export default function AdvisoryForm({
 
           <PrimaryActions
             mode={mode}
-            advisoryStatusCode={advisoryStatusCode}
+            advisoryStatusCode={advisoryStatus?.code}
             isUrgent={isAfterHourPublish}
             isApprover={isApprover}
             onPublish={handlePublish}
@@ -1792,7 +1791,6 @@ AdvisoryForm.propTypes = {
     submittedByName: PropTypes.string,
     setSubmittedByName: PropTypes.func.isRequired,
     advisoryStatuses: PropTypes.array.isRequired,
-    advisoryStatusCode: PropTypes.string,
     advisoryStatus: PropTypes.shape({
       code: PropTypes.string.isRequired,
       documentId: PropTypes.string.isRequired,

--- a/frontend/src/components/advisories/composite/advisoryForm/AdvisoryForm.jsx
+++ b/frontend/src/components/advisories/composite/advisoryForm/AdvisoryForm.jsx
@@ -465,10 +465,7 @@ export default function AdvisoryForm({
 
     // Super admins can specify the publishing status with an extra `advisoryStatus` field on the form
     if (hasAnyRole([ROLES.SUPER_ADMIN]) && advisoryStatus) {
-      // Get the Strapi data for the advisory status from the selected value
-      publishedStatus = advisoryStatuses.find(
-        (status) => status.value === advisoryStatus,
-      );
+      publishedStatus = advisoryStatus;
     } else {
       // Get the Strapi data for the "Published" advisory status from its code
       publishedStatus = advisoryStatuses.find(
@@ -1612,11 +1609,11 @@ export default function AdvisoryForm({
               <Select
                 id="advisory-status"
                 options={advisoryStatuses}
-                value={advisoryStatuses.filter(
-                  (a) => a.value === advisoryStatus,
-                )}
+                value={advisoryStatus}
+                getOptionValue={(option) => option.documentId}
+                getOptionLabel={(option) => option.advisoryStatus}
                 onChange={(e) => {
-                  setAdvisoryStatus(e ? e.value : null);
+                  setAdvisoryStatus(e);
                   markChanged();
                 }}
                 placeholder="Search or select an advisory status"
@@ -1796,7 +1793,11 @@ AdvisoryForm.propTypes = {
     setSubmittedByName: PropTypes.func.isRequired,
     advisoryStatuses: PropTypes.array.isRequired,
     advisoryStatusCode: PropTypes.string,
-    advisoryStatus: PropTypes.string,
+    advisoryStatus: PropTypes.shape({
+      code: PropTypes.string.isRequired,
+      documentId: PropTypes.string.isRequired,
+      advisoryStatus: PropTypes.string.isRequired,
+    }),
     setAdvisoryStatus: PropTypes.func.isRequired,
     isStatHoliday: PropTypes.bool,
     isAfterHours: PropTypes.bool,

--- a/frontend/src/router/pages/advisories/advisory/Advisory.jsx
+++ b/frontend/src/router/pages/advisories/advisory/Advisory.jsx
@@ -74,9 +74,7 @@ export default function Advisory({ mode }) {
   const [urgencies, setUrgencies] = useState([]);
   const [urgency, setUrgency] = useState();
   const [advisoryStatuses, setAdvisoryStatuses] = useState([]);
-  // Unfiltered list of all advisory statuses from the CMS (for code lookup)
-  const [allAdvisoryStatuses, setAllAdvisoryStatuses] = useState([]);
-  const [advisoryStatus, setAdvisoryStatus] = useState();
+  const [advisoryStatus, setAdvisoryStatus] = useState(null);
   const [linkTypes, setLinkTypes] = useState([]);
   const [links, setLinks] = useState([]);
   const [headline, setHeadline] = useState("");
@@ -344,7 +342,7 @@ export default function Advisory({ mode }) {
               setUrgency(advisoryData.urgency.documentId);
             }
             if (advisoryData.advisoryStatus) {
-              setAdvisoryStatus(advisoryData.advisoryStatus.documentId);
+              setAdvisoryStatus(advisoryData.advisoryStatus);
             }
             setDisplayAdvisoryDate(
               advisoryData.isAdvisoryDateDisplayed
@@ -680,33 +678,19 @@ export default function Advisory({ mode }) {
 
           setUrgencies([...newUrgencies]);
           const advisoryStatusData = res[12];
-          // Store the list of all advisory statuses before filtering
-          // so we can reference it later for status code lookup
-          const allStatuses = advisoryStatusData.map((s) => ({
-            code: s.code,
-            value: s.documentId,
-          }));
-
-          setAllAdvisoryStatuses(allStatuses);
-
           const restrictedAdvisoryStatusCodes = new Set(["UNP", "SCH"]);
           const desiredOrder = ["PUB", "UNP", "DFT", "SCH", "HQR"];
           const tempAdvisoryStatuses = advisoryStatusData.map((s) => {
-            if (restrictedAdvisoryStatusCodes.has(s.code) && approver) {
-              return {
-                code: s.code,
-                label: s.advisoryStatus,
-                value: s.documentId,
-              };
-            }
-            if (!restrictedAdvisoryStatusCodes.has(s.code)) {
-              return {
-                code: s.code,
-                label: s.advisoryStatus,
-                value: s.documentId,
-              };
-            }
-            return null;
+            const isAllowedStatus =
+              approver || !restrictedAdvisoryStatusCodes.has(s.code);
+
+            if (!isAllowedStatus) return null;
+
+            return {
+              code: s.code,
+              advisoryStatus: s.advisoryStatus,
+              documentId: s.documentId,
+            };
           });
           const filteredStatuses = tempAdvisoryStatuses.filter(
             (s) => s !== null,
@@ -784,27 +768,10 @@ export default function Advisory({ mode }) {
   ]);
 
   // Get the advisory status code to determine the form action button text
-  const advisoryStatusCode = useMemo(() => {
-    // If advisoryStatus is not set, return null
-    if (!advisoryStatus) return null;
-
-    // advisoryStatus can sometimes be an object
-    // return the code property if it exists
-    if (typeof advisoryStatus === "object") {
-      return advisoryStatus.code ?? null;
-    }
-
-    // advisoryStatus can sometimes be a documentId string
-    // Find the document ID in the allAdvisoryStatuses list
-    if (typeof advisoryStatus === "string") {
-      return (
-        allAdvisoryStatuses.find((status) => status.value === advisoryStatus)
-          ?.code ?? null
-      );
-    }
-
-    return null;
-  }, [advisoryStatus, allAdvisoryStatuses]);
+  const advisoryStatusCode = useMemo(
+    () => advisoryStatus?.code ?? null,
+    [advisoryStatus],
+  );
 
   async function setToBack() {
     if (dataChanged) {
@@ -1072,7 +1039,7 @@ export default function Advisory({ mode }) {
    * Creates a new advisory in the CMS with the given status.
    * @param {Object} status advisory-status document from the CMS
    * @param {string} status.code the code of the advisory-status to check
-   * @param {string} status.value the documentId of the advisory-status to set for the advisory
+   * @param {string} status.documentId the documentId of the advisory-status to set for the advisory
    * @returns {Promise<Object|null>} the saved advisory document, or null if the save fails
    */
   async function createAdvisory(status) {
@@ -1118,7 +1085,7 @@ export default function Advisory({ mode }) {
         urgency,
         standardMessages: selectedStandardMessages.map((s) => s.value),
         protectedAreas: selProtectedAreas,
-        advisoryStatus: status.value,
+        advisoryStatus: status.documentId,
         links: savedLinks,
         regions: selRegions,
         sections: selSections,
@@ -1180,7 +1147,7 @@ export default function Advisory({ mode }) {
    * Updates advisory details in the CMS, and sets the status to the given status value.
    * @param {Object} status advisory-status document from the CMS
    * @param {string} status.code the code of the advisory-status to check
-   * @param {string} status.value the documentId of the advisory-status to set for the advisory
+   * @param {string} status.documentId the documentId of the advisory-status to set for the advisory
    * @returns {Promise<Object|null>} the updated advisory document, or null if the save fails
    */
   async function updateAdvisory(status) {
@@ -1230,7 +1197,7 @@ export default function Advisory({ mode }) {
         urgency,
         standardMessages: selectedStandardMessages.map((s) => s.value),
         protectedAreas: selProtectedAreas,
-        advisoryStatus: status.value,
+        advisoryStatus: status.documentId,
         links: updatedLinks,
         regions: selRegions,
         sections: selSections,

--- a/frontend/src/router/pages/advisories/advisory/Advisory.jsx
+++ b/frontend/src/router/pages/advisories/advisory/Advisory.jsx
@@ -3,7 +3,6 @@ import {
   useRef,
   useEffect,
   useContext,
-  useMemo,
   useCallback,
 } from "react";
 import {
@@ -767,12 +766,6 @@ export default function Advisory({ mode }) {
     getStandardMessages,
   ]);
 
-  // Get the advisory status code to determine the form action button text
-  const advisoryStatusCode = useMemo(
-    () => advisoryStatus?.code ?? null,
-    [advisoryStatus],
-  );
-
   async function setToBack() {
     if (dataChanged) {
       // Show the "Unsaved changes" dialog and wait for the user's response before navigating back
@@ -1414,7 +1407,6 @@ export default function Advisory({ mode }) {
                   submittedByName,
                   setSubmittedByName,
                   advisoryStatuses,
-                  advisoryStatusCode,
                   advisoryStatus,
                   setAdvisoryStatus,
                   isStatHoliday,


### PR DESCRIPTION
### Jira Ticket

CMS-1803

### Description
<!-- What did you change, and why? -->

A refactor ticket to make `advisoryStatus` always use a consistent object shape (or null), instead of being string/number/object/undefined in different circumstances. This lets us remove some type checks and guards, and makes the code easier to follow and less error-prone. 

I also took out some code that converted the object to a different shape for the react-select control, because we can use the `getOptionLabel` and `getOptionValue` props to find the label and value in our existing object.

There's surely more we can do, but this is a nice fix for now.