### PR TITLE
CMS-1613: Update frontend headings to show two year spans

### DIFF
--- a/backend/routes/api/parks.js
+++ b/backend/routes/api/parks.js
@@ -97,6 +97,7 @@ function featureModel(minYear, where = {}) {
       "hasBackcountryPermits",
       "hasReservations",
       "inReservationSystem",
+      "datesCanSpan2Years",
     ],
     include: [
       {
@@ -242,6 +243,7 @@ function buildFeatureOutput(feature, seasons, includeCurrentSeason = true) {
     hasBackcountryPermits: feature.hasBackcountryPermits,
     hasReservations: feature.hasReservations,
     inReservationSystem: feature.inReservationSystem,
+    datesCanSpan2Years: feature.datesCanSpan2Years,
     featureType: {
       id: feature.featureType.id,
       name: feature.featureType.name,

--- a/backend/routes/api/seasons.js
+++ b/backend/routes/api/seasons.js
@@ -759,6 +759,9 @@ router.get(
 
     parkWinterDates.push(...previousParkWinterDates);
 
+    // Add datesCanSpan2Years flag at the season level
+    currentSeason.datesCanSpan2Years = feature.datesCanSpan2Years;
+
     const output = {
       current: currentSeason,
       previous: previousSeason,
@@ -887,6 +890,12 @@ router.get(
     const previousParkWinterDates = (await previousParkDates).parkWinterDates;
 
     parkWinterDates.push(...previousParkWinterDates);
+
+    // Add datesCanSpan2Years flag at the season level
+    // to indicate if any features have dates that span two years
+    currentSeason.datesCanSpan2Years = seasonModel.parkArea.features.some(
+      (feature) => feature.datesCanSpan2Years,
+    );
 
     const output = {
       current: currentSeason,
@@ -1039,6 +1048,11 @@ router.get(
       dateRangeAnnuals,
       gateDetail,
     };
+
+    // Add datesCanSpan2Years flag at the season level.
+    // Park-level forms won't have this flag, but set it false for the template.
+    // Winter season dates can span 2 years, but validation/UI logic is different for winter fees.
+    currentSeason.datesCanSpan2Years = false;
 
     const output = {
       current: currentSeason,

--- a/frontend/src/components/EditAndReviewTable.jsx
+++ b/frontend/src/components/EditAndReviewTable.jsx
@@ -108,7 +108,7 @@ DateRangesList.propTypes = {
 function DateTypeTableRow({
   groupedDateRanges,
   currentYear,
-  isWinterSeason = false,
+  showYearRange = false,
 }) {
   if (
     !currentYear ||
@@ -117,11 +117,13 @@ function DateTypeTableRow({
   )
     return null;
 
+  // Winter fee seasons and seasons with a specific flag have dates that can span 2 years,
+  // So we show a year range in the table header instead of just the year.
   const lastYear = currentYear - 1;
-  const displayLastYear = isWinterSeason
+  const displayLastYear = showYearRange
     ? `${lastYear} – ${currentYear}`
     : lastYear;
-  const displayCurrentYear = isWinterSeason
+  const displayCurrentYear = showYearRange
     ? `${currentYear} – ${currentYear + 1}`
     : currentYear;
 
@@ -137,7 +139,7 @@ function DateTypeTableRow({
 DateTypeTableRow.propTypes = {
   groupedDateRanges: PropTypes.object,
   currentYear: PropTypes.number,
-  isWinterSeason: PropTypes.bool,
+  showYearRange: PropTypes.bool,
 };
 
 function DateTableRow({ groupedDateRanges, currentYear }) {
@@ -355,6 +357,7 @@ function FeaturesByFeatureTypeWithAreas({
                   <DateTypeTableRow
                     groupedDateRanges={parkFeature.groupedDateRanges}
                     currentYear={regularSeason.operatingYear}
+                    showYearRange={parkFeature.datesCanSpan2Years}
                   />
                   <DateTableRow
                     groupedDateRanges={parkFeature.groupedDateRanges}
@@ -408,6 +411,7 @@ function FeaturesByFeatureTypeNoAreas({
             <DateTypeTableRow
               groupedDateRanges={feature.groupedDateRanges}
               currentYear={regularSeason.operatingYear}
+              showYearRange={feature.datesCanSpan2Years}
             />
             <DateTableRow
               groupedDateRanges={feature.groupedDateRanges}
@@ -512,7 +516,7 @@ function Table({ park, formPanelHandler, sortOrder }) {
                 <DateTypeTableRow
                   groupedDateRanges={park.winterGroupedDateRanges}
                   currentYear={winterSeason.operatingYear}
-                  isWinterSeason={true}
+                  showYearRange={true}
                 />
                 <DateTableRow
                   groupedDateRanges={park.winterGroupedDateRanges}

--- a/frontend/src/components/FormPanel.jsx
+++ b/frontend/src/components/FormPanel.jsx
@@ -152,7 +152,22 @@ function SeasonForm({
     previousWinter: previousWinterSeasonDates,
     ...seasonMetadata
   } = data || {};
-  const currentYear = season?.operatingYear;
+
+  // Derive the header text from the season data
+  const yearHeaderText = useMemo(() => {
+    // operatingYear is always defined for a Season, so data is still loading if it's undefined
+    if (!season?.operatingYear) return "";
+
+    const operatingYear = season.operatingYear;
+    const nextYear = operatingYear + 1;
+
+    if (season.datesCanSpan2Years) {
+      return `${operatingYear} – ${nextYear} dates`;
+    }
+
+    // Default: operating year
+    return `${operatingYear} dates`;
+  }, [season?.datesCanSpan2Years, season?.operatingYear]);
 
   const seasonTitle = useMemo(() => {
     // Return blank while loading
@@ -501,7 +516,7 @@ If dates have already been published, they will not be updated until new dates a
             )}
 
             <h2>{seasonTitle}</h2>
-            <h2 className="fw-normal">{currentYear} dates</h2>
+            <h2 className="fw-normal">{yearHeaderText}</h2>
             <p className="fs-6 fw-normal">
               <a
                 href="https://www2.gov.bc.ca/gov/content/employment-business/employment-standards-advice/employment-standards/statutory-holidays"


### PR DESCRIPTION
### Jira Ticket

CMS-1613

### Description
<!-- What did you change, and why? -->

Updated the Form Panel heading and the table column headings for Features with "Dates can span 2 years" flags.
In these cases, we'll now show a date range ("2026 – 2027") instead of just the operating year ("2026")

To keep things simple in the template, I added the datesCanSpan2Years property to the season endpoint. Always false for parks, same as Feature for features, and calculated for Areas.