### PR TITLE
CMS-1704: Prevent double-prompt from draft modal

### DIFF
--- a/frontend/src/hooks/useNavigationGuard.js
+++ b/frontend/src/hooks/useNavigationGuard.js
@@ -1,24 +1,12 @@
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
 
-// Prevent navigation away when hasChanges is true.
-// This hook prevents browser-level unloads (back button, tab close, reload)
-// by showing the browser's native leave-page dialog. (`beforeunload` event handler)
-// It also exposes a ref that indicates when this native dialog is active,
-// so the nav blocker can suppress the in-app modal and let the browser prompt own that attempt.
+// Prevent document-level unloads when hasChanges is true.
+// This hook handles native browser prompts for reload/tab close/external document navigation.
 
 export default function useNavigationGuard(hasChanges) {
-  // Ref to track when a browser-level unload attempt is in progress.
-  // Used by callers (e.g., useBlocker) to suppress the in-app modal when
-  // the native browser prompt is already handling the navigation decision.
-  const isBrowserUnloadActiveRef = useRef(false);
-
   useEffect(() => {
     function handleBeforeUnload(event) {
       if (hasChanges) {
-        // Set the flag so the nav blocker knows a native unload is active.
-        // This happens synchronously before the browser shows its leave-page dialog.
-        isBrowserUnloadActiveRef.current = true;
-
         // Prevent the default unload, which tells the browser to show its native dialog.
         event.preventDefault();
 
@@ -27,25 +15,10 @@ export default function useNavigationGuard(hasChanges) {
       }
     }
 
-    // When the user cancels the browser dialog and stays on the page,
-    // the window receives a `focus` event. Clear the flag so the next
-    // internal navigation can use the in-app modal again.
-    function handleFocusAfterCancel() {
-      if (isBrowserUnloadActiveRef.current) {
-        isBrowserUnloadActiveRef.current = false;
-      }
-    }
-
     window.addEventListener("beforeunload", handleBeforeUnload);
-    window.addEventListener("focus", handleFocusAfterCancel);
 
     return () => {
       window.removeEventListener("beforeunload", handleBeforeUnload);
-      window.removeEventListener("focus", handleFocusAfterCancel);
     };
   }, [hasChanges]);
-
-  return {
-    isBrowserUnloadActiveRef,
-  };
 }

--- a/frontend/src/hooks/useNavigationGuard.js
+++ b/frontend/src/hooks/useNavigationGuard.js
@@ -1,12 +1,25 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 
-// adds a beforeunload event listener to the window
-// to prevent navigating away when hasChanges is true
+// Prevent navigation away when hasChanges is true.
+// This hook prevents browser-level unloads (back button, tab close, reload)
+// by showing the browser's native leave-page dialog. (`beforeunload` event handler)
+// It also exposes a ref that indicates when this native dialog is active,
+// so the nav blocker can suppress the in-app modal and let the browser prompt own that attempt.
 
 export default function useNavigationGuard(hasChanges) {
+  // Ref to track when a browser-level unload attempt is in progress.
+  // Used by callers (e.g., useBlocker) to suppress the in-app modal when
+  // the native browser prompt is already handling the navigation decision.
+  const isBrowserUnloadActiveRef = useRef(false);
+
   useEffect(() => {
     function handleBeforeUnload(event) {
       if (hasChanges) {
+        // Set the flag so the nav blocker knows a native unload is active.
+        // This happens synchronously before the browser shows its leave-page dialog.
+        isBrowserUnloadActiveRef.current = true;
+
+        // Prevent the default unload, which tells the browser to show its native dialog.
         event.preventDefault();
 
         // Included for legacy support, e.g. Chrome/Edge < 119
@@ -14,9 +27,25 @@ export default function useNavigationGuard(hasChanges) {
       }
     }
 
+    // When the user cancels the browser dialog and stays on the page,
+    // the window receives a `focus` event. Clear the flag so the next
+    // internal navigation can use the in-app modal again.
+    function handleFocusAfterCancel() {
+      if (isBrowserUnloadActiveRef.current) {
+        isBrowserUnloadActiveRef.current = false;
+      }
+    }
+
     window.addEventListener("beforeunload", handleBeforeUnload);
+    window.addEventListener("focus", handleFocusAfterCancel);
+
     return () => {
       window.removeEventListener("beforeunload", handleBeforeUnload);
+      window.removeEventListener("focus", handleFocusAfterCancel);
     };
   }, [hasChanges]);
+
+  return {
+    isBrowserUnloadActiveRef,
+  };
 }

--- a/frontend/src/router/pages/advisories/advisory/Advisory.jsx
+++ b/frontend/src/router/pages/advisories/advisory/Advisory.jsx
@@ -789,7 +789,7 @@ export default function Advisory({ mode }) {
   ]);
 
   // Navigates back to the dashboard or summary page, depending on where the user came from
-  async function navigateBack() {
+  function navigateBack() {
     if (mode === "update" && fromSummary) {
       navigate(getSummaryUrl(documentId));
     } else {

--- a/frontend/src/router/pages/advisories/advisory/Advisory.jsx
+++ b/frontend/src/router/pages/advisories/advisory/Advisory.jsx
@@ -793,17 +793,9 @@ export default function Advisory({ mode }) {
     getStandardMessages,
   ]);
 
-  async function setToBack() {
-    if (dataChanged) {
-      // Show the "Unsaved changes" dialog and wait for the user's response before navigating back
-      const shouldProceed = await confirmUnsavedChangesNavigation();
-
-      if (!shouldProceed) {
-        return;
-      }
-
-      setDataChanged(false);
-    }
+  // Navigates back to the dashboard or summary page, depending on where the user came from
+  async function navigateBack() {
+    setDataChanged(false);
 
     if (mode === "update" && fromSummary) {
       navigate(getSummaryUrl(documentId));
@@ -1311,7 +1303,7 @@ export default function Advisory({ mode }) {
                 <button
                   type="button"
                   className="btn btn-link btn-back mt-4"
-                  onClick={setToBack}
+                  onClick={navigateBack}
                 >
                   <FontAwesomeIcon icon={faArrowLeft} className="me-1" />
                   Back to{" "}

--- a/frontend/src/router/pages/advisories/advisory/Advisory.jsx
+++ b/frontend/src/router/pages/advisories/advisory/Advisory.jsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect, useContext, useCallback } from "react";
 import {
   Navigate,
   useLocation,
+  useNavigate,
   useBlocker,
   useParams,
   useSearchParams,
@@ -32,6 +33,7 @@ export default function Advisory({ mode }) {
   const { setError } = useContext(ErrorContext);
   const [searchParams] = useSearchParams();
   const location = useLocation();
+  const navigate = useNavigate();
   const tabParam = searchParams.get("tab");
   const fromSummary = location.state?.fromSummary === true;
 
@@ -89,20 +91,16 @@ export default function Advisory({ mode }) {
   const [submitter, setSubmitter] = useState("");
   const [listingRank, setListingRank] = useState(0);
   const [toError, setToError] = useState(false);
-  const [toDashboard, setToDashboard] = useState(false);
   const [isLoadingPage, setIsLoadingPage] = useState(true);
   const [isLoadingData, setIsLoadingData] = useState(true);
   const [isStatHoliday, setIsStatHoliday] = useState(false);
   const [isAfterHours, setIsAfterHours] = useState(false);
   const [isAfterHourPublish, setIsAfterHourPublish] = useState(false);
-  const [isConfirmation, setIsConfirmation] = useState(false);
-  const [confirmationText, setConfirmationText] = useState("");
   const [isSavingDraft, setIsSavingDraft] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [dataChanged, setDataChanged] = useState(false);
   const linksRef = useRef([]);
   const advisoryDateRef = useRef(moment().tz("America/Vancouver").toDate());
-  const [advisoryId, setAdvisoryId] = useState();
   const [isApprover, setIsApprover] = useState(false);
   const [formError, setFormError] = useState("");
 
@@ -274,10 +272,27 @@ export default function Advisory({ mode }) {
     setLinks(linkIds);
   }
 
+  /**
+   * Returns the URL for the advisory summary page,
+   * including the "review" tab query parameter if applicable.
+   * @param {string} targetId  The document ID of the advisory to link to the summary page
+   * @returns {string} URL for the advisory summary page
+   */
+  function getSummaryUrl(targetId) {
+    const summaryUrl = `/advisory-summary/${targetId}`;
+
+    return tabParam === "review" ? `${summaryUrl}?tab=review` : summaryUrl;
+  }
+
+  function getDashboardUrl() {
+    return tabParam === "review"
+      ? "/advisories-and-closures/review"
+      : "/advisories-and-closures";
+  }
+
   useEffect(() => {
     if (mode === "update" && !isLoadingData && !originalDataLoaded.current) {
       if (documentId) {
-        setAdvisoryId(documentId);
         cmsGet(`public-advisory-audits/${documentId}?${query}`)
           .then((advisoryData) => {
             linksRef.current = [];
@@ -791,9 +806,9 @@ export default function Advisory({ mode }) {
     }
 
     if (mode === "update" && fromSummary) {
-      setIsConfirmation(true);
+      navigate(getSummaryUrl(documentId));
     } else {
-      setToDashboard(true);
+      navigate(getDashboardUrl());
     }
   }
 
@@ -1030,13 +1045,11 @@ export default function Advisory({ mode }) {
   function setConfirmationTextForStatus(statusCode) {
     switch (statusCode) {
       case "DFT":
-        setConfirmationText("Your advisory has been saved successfully!");
-        break;
+        return "Your advisory has been saved successfully!";
       case "PUB":
-        setConfirmationText("Your advisory has been published successfully!");
-        break;
+        return "Your advisory has been published successfully!";
       default:
-        setConfirmationText("Your advisory has been saved successfully!");
+        return "Your advisory has been saved successfully!";
     }
   }
 
@@ -1131,12 +1144,16 @@ export default function Advisory({ mode }) {
         data: newAdvisory,
       });
 
-      setAdvisoryId(advisory.documentId);
       setDataChanged(false);
       setIsSubmitting(false);
       setIsSavingDraft(false);
-      setConfirmationTextForStatus(status.code);
-      setIsConfirmation(true);
+
+      const confirmationText = setConfirmationTextForStatus(status.code);
+
+      navigate(getSummaryUrl(advisory.documentId), {
+        state: { confirmationText },
+      });
+
       return advisory;
     } catch (error) {
       console.error("error occurred", error);
@@ -1253,12 +1270,16 @@ export default function Advisory({ mode }) {
         data: updatedAdvisory,
       });
 
-      setAdvisoryId(advisory.documentId);
       setDataChanged(false);
       setIsSubmitting(false);
       setIsSavingDraft(false);
-      setConfirmationTextForStatus(status.code);
-      setIsConfirmation(true);
+
+      const confirmationText = setConfirmationTextForStatus(status.code);
+
+      navigate(getSummaryUrl(advisory.documentId), {
+        state: { confirmationText },
+      });
+
       return advisory;
     } catch (error) {
       console.error("error occurred", error);
@@ -1271,33 +1292,8 @@ export default function Advisory({ mode }) {
     }
   }
 
-  if (toDashboard) {
-    const dashboardPath =
-      tabParam === "review"
-        ? "/advisories-and-closures/review"
-        : "/advisories-and-closures";
-
-    return (
-      <Navigate
-        push
-        to={{
-          pathname: dashboardPath,
-          index: 0,
-        }}
-      />
-    );
-  }
-
   if (toError) {
     return <Navigate to="/error" />;
-  }
-
-  if (isConfirmation) {
-    const summaryUrl = `/advisory-summary/${advisoryId}`;
-    const finalUrl =
-      tabParam === "review" ? `${summaryUrl}?tab=review` : summaryUrl;
-
-    return <Navigate to={finalUrl} state={{ confirmationText }} />;
   }
 
   return (

--- a/frontend/src/router/pages/advisories/advisory/Advisory.jsx
+++ b/frontend/src/router/pages/advisories/advisory/Advisory.jsx
@@ -173,7 +173,7 @@ export default function Advisory({ mode }) {
     setDataChanged(true);
   }, []);
 
-  useNavigationGuard(dataChanged);
+  const { isBrowserUnloadActiveRef } = useNavigationGuard(dataChanged);
 
   // Block internal route transitions while there are unsaved changes.
   // beforeunload is still handled by useNavigationGuard for browser-level exits.
@@ -181,6 +181,11 @@ export default function Advisory({ mode }) {
     if (blocker.state !== "blocked" || isBlockerActive.current) {
       return;
     }
+
+    // If a browser-level unload is in progress (e.g., back button, tab close),
+    // the beforeunload handler and native dialog are already managing the exit attempt.
+    // Skip the in-app modal to avoid showing both prompts at once.
+    if (isBrowserUnloadActiveRef.current) return;
 
     // Lock this blocked transition until the router confirms it has been
     // resolved so we do not start a second prompt flow for the same attempt.
@@ -200,7 +205,7 @@ export default function Advisory({ mode }) {
         blocker.reset();
       }
     })();
-  }, [blocker, confirmUnsavedChangesNavigation]);
+  }, [blocker, confirmUnsavedChangesNavigation, isBrowserUnloadActiveRef]);
 
   // Keep the blocked-navigation lock until the router confirms the transition is unblocked.
   // This prevents a second modal from opening on the same blocked navigation attempt.

--- a/frontend/src/router/pages/advisories/advisory/Advisory.jsx
+++ b/frontend/src/router/pages/advisories/advisory/Advisory.jsx
@@ -171,19 +171,14 @@ export default function Advisory({ mode }) {
     setDataChanged(true);
   }, []);
 
-  const { isBrowserUnloadActiveRef } = useNavigationGuard(dataChanged);
+  useNavigationGuard(dataChanged);
 
   // Block internal route transitions while there are unsaved changes.
-  // beforeunload is still handled by useNavigationGuard for browser-level exits.
+  // beforeunload is still handled by useNavigationGuard for document-level exits.
   useEffect(() => {
     if (blocker.state !== "blocked" || isBlockerActive.current) {
       return;
     }
-
-    // If a browser-level unload is in progress (e.g., back button, tab close),
-    // the beforeunload handler and native dialog are already managing the exit attempt.
-    // Skip the in-app modal to avoid showing both prompts at once.
-    if (isBrowserUnloadActiveRef.current) return;
 
     // Lock this blocked transition until the router confirms it has been
     // resolved so we do not start a second prompt flow for the same attempt.
@@ -203,7 +198,7 @@ export default function Advisory({ mode }) {
         blocker.reset();
       }
     })();
-  }, [blocker, confirmUnsavedChangesNavigation, isBrowserUnloadActiveRef]);
+  }, [blocker, confirmUnsavedChangesNavigation]);
 
   // Keep the blocked-navigation lock until the router confirms the transition is unblocked.
   // This prevents a second modal from opening on the same blocked navigation attempt.
@@ -795,8 +790,6 @@ export default function Advisory({ mode }) {
 
   // Navigates back to the dashboard or summary page, depending on where the user came from
   async function navigateBack() {
-    setDataChanged(false);
-
     if (mode === "update" && fromSummary) {
       navigate(getSummaryUrl(documentId));
     } else {

--- a/frontend/src/router/pages/advisories/advisory/Advisory.jsx
+++ b/frontend/src/router/pages/advisories/advisory/Advisory.jsx
@@ -1023,11 +1023,11 @@ export default function Advisory({ mode }) {
   }
 
   /**
-   * Sets the confirmation text to display on the Advisory summary page after form submission.
+   * Gets the confirmation text to display on the Advisory summary page after form submission, based on the advisory status code.
    * @param {string} statusCode the advisory-status code of the form submission
-   * @returns {void}
+   * @returns {string} confirmation text to display on the summary page after submission
    */
-  function setConfirmationTextForStatus(statusCode) {
+  function getConfirmationTextForStatus(statusCode) {
     switch (statusCode) {
       case "DFT":
         return "Your advisory has been saved successfully!";
@@ -1133,7 +1133,7 @@ export default function Advisory({ mode }) {
       setIsSubmitting(false);
       setIsSavingDraft(false);
 
-      const confirmationText = setConfirmationTextForStatus(status.code);
+      const confirmationText = getConfirmationTextForStatus(status.code);
 
       navigate(getSummaryUrl(advisory.documentId), {
         state: { confirmationText },
@@ -1259,7 +1259,7 @@ export default function Advisory({ mode }) {
       setIsSubmitting(false);
       setIsSavingDraft(false);
 
-      const confirmationText = setConfirmationTextForStatus(status.code);
+      const confirmationText = getConfirmationTextForStatus(status.code);
 
       navigate(getSummaryUrl(advisory.documentId), {
         state: { confirmationText },

--- a/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.jsx
+++ b/frontend/src/router/pages/advisories/advisoryDashboard/AdvisoryDashboard.jsx
@@ -15,7 +15,7 @@ import {
   useDebounceValue,
 } from "usehooks-ts";
 import qs from "qs";
-import { Link, Navigate, NavLink } from "react-router-dom";
+import { Link, Navigate, NavLink, useNavigate } from "react-router-dom";
 import { useAuth } from "react-oidc-context";
 import { useTranslation } from "react-i18next";
 import ErrorContext from "@/contexts/ErrorContext";
@@ -127,8 +127,9 @@ export default function AdvisoryDashboard({
     cmsGet,
   } = useCms();
 
+  const navigate = useNavigate();
+
   const [toError, setToError] = useState(false);
-  const [toCreate, setToCreate] = useState(false);
   const [selectedRegionId, setSelectedRegionId] = useState([]);
   const [selectedRegion, setSelectedRegion] = useState([]);
   const [selectedDistrictId, setSelectedDistrictId] = useState([]);
@@ -1243,9 +1244,6 @@ export default function AdvisoryDashboard({
     ],
   );
 
-  if (toCreate) {
-    return <Navigate to="/create-advisory" />;
-  }
   if (toError || hasErrors) {
     return <Navigate to="/error" />;
   }
@@ -1368,7 +1366,7 @@ export default function AdvisoryDashboard({
                 }
                 styling="btn-primary btn mt-3"
                 onClick={() => {
-                  setToCreate(true);
+                  navigate("/create-advisory");
                 }}
               />
             </div>

--- a/frontend/src/router/pages/advisories/advisorySummary/AdvisorySummary.jsx
+++ b/frontend/src/router/pages/advisories/advisorySummary/AdvisorySummary.jsx
@@ -317,9 +317,9 @@ export default function AdvisorySummary() {
       : baseUrl;
   }, [documentId, tabParam]);
 
-  // Use a different target for the "Back" navigation link based on which page we came from.
-  // If we have an index in location state, that means we came from the dashboard and should return there to preserve pagination context.
-  // If not, return to the default dashboard URL which will show the first page of results.
+  // Dashboard route for the "Back" link.
+  // Use the Review dashboard when the current tab is "review".
+  // Otherwise, return to the main advisories and closures dashboard.
   const dashboardPath = useMemo(
     () =>
       tabParam === "review"

--- a/frontend/src/router/pages/advisories/advisorySummary/AdvisorySummary.jsx
+++ b/frontend/src/router/pages/advisories/advisorySummary/AdvisorySummary.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useContext, useMemo, useCallback } from "react";
 import {
   Navigate,
   useLocation,
+  useNavigate,
   useParams,
   useSearchParams,
 } from "react-router-dom";
@@ -47,13 +48,12 @@ export default function AdvisorySummary() {
   const [advisory, setAdvisory] = useState({});
   const [parkUrls, setParkUrls] = useState("");
   const [siteUrls, setSiteUrls] = useState("");
-  const [toDashboard, setToDashboard] = useState(false);
-  const [toUpdate, setToUpdate] = useState(false);
   const [snackPack, setSnackPack] = useState([]);
   const [openSnack, setOpenSnack] = useState(false);
   const [snackMessageInfo, setSnackMessageInfo] = useState(null);
   const { documentId } = useParams();
   const location = useLocation();
+  const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const tabParam = searchParams.get("tab");
   const [confirmationText] = useState(location.state?.confirmationText || "");
@@ -317,6 +317,17 @@ export default function AdvisorySummary() {
       : baseUrl;
   }, [documentId, tabParam]);
 
+  // Use a different target for the "Back" navigation link based on which page we came from.
+  // If we have an index in location state, that means we came from the dashboard and should return there to preserve pagination context.
+  // If not, return to the default dashboard URL which will show the first page of results.
+  const dashboardPath = useMemo(
+    () =>
+      tabParam === "review"
+        ? "/advisories-and-closures/review"
+        : "/advisories-and-closures",
+    [tabParam],
+  );
+
   // Helper function to build a timestamp string with an actor name
   const buildTimestampString = useCallback((prefix, actorName, timestamp) => {
     if (!timestamp) return "";
@@ -424,27 +435,6 @@ export default function AdvisorySummary() {
     setSnackMessageInfo(null);
   }
 
-  if (toDashboard) {
-    const dashboardPath =
-      tabParam === "review"
-        ? "/advisories-and-closures/review"
-        : "/advisories-and-closures";
-
-    return (
-      <Navigate
-        push
-        to={{
-          pathname: dashboardPath,
-          index: index >= 0 ? index : 0,
-        }}
-      />
-    );
-  }
-
-  if (toUpdate) {
-    return <Navigate to={updateAdvisoryUrl} state={{ fromSummary: true }} />;
-  }
-
   if (toError) {
     return <Navigate to="/error" />;
   }
@@ -466,7 +456,9 @@ export default function AdvisorySummary() {
                     type="button"
                     className="btn btn-link btn-back my-4"
                     onClick={() => {
-                      setToDashboard(true);
+                      navigate(dashboardPath, {
+                        state: { index: index >= 0 ? index : 0 },
+                      });
                     }}
                   >
                     <FontAwesomeIcon icon={faArrowLeft} className="me-2" />
@@ -570,7 +562,9 @@ export default function AdvisorySummary() {
                           styling="btn-primary btn flex-grow-1 flex-xl-shrink-0"
                           disabled={isRequestingCms}
                           onClick={() => {
-                            setToUpdate(true);
+                            navigate(updateAdvisoryUrl, {
+                              state: { fromSummary: true },
+                            });
                           }}
                           leftIcon={<FontAwesomeIcon icon={faPen} />}
                         />


### PR DESCRIPTION
### Jira Ticket

CMS-1704

### Description
<!-- What did you change, and why? -->

Fixing two issues noticed by QA. One seemed to only affect the dev environment, so I'll have to confirm once we merge and deploy, but these changes should fix both issues.

- The "Back" link on the form was showing a blank page in some scenarios (only the prod build; it didn't happen on local dev)
- The in-app modal was showing after the browser-level confirmation dialog in some scenarios. 

Manuji has screen recordings to reproduce both in the Jira ticket.

To fix them, I replaced some declarative render-time `<Navigate>` tags with imperative calls to the `navigate()` function. This seemed to also fix a lot of weird edge case bugs with some pages showing up twice in the browser history. (You'd have to click the browser "Back" button twice to get the page to change sometimes).

I initially changed a lot more, but I gradually reverted those changes and mostly kept the navigation changes that seem to fix the issues.

If the router bug still happens on the dev environment, I'll work on a follow-up branch, but I think the switch to `navigate(...)` function calls is a nice improvement either way. The `useNavigate` hook's `navigate(...)` function is generally a cleaner pattern for navigating in event handlers.