### PR TITLE
CMS-1811: Role checks for handling the advisory contributor role

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -70,19 +70,18 @@ const apiRouter = express.Router();
 // Apply JWT check and user middleware to all /api routes
 apiRouter.use(checkJwt);
 
+// Ensure user has STAFF_PORTAL_USER role to access any /api route
+apiRouter.use(checkPermissions([ROLES.STAFF_PORTAL_USER]));
+
 // Attach user data from the DB to the request object
 apiRouter.use(usersMiddleware);
 
-apiRouter.use("/user", checkPermissions([ROLES.STAFF_PORTAL_USER]), userRoutes);
+apiRouter.use("/user", userRoutes);
 apiRouter.use("/parks", checkPermissions([ROLES.DOOT_USER]), parkRoutes);
 apiRouter.use("/seasons", checkPermissions([ROLES.DOOT_USER]), seasonRoutes);
 apiRouter.use("/export", checkPermissions([ROLES.DOOT_USER]), exportRoutes);
 apiRouter.use("/publish", checkPermissions([ROLES.DOOT_USER]), publishRoutes);
-apiRouter.use(
-  "/filter-options",
-  checkPermissions([ROLES.DOOT_USER]),
-  filterOptionsRoutes,
-);
+apiRouter.use("/filter-options", filterOptionsRoutes);
 
 app.use("/api", apiRouter);
 

--- a/backend/index.js
+++ b/backend/index.js
@@ -70,18 +70,19 @@ const apiRouter = express.Router();
 // Apply JWT check and user middleware to all /api routes
 apiRouter.use(checkJwt);
 
-// Ensure user has DOOT_USER role to access any /api route
-apiRouter.use(checkPermissions([ROLES.DOOT_USER]));
-
 // Attach user data from the DB to the request object
 apiRouter.use(usersMiddleware);
 
-apiRouter.use("/user", userRoutes);
-apiRouter.use("/parks", parkRoutes);
-apiRouter.use("/seasons", seasonRoutes);
-apiRouter.use("/export", exportRoutes);
-apiRouter.use("/publish", publishRoutes);
-apiRouter.use("/filter-options", filterOptionsRoutes);
+apiRouter.use("/user", checkPermissions([ROLES.STAFF_PORTAL_USER]), userRoutes);
+apiRouter.use("/parks", checkPermissions([ROLES.DOOT_USER]), parkRoutes);
+apiRouter.use("/seasons", checkPermissions([ROLES.DOOT_USER]), seasonRoutes);
+apiRouter.use("/export", checkPermissions([ROLES.DOOT_USER]), exportRoutes);
+apiRouter.use("/publish", checkPermissions([ROLES.DOOT_USER]), publishRoutes);
+apiRouter.use(
+  "/filter-options",
+  checkPermissions([ROLES.DOOT_USER]),
+  filterOptionsRoutes,
+);
 
 app.use("/api", apiRouter);
 

