### PR TITLE
CMS-1767: Add savedWithErrors field to Season model

### DIFF
--- a/backend/migrations/20260622233301-add-saved-with-errors.js
+++ b/backend/migrations/20260622233301-add-saved-with-errors.js
@@ -1,0 +1,18 @@
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    // Add the new column to the Seasons table
+    await queryInterface.addColumn("Seasons", "savedWithErrors", {
+      type: Sequelize.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+      comment:
+        "True when the most recent update to the season bypassed validation errors",
+    });
+  },
+
+  // Remove the column from the Seasons table
+  async down(queryInterface, Sequelize) {
+    await queryInterface.removeColumn("Seasons", "savedWithErrors");
+  },
+};

--- a/backend/models/season.js
+++ b/backend/models/season.js
@@ -54,6 +54,11 @@ export default (sequelize) => {
       operatingYear: DataTypes.INTEGER,
       publishableId: DataTypes.INTEGER,
       status: DataTypes.STRING,
+      savedWithErrors: {
+        type: DataTypes.BOOLEAN,
+        allowNull: false,
+        defaultValue: false,
+      },
       readyToPublish: {
         type: DataTypes.BOOLEAN,
         allowNull: false,


### PR DESCRIPTION
### Jira Ticket

CMS-1767

### Description
<!-- What did you change, and why? -->

Added the `savedWithErrors` boolean column to the Seasons table for future "save with errors" functionality work.

I considered adding this to the SeasonChangeLog model instead, or having a corresponding value in that table, but I don't think we will ever need to track the historical values or know _when_ it changed. So I've just added it on the Season model so we can easily check what the current value is (like we do with the season status). I think that makes the most sense for how we intend to use it, but let me know if there are other things to consider!