### PR TITLE
CMS-1828: Populate modifiedByName/Role when creating advisory

### DIFF
--- a/frontend/src/router/pages/advisories/advisory/Advisory.jsx
+++ b/frontend/src/router/pages/advisories/advisory/Advisory.jsx
@@ -1103,10 +1103,12 @@ export default function Advisory({ mode }) {
         isEndDateDisplayed: displayEndDate,
         isLatestRevision: true,
         createdByName: auth.user?.profile?.name,
+        modifiedByName: auth.user?.profile?.name,
         createdByEmail: auth.user?.profile?.email,
         reviewedByName: null,
         reviewedDate: null,
         createdByRole: getUserAdvisoryRole(),
+        modifiedByRole: getUserAdvisoryRole(),
         isUrgentAfterHours:
           !isApprover && (isAfterHours || isStatHoliday) && isAfterHourPublish,
       };


### PR DESCRIPTION
### Jira Ticket

CMS-1828

### Description
This change builds on #619, which introduced `modifiedDate` to the advisory creation payload. It extends that work by adding `modifiedByName` and `modifiedByRole`.
Ensuring these fields are always populated reduces edge cases, particularly for revision 1 where they may otherwise be null. In CMS-1828, a null value for modifiedByName caused both the "Reviewed by" and "Updated by" headers to appear on the preview page when the advisory was created and reviewed by the same HQ user.


