### PR TITLE
CMS-1714: Change main-dev helm to use prod Keycloak

### DIFF
--- a/helm/deployment/values-dev.yaml
+++ b/helm/deployment/values-dev.yaml
@@ -1,5 +1,5 @@
 cluster:
-  ssoAuthUrl: https://dev.loginproxy.gov.bc.ca/auth
+  ssoAuthUrl: https://loginproxy.gov.bc.ca/auth
   cmsUrl: https://dev-cms.bcparks.ca
 
 frontend:


### PR DESCRIPTION
### Jira Ticket

CMS-1714

### Description
Updating the staff portal main-dev helm config to use the prod Keycloak instead of the dev Keycloak.
This was missed previously in https://github.com/bcgov/bcparks-staff-portal/pull/565

