### PR TITLE
CMS-1776: Update standard message select field

### DIFF
--- a/frontend/src/components/advisories/composite/advisoryForm/AdvisoryForm.jsx
+++ b/frontend/src/components/advisories/composite/advisoryForm/AdvisoryForm.jsx
@@ -43,6 +43,7 @@ import PrimaryActions from "@/components/advisories/composite/advisoryForm/Prima
 import DraftButton from "@/components/advisories/composite/advisoryForm/DraftButton";
 import AccessStatusPicker from "@/components/advisories/composite/advisoryForm/AccessStatusPicker";
 import EventTypePicker from "@/components/advisories/composite/advisoryForm/EventTypePicker";
+import StandardMessagePicker from "@/components/advisories/composite/advisoryForm/StandardMessagePicker";
 
 export default function AdvisoryForm({
   mode,
@@ -560,8 +561,8 @@ export default function AdvisoryForm({
           <AccessStatusPicker
             accessStatus={accessStatus}
             accessStatuses={accessStatuses}
-            setAccessStatus={(nextStatus) => {
-              setAccessStatus(nextStatus);
+            setAccessStatus={(status) => {
+              setAccessStatus(status);
               markChanged();
             }}
             selectedProtectedAreas={selectedProtectedAreas}
@@ -585,8 +586,8 @@ export default function AdvisoryForm({
             <EventTypePicker
               eventType={eventType}
               eventTypes={eventTypes}
-              setEventType={(nextStatus) => {
-                setEventType(nextStatus);
+              setEventType={(type) => {
+                setEventType(type);
                 markChanged();
               }}
               selectedProtectedAreas={selectedProtectedAreas}
@@ -691,18 +692,15 @@ export default function AdvisoryForm({
             </LightTooltip>
           </Form.Label>
 
-          <Select
-            id="standard-messages"
-            options={standardMessages}
-            value={selectedStandardMessages}
-            onChange={(e) => {
-              setSelectedStandardMessages(e);
+          <StandardMessagePicker
+            standardMessages={standardMessages}
+            selectedStandardMessages={selectedStandardMessages}
+            setSelectedStandardMessages={(messages) => {
+              setSelectedStandardMessages(messages);
               markChanged();
             }}
-            placeholder="Search or select standard message(s)"
-            className="bcgov-select"
-            isMulti
-            isClearable
+            selectedProtectedAreas={selectedProtectedAreas}
+            selectedRecreationResources={selectedRecreationResources}
           />
         </Form.Group>
 

--- a/frontend/src/components/advisories/composite/advisoryForm/StandardMessagePicker.jsx
+++ b/frontend/src/components/advisories/composite/advisoryForm/StandardMessagePicker.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo } from "react";
 import PropTypes from "prop-types";
+import { sortBy } from "lodash-es";
 import CategorySelect from "@/components/advisories/shared/categorySelect/CategorySelect";
 import {
   filterOptionsByScope,
@@ -30,22 +31,10 @@ export default function StandardMessagePicker({
   // Sort messages by event type precedence first, then alphabetically by label
   const sortedStandardMessages = useMemo(
     () =>
-      [...filteredStandardMessages].sort((left, right) => {
-        const leftPrecedence = Number.isFinite(left?.eventTypePrecedence)
-          ? left.eventTypePrecedence
-          : Number.POSITIVE_INFINITY;
-        const rightPrecedence = Number.isFinite(right?.eventTypePrecedence)
-          ? right.eventTypePrecedence
-          : Number.POSITIVE_INFINITY;
-
-        if (leftPrecedence !== rightPrecedence) {
-          return leftPrecedence - rightPrecedence;
-        }
-
-        return (left?.label || "").localeCompare(right?.label || "", "en", {
-          sensitivity: "base",
-        });
-      }),
+      sortBy(filteredStandardMessages, [
+        (message) => message?.eventTypePrecedence ?? Number.POSITIVE_INFINITY,
+        (message) => message?.label?.toLowerCase() ?? "",
+      ]),
     [filteredStandardMessages],
   );
 

--- a/frontend/src/components/advisories/composite/advisoryForm/StandardMessagePicker.jsx
+++ b/frontend/src/components/advisories/composite/advisoryForm/StandardMessagePicker.jsx
@@ -1,0 +1,94 @@
+import { useEffect, useMemo } from "react";
+import PropTypes from "prop-types";
+import CategorySelect from "@/components/advisories/shared/categorySelect/CategorySelect";
+import {
+  filterOptionsByScope,
+  hasSelectedItems,
+} from "@/components/advisories/shared/categorySelect/categorySelectUtils";
+
+export default function StandardMessagePicker({
+  standardMessages,
+  selectedStandardMessages,
+  setSelectedStandardMessages,
+  selectedProtectedAreas,
+  selectedRecreationResources,
+}) {
+  const hasBcpResourcesSelected = hasSelectedItems(selectedProtectedAreas);
+  const hasRstResourcesSelected = hasSelectedItems(selectedRecreationResources);
+
+  // Filter message options based on scope and selected resources (BCP or RST)
+  const filteredStandardMessages = useMemo(
+    () =>
+      filterOptionsByScope(
+        standardMessages,
+        hasBcpResourcesSelected,
+        hasRstResourcesSelected,
+      ),
+    [standardMessages, hasBcpResourcesSelected, hasRstResourcesSelected],
+  );
+
+  // Sort messages by event type precedence first, then alphabetically by label
+  const sortedStandardMessages = useMemo(
+    () =>
+      [...filteredStandardMessages].sort((left, right) => {
+        const leftPrecedence = Number.isFinite(left?.eventTypePrecedence)
+          ? left.eventTypePrecedence
+          : Number.POSITIVE_INFINITY;
+        const rightPrecedence = Number.isFinite(right?.eventTypePrecedence)
+          ? right.eventTypePrecedence
+          : Number.POSITIVE_INFINITY;
+
+        if (leftPrecedence !== rightPrecedence) {
+          return leftPrecedence - rightPrecedence;
+        }
+
+        return (left?.label || "").localeCompare(right?.label || "", "en", {
+          sensitivity: "base",
+        });
+      }),
+    [filteredStandardMessages],
+  );
+
+  // Keep only selected messages that remain in the current scope.
+  useEffect(() => {
+    const currentSelectedMessages = selectedStandardMessages || [];
+
+    const filteredSelectedMessages = currentSelectedMessages.filter(
+      (selectedMessage) =>
+        filteredStandardMessages.some(
+          (option) => option.value === selectedMessage?.value,
+        ),
+    );
+
+    if (filteredSelectedMessages.length !== currentSelectedMessages.length) {
+      setSelectedStandardMessages(filteredSelectedMessages);
+    }
+  }, [
+    filteredStandardMessages,
+    selectedStandardMessages,
+    setSelectedStandardMessages,
+  ]);
+
+  return (
+    <CategorySelect
+      id="standard-messages"
+      options={sortedStandardMessages}
+      value={selectedStandardMessages}
+      onChange={(messages) => {
+        setSelectedStandardMessages(messages || []);
+      }}
+      placeholder="Search or select standard message(s)"
+      defaultMenuLabel={(option) => option.label}
+      isMulti={true}
+      isClearable
+    />
+  );
+}
+
+StandardMessagePicker.propTypes = {
+  standardMessages: PropTypes.arrayOf(PropTypes.object).isRequired,
+  selectedStandardMessages: PropTypes.arrayOf(PropTypes.object),
+  setSelectedStandardMessages: PropTypes.func.isRequired,
+  selectedProtectedAreas: PropTypes.array,
+  selectedRecreationResources: PropTypes.array,
+};

--- a/frontend/src/components/advisories/shared/categorySelect/CategorySelect.jsx
+++ b/frontend/src/components/advisories/shared/categorySelect/CategorySelect.jsx
@@ -28,9 +28,11 @@ export default function CategorySelect({
   placeholder = "Select...",
   categoryKey = "category",
   defaultMenuLabel,
+  isMulti = false,
   isClearable = false,
 }) {
-  const hasSelection = Boolean(value);
+  // value can be object for single select, array for multi select
+  const hasSelection = Array.isArray(value) ? value.length > 0 : Boolean(value);
 
   function formatValueLabel(option) {
     return formatCategoryLabel(option, categoryKey);
@@ -90,6 +92,7 @@ export default function CategorySelect({
       className={classNames("bcgov-select", {
         "bcgov-select--has-selection": hasSelection,
       })}
+      isMulti={isMulti}
       isClearable={isClearable}
       formatOptionLabel={(option, { context }) => {
         if (context === "value") {
@@ -121,12 +124,16 @@ export default function CategorySelect({
 
 CategorySelect.propTypes = {
   id: PropTypes.string,
-  value: PropTypes.object,
+  value: PropTypes.oneOfType([
+    PropTypes.object,
+    PropTypes.arrayOf(PropTypes.object),
+  ]),
   options: PropTypes.arrayOf(PropTypes.object),
   onChange: PropTypes.func,
   onBlur: PropTypes.func,
   placeholder: PropTypes.string,
   categoryKey: PropTypes.string,
   defaultMenuLabel: PropTypes.func,
+  isMulti: PropTypes.bool,
   isClearable: PropTypes.bool,
 };

--- a/frontend/src/hooks/useCms.js
+++ b/frontend/src/hooks/useCms.js
@@ -342,7 +342,7 @@ export default function useCms() {
     () =>
       fetchCached(
         "standardMessages",
-        `/standard-messages?${querySort("precedence")}`,
+        `/standard-messages?${querySort("precedence")}&populate=*`,
       ),
     [fetchCached],
   );

--- a/frontend/src/hooks/useCms.js
+++ b/frontend/src/hooks/useCms.js
@@ -338,14 +338,22 @@ export default function useCms() {
     [fetchCached],
   );
 
-  const getStandardMessages = useCallback(
-    () =>
-      fetchCached(
-        "standardMessages",
-        `/standard-messages?${querySort("precedence")}&populate=*`,
-      ),
-    [fetchCached],
-  );
+  const getStandardMessages = useCallback(() => {
+    const query = qs.stringify(
+      {
+        sort: ["precedence"],
+        fields: ["documentId", "title", "description", "scope"],
+        populate: {
+          eventType: {
+            fields: ["groupLabel", "precedence"],
+          },
+        },
+      },
+      { encodeValuesOnly: true },
+    );
+
+    return fetchCached("standardMessages", `/standard-messages?${query}`);
+  }, [fetchCached]);
 
   /**
    * Determines whether today is a statutory holiday and updates component state.

--- a/frontend/src/router/pages/advisories/advisory/Advisory.jsx
+++ b/frontend/src/router/pages/advisories/advisory/Advisory.jsx
@@ -1,10 +1,4 @@
-import {
-  useState,
-  useRef,
-  useEffect,
-  useContext,
-  useCallback,
-} from "react";
+import { useState, useRef, useEffect, useContext, useCallback } from "react";
 import {
   Navigate,
   useLocation,
@@ -721,6 +715,9 @@ export default function Advisory({ mode }) {
           const newStandardMessages = standardMessageData.map((m) => ({
             label: m.title,
             value: m.documentId,
+            category: m.eventType?.groupLabel,
+            scope: m.scope,
+            eventTypePrecedence: m.eventType?.precedence,
             type: "standardMessage",
             obj: m,
           }));


### PR DESCRIPTION
### Jira Ticket

CMS-1776

### Description
<!-- What did you change, and why? -->
- Updated the standard message select field
- Added a option category (`standardMessage.eventType.groupLabel`) in the dropdown
- Added a search functionality by not only option label, but also option category
- Added an auto scope filter based on an advisory associated resource (BCP or RST)