--- a/frontend/src/components/advisories/composite/advisoryForm/AdvisoryForm.jsx
+++ b/frontend/src/components/advisories/composite/advisoryForm/AdvisoryForm.jsx
@@ -1628,6 +1628,7 @@ export default function AdvisoryForm({
       </section>
 
       {!hasAnyRole([ROLES.ADVISORY_PUBLISH_WITHOUT_APPROVAL]) &&
+        hasAnyRole([ROLES.ADVISORY_SUBMITTER]) &&
         (isStatHoliday || isAfterHours) && (
           <section className="act-af-hour-box d-flex field-bg-blue">
             <FontAwesomeIcon

--- a/frontend/src/components/advisories/composite/advisoryForm/PrimaryActions.jsx
+++ b/frontend/src/components/advisories/composite/advisoryForm/PrimaryActions.jsx
@@ -34,6 +34,10 @@ export default function PrimaryActions({
     return "Create advisory / closure";
   }, [mode, advisoryStatusCode]);
 
+  if (!hasAnyRole([ROLES.ADVISORY_SUBMITTER, ROLES.ADVISORY_APPROVER])) {
+    return null;
+  }
+
   if (!canPublish) {
     // Show a button to submit for review if the user can't publish directly
     return (

--- a/frontend/src/components/advisories/shared/tableActionButton/TableActionButton.jsx
+++ b/frontend/src/components/advisories/shared/tableActionButton/TableActionButton.jsx
@@ -12,6 +12,7 @@ import {
   faPen,
 } from "@fa-kit/icons/classic/regular";
 
+import useAccess from "@/hooks/useAccess";
 import "./TableActionButton.scss";
 
 const ACTION_DROPDOWN_OPEN_EVENT = "table-action-dropdown-open";
@@ -38,6 +39,7 @@ export function TableActionButton({
   className = "",
 }) {
   const [isOpen, setIsOpen] = useState(false);
+  const { hasAnyRole, ROLES } = useAccess();
 
   function action(callback) {
     setIsOpen(false);
@@ -105,6 +107,7 @@ export function TableActionButton({
             <FontAwesomeIcon icon={faMemo} />
             View
           </Dropdown.Item>
+
           <Dropdown.Item
             as={Link}
             to={editPath}
@@ -113,13 +116,15 @@ export function TableActionButton({
             <FontAwesomeIcon icon={faPen} />
             Edit
           </Dropdown.Item>
-          <Dropdown.Item
-            disabled={!canUnpublish}
-            onClick={() => action(onUnpublish)}
-          >
-            <FontAwesomeIcon icon={faEyeSlash} />
-            Unpublish
-          </Dropdown.Item>
+          {hasAnyRole([ROLES.ADVISORY_SUBMITTER, ROLES.ADVISORY_APPROVER]) && (
+            <Dropdown.Item
+              disabled={!canUnpublish}
+              onClick={() => action(onUnpublish)}
+            >
+              <FontAwesomeIcon icon={faEyeSlash} />
+              Unpublish
+            </Dropdown.Item>
+          )}
           {onMarkReviewed && (
             <Dropdown.Item onClick={() => action(onMarkReviewed)}>
               <FontAwesomeIcon icon={faCircleCheck} />

--- a/frontend/src/components/shared/navItems.jsx
+++ b/frontend/src/components/shared/navItems.jsx
@@ -6,7 +6,7 @@ const navItems = [
     label: "Advisories and closures",
     Tag: NavLink,
     to: "/advisories-and-closures",
-    allowedRoles: [ROLES.ADVISORY_SUBMITTER, ROLES.ADVISORY_APPROVER],
+    allowedRoles: [ROLES.ADVISORY_USER],
   },
   {
     label: "Park access status",

--- a/frontend/src/hooks/useNavigationGuard.js
+++ b/frontend/src/hooks/useNavigationGuard.js
@@ -1,12 +1,12 @@
 import { useEffect } from "react";
 
-// Prevent document-level unloads when hasChanges is true.
+// Prevent document-level unloads when hasChanges resolves to true.
 // This hook handles native browser prompts for reload/tab close/external document navigation.
 
 export default function useNavigationGuard(hasChanges) {
   useEffect(() => {
     function handleBeforeUnload(event) {
-      if (hasChanges) {
+      if (typeof hasChanges === "function" ? hasChanges() : !!hasChanges) {
         // Prevent the default unload, which tells the browser to show its native dialog.
         event.preventDefault();
 

--- a/frontend/src/router/index.jsx
+++ b/frontend/src/router/index.jsx
@@ -73,9 +73,7 @@ const RouterConfig = createBrowserRouter([
       {
         path: "advisories-and-closures",
         element: (
-          <AccessControlledRoute
-            allowedRoles={[ROLES.ADVISORY_SUBMITTER, ROLES.ADVISORY_APPROVER]}
-          >
+          <AccessControlledRoute allowedRoles={[ROLES.ADVISORY_USER]}>
             <AdvisoryDashboard />
           </AccessControlledRoute>
         ),
@@ -92,9 +90,7 @@ const RouterConfig = createBrowserRouter([
       {
         path: "/create-advisory",
         element: (
-          <AccessControlledRoute
-            allowedRoles={[ROLES.ADVISORY_SUBMITTER, ROLES.ADVISORY_APPROVER]}
-          >
+          <AccessControlledRoute allowedRoles={[ROLES.ADVISORY_USER]}>
             <Advisory mode="create" />
           </AccessControlledRoute>
         ),
@@ -102,9 +98,7 @@ const RouterConfig = createBrowserRouter([
       {
         path: "/advisory-summary/:documentId",
         element: (
-          <AccessControlledRoute
-            allowedRoles={[ROLES.ADVISORY_SUBMITTER, ROLES.ADVISORY_APPROVER]}
-          >
+          <AccessControlledRoute allowedRoles={[ROLES.ADVISORY_USER]}>
             <AdvisorySummary />
           </AccessControlledRoute>
         ),
@@ -112,9 +106,7 @@ const RouterConfig = createBrowserRouter([
       {
         path: "/update-advisory/:documentId",
         element: (
-          <AccessControlledRoute
-            allowedRoles={[ROLES.ADVISORY_SUBMITTER, ROLES.ADVISORY_APPROVER]}
-          >
+          <AccessControlledRoute allowedRoles={[ROLES.ADVISORY_USER]}>
             <Advisory mode="update" />
           </AccessControlledRoute>
         ),

--- a/frontend/src/router/pages/advisories/advisory/Advisory.jsx
+++ b/frontend/src/router/pages/advisories/advisory/Advisory.jsx
@@ -98,7 +98,7 @@ export default function Advisory({ mode }) {
   const [isAfterHourPublish, setIsAfterHourPublish] = useState(false);
   const [isSavingDraft, setIsSavingDraft] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [dataChanged, setDataChanged] = useState(false);
+  const dataChanged = useRef(false);
   const linksRef = useRef([]);
   const advisoryDateRef = useRef(moment().tz("America/Vancouver").toDate());
   const [isApprover, setIsApprover] = useState(false);
@@ -134,7 +134,7 @@ export default function Advisory({ mode }) {
   const isAuthenticated = auth.isAuthenticated;
 
   // Use a route blocker to show a confirmation dialog when the user attempts to navigate away with unsaved changes
-  const blocker = useBlocker(dataChanged);
+  const blocker = useBlocker(() => dataChanged.current);
   // Ref to track if the route blocker is currently active, to prevent multiple blocker flows from stacking if more navigation is attempted while the dialog is open
   const isBlockerActive = useRef(false);
 
@@ -168,10 +168,10 @@ export default function Advisory({ mode }) {
 
   // Set dataChanged to true when any of the form fields change, to enable the navigation guard
   const markChanged = useCallback(() => {
-    setDataChanged(true);
+    dataChanged.current = true;
   }, []);
 
-  useNavigationGuard(dataChanged);
+  useNavigationGuard(useCallback(() => dataChanged.current, []));
 
   // Block internal route transitions while there are unsaved changes.
   // beforeunload is still handled by useNavigationGuard for document-level exits.
@@ -189,7 +189,7 @@ export default function Advisory({ mode }) {
       const shouldProceed = await confirmUnsavedChangesNavigation();
 
       if (shouldProceed) {
-        setDataChanged(false);
+        dataChanged.current = false;
         blocker.proceed();
         return;
       }
@@ -1129,7 +1129,7 @@ export default function Advisory({ mode }) {
         data: newAdvisory,
       });
 
-      setDataChanged(false);
+      dataChanged.current = false;
       setIsSubmitting(false);
       setIsSavingDraft(false);
 
@@ -1255,7 +1255,7 @@ export default function Advisory({ mode }) {
         data: updatedAdvisory,
       });
 
-      setDataChanged(false);
+      dataChanged.current = false;
       setIsSubmitting(false);
       setIsSavingDraft(false);
 

--- a/frontend/src/router/pages/advisories/advisorySummary/AdvisorySummary.jsx
+++ b/frontend/src/router/pages/advisories/advisorySummary/AdvisorySummary.jsx
@@ -540,22 +540,27 @@ export default function AdvisorySummary() {
                           </>
                         )}
 
-                        <Button
-                          label="Unpublish"
-                          styling={classNames(
-                            "btn-outline-primary",
-                            "btn",
-                            "flex-grow-1",
-                            "flex-xl-shrink-0",
-                            // If the user can mark reviewed, hide the unpublish button on smaller screens
-                            // and show an overflow menu instead,
-                            isApprover ? "d-none d-xl-block" : "",
-                          )}
-                          disabled={isRequestingCms || !canUnpublish}
-                          onClick={handleUnpublish}
-                          hasLoader={isUnpublishing}
-                          leftIcon={<FontAwesomeIcon icon={faEyeSlash} />}
-                        />
+                        {hasAnyRole([
+                          ROLES.ADVISORY_SUBMITTER,
+                          ROLES.ADVISORY_APPROVER,
+                        ]) && (
+                          <Button
+                            label="Unpublish"
+                            styling={classNames(
+                              "btn-outline-primary",
+                              "btn",
+                              "flex-grow-1",
+                              "flex-xl-shrink-0",
+                              // If the user can mark reviewed, hide the unpublish button on smaller screens
+                              // and show an overflow menu instead,
+                              isApprover ? "d-none d-xl-block" : "",
+                            )}
+                            disabled={isRequestingCms || !canUnpublish}
+                            onClick={handleUnpublish}
+                            hasLoader={isUnpublishing}
+                            leftIcon={<FontAwesomeIcon icon={faEyeSlash} />}
+                          />
+                        )}
 
                         <Button
                           label="Edit"


### PR DESCRIPTION
### Jira Ticket

CMS-1811

### Description
Add role checks for handling the new advisory contributor role.

### Notes

This tickets implements UI elements of the contributor role, but for full usage comparable to DOOT more work is required, especially around implementing bundle access restrictions.  POs in DOOT only have access to parks in their bundle.  This is currently implemented to users in the contributor role can draft advisories for all BC Parks and RST resources. 

A Keycloak group has been created on the Dev keycloak environment called "BCP Park Operator ACT TESTING" but there will be no actual groups that only have the contributor role in the prod environment as part of the MVP launch. 

Also includes a fix for the UnsavedChangesDialog incorrectly appearing after a successful form save. The unsaved-changes flag was tracked with useState, which updates asynchronously — by the time navigate() fired after saving, the route blocker and beforeunload guard still read the stale true value. Switching to useRef ensures the flag is cleared synchronously before navigation is attempted.
