### PR TITLE
CMS-1776: Add a custom sort order to standard message options

### DIFF
--- a/frontend/src/components/advisories/composite/advisoryForm/AccessStatusPicker.jsx
+++ b/frontend/src/components/advisories/composite/advisoryForm/AccessStatusPicker.jsx
@@ -1,10 +1,26 @@
 import { useEffect, useMemo, useState } from "react";
 import PropTypes from "prop-types";
+import { keyBy, mapValues, sortBy } from "lodash-es";
 import CategorySelect from "@/components/advisories/shared/categorySelect/CategorySelect";
 import {
   filterOptionsByScope,
   hasSelectedItems,
 } from "@/components/advisories/shared/categorySelect/categorySelectUtils";
+
+const CATEGORIES = [
+  { name: "Closed", sortOrder: 1 },
+  { name: "Restricted", sortOrder: 2 },
+  { name: "Limited access", sortOrder: 3 },
+  { name: "Visit with caution", sortOrder: 4 },
+  { name: "Seasonal restrictions", sortOrder: 5 },
+  { name: "Open", sortOrder: 6 },
+];
+
+// Map category names to their sort order
+const CATEGORY_SORT_ORDER = mapValues(
+  keyBy(CATEGORIES, (category) => category.name.toLowerCase()),
+  "sortOrder",
+);
 
 export default function AccessStatusPicker({
   accessStatus,
@@ -30,12 +46,24 @@ export default function AccessStatusPicker({
     [accessStatuses, hasBcpResourcesSelected, hasRstResourcesSelected],
   );
 
+  // Sort access statuses by category order first, then alphabetically by label
+  const sortedAccessStatuses = useMemo(
+    () =>
+      sortBy(filteredAccessStatuses, [
+        (status) =>
+          CATEGORY_SORT_ORDER[(status.category || "").toLowerCase()] ??
+          Number.POSITIVE_INFINITY,
+        (status) => (status.label || "").toLowerCase(),
+      ]),
+    [filteredAccessStatuses],
+  );
+
   // If the currently selected access status is not in the filtered list, select the first option by default (if available)
   const selectedAccessStatusOption = useMemo(
     () =>
-      filteredAccessStatuses.find((option) => option.value === accessStatus) ||
+      sortedAccessStatuses.find((option) => option.value === accessStatus) ||
       null,
-    [filteredAccessStatuses, accessStatus],
+    [sortedAccessStatuses, accessStatus],
   );
 
   useEffect(() => {
@@ -49,21 +77,21 @@ export default function AccessStatusPicker({
       return;
     }
 
-    if (!filteredAccessStatuses.length) {
+    if (!sortedAccessStatuses.length) {
       return;
     }
 
     // If the selected access status is not in the filtered options, select the first option by default
-    const hasSelectedAccessStatus = filteredAccessStatuses.some(
+    const hasSelectedAccessStatus = sortedAccessStatuses.some(
       (option) => option.value === accessStatus,
     );
 
     // Only update access status if the current selected access status is not in the filtered list, to avoid unnecessary updates
     if (!hasSelectedAccessStatus) {
-      setAccessStatus(filteredAccessStatuses[0].value);
+      setAccessStatus(sortedAccessStatuses[0].value);
     }
   }, [
-    filteredAccessStatuses,
+    sortedAccessStatuses,
     accessStatus,
     setAccessStatus,
     isRecreationUser,
@@ -74,7 +102,7 @@ export default function AccessStatusPicker({
     <CategorySelect
       id="resource-status"
       value={selectedAccessStatusOption}
-      options={filteredAccessStatuses}
+      options={sortedAccessStatuses}
       onChange={(option, actionMeta) => {
         if (actionMeta?.action === "clear") {
           setIsCleared(true);
@@ -88,6 +116,7 @@ export default function AccessStatusPicker({
       onBlur={validation}
       placeholder="Search or select public access status"
       defaultMenuLabel={(option) => option.label}
+      sortGroupsByLabel={false}
       isClearable
     />
   );

--- a/frontend/src/components/advisories/composite/advisoryForm/AccessStatusPicker.jsx
+++ b/frontend/src/components/advisories/composite/advisoryForm/AccessStatusPicker.jsx
@@ -1,26 +1,20 @@
 import { useEffect, useMemo, useState } from "react";
 import PropTypes from "prop-types";
-import { keyBy, mapValues, sortBy } from "lodash-es";
+import { sortBy } from "lodash-es";
 import CategorySelect from "@/components/advisories/shared/categorySelect/CategorySelect";
 import {
   filterOptionsByScope,
   hasSelectedItems,
 } from "@/components/advisories/shared/categorySelect/categorySelectUtils";
 
-const CATEGORIES = [
-  { name: "Closed", sortOrder: 1 },
-  { name: "Restricted", sortOrder: 2 },
-  { name: "Limited access", sortOrder: 3 },
-  { name: "Visit with caution", sortOrder: 4 },
-  { name: "Seasonal restrictions", sortOrder: 5 },
-  { name: "Open", sortOrder: 6 },
-];
-
-// Map category names to their sort order
-const CATEGORY_SORT_ORDER = mapValues(
-  keyBy(CATEGORIES, (category) => category.name.toLowerCase()),
-  "sortOrder",
-);
+const CATEGORIES = {
+  closed: 1,
+  restricted: 2,
+  "limited access": 3,
+  "visit with caution": 4,
+  "seasonal restrictions": 5,
+  open: 6,
+};
 
 export default function AccessStatusPicker({
   accessStatus,
@@ -51,7 +45,7 @@ export default function AccessStatusPicker({
     () =>
       sortBy(filteredAccessStatuses, [
         (status) =>
-          CATEGORY_SORT_ORDER[(status.category || "").toLowerCase()] ??
+          CATEGORIES[(status.category || "").toLowerCase()] ??
           Number.POSITIVE_INFINITY,
         (status) => (status.label || "").toLowerCase(),
       ]),

--- a/frontend/src/components/advisories/composite/advisoryForm/StandardMessagePicker.jsx
+++ b/frontend/src/components/advisories/composite/advisoryForm/StandardMessagePicker.jsx
@@ -1,11 +1,27 @@
 import { useEffect, useMemo } from "react";
 import PropTypes from "prop-types";
-import { sortBy } from "lodash-es";
+import { keyBy, mapValues, sortBy } from "lodash-es";
 import CategorySelect from "@/components/advisories/shared/categorySelect/CategorySelect";
 import {
   filterOptionsByScope,
   hasSelectedItems,
 } from "@/components/advisories/shared/categorySelect/categorySelectUtils";
+
+const CATEGORIES = [
+  { name: "Wildfire", sortOrder: 1 },
+  { name: "Environmental", sortOrder: 2 },
+  { name: "Access", sortOrder: 3 },
+  { name: "Public safety", sortOrder: 4 },
+  { name: "Wildlife", sortOrder: 5 },
+  { name: "Seasonal restrictions", sortOrder: 6 },
+  { name: "Pandemic", sortOrder: 7 },
+];
+
+// Map category names to their sort order
+const CATEGORY_SORT_ORDER = mapValues(
+  keyBy(CATEGORIES, (category) => category.name.toLowerCase()),
+  "sortOrder",
+);
 
 export default function StandardMessagePicker({
   standardMessages,
@@ -16,6 +32,8 @@ export default function StandardMessagePicker({
 }) {
   const hasBcpResourcesSelected = hasSelectedItems(selectedProtectedAreas);
   const hasRstResourcesSelected = hasSelectedItems(selectedRecreationResources);
+  const hasBothResourcesSelected =
+    hasBcpResourcesSelected && hasRstResourcesSelected;
 
   // Filter message options based on scope and selected resources (BCP or RST)
   const filteredStandardMessages = useMemo(
@@ -28,12 +46,14 @@ export default function StandardMessagePicker({
     [standardMessages, hasBcpResourcesSelected, hasRstResourcesSelected],
   );
 
-  // Sort messages by event type precedence first, then alphabetically by label
+  // Sort messages by category order first, then alphabetically by label
   const sortedStandardMessages = useMemo(
     () =>
       sortBy(filteredStandardMessages, [
-        (message) => message?.eventTypePrecedence ?? Number.POSITIVE_INFINITY,
-        (message) => message?.label?.toLowerCase() ?? "",
+        (message) =>
+          CATEGORY_SORT_ORDER[(message.category || "").toLowerCase()] ??
+          Number.POSITIVE_INFINITY,
+        (message) => (message.label || "").toLowerCase(),
       ]),
     [filteredStandardMessages],
   );
@@ -66,8 +86,14 @@ export default function StandardMessagePicker({
       onChange={(messages) => {
         setSelectedStandardMessages(messages || []);
       }}
-      placeholder="Search or select standard message(s)"
+      placeholder={
+        hasBothResourcesSelected
+          ? "No options available based on your resource selection"
+          : "Search or select standard message(s)"
+      }
       defaultMenuLabel={(option) => option.label}
+      sortGroupsByLabel={false}
+      isDisabled={hasBothResourcesSelected}
       isMulti={true}
       isClearable
     />

--- a/frontend/src/components/advisories/composite/advisoryForm/StandardMessagePicker.jsx
+++ b/frontend/src/components/advisories/composite/advisoryForm/StandardMessagePicker.jsx
@@ -1,27 +1,21 @@
 import { useEffect, useMemo } from "react";
 import PropTypes from "prop-types";
-import { keyBy, mapValues, sortBy } from "lodash-es";
+import { sortBy } from "lodash-es";
 import CategorySelect from "@/components/advisories/shared/categorySelect/CategorySelect";
 import {
   filterOptionsByScope,
   hasSelectedItems,
 } from "@/components/advisories/shared/categorySelect/categorySelectUtils";
 
-const CATEGORIES = [
-  { name: "Wildfire", sortOrder: 1 },
-  { name: "Environmental", sortOrder: 2 },
-  { name: "Access", sortOrder: 3 },
-  { name: "Public safety", sortOrder: 4 },
-  { name: "Wildlife", sortOrder: 5 },
-  { name: "Seasonal restrictions", sortOrder: 6 },
-  { name: "Pandemic", sortOrder: 7 },
-];
-
-// Map category names to their sort order
-const CATEGORY_SORT_ORDER = mapValues(
-  keyBy(CATEGORIES, (category) => category.name.toLowerCase()),
-  "sortOrder",
-);
+const CATEGORIES = {
+  wildfire: 1,
+  environmental: 2,
+  access: 3,
+  "public safety": 4,
+  wildlife: 5,
+  "seasonal restrictions": 6,
+  pandemic: 7,
+};
 
 export default function StandardMessagePicker({
   standardMessages,
@@ -51,7 +45,7 @@ export default function StandardMessagePicker({
     () =>
       sortBy(filteredStandardMessages, [
         (message) =>
-          CATEGORY_SORT_ORDER[(message.category || "").toLowerCase()] ??
+          CATEGORIES[(message.category || "").toLowerCase()] ??
           Number.POSITIVE_INFINITY,
         (message) => (message.label || "").toLowerCase(),
       ]),

--- a/frontend/src/components/advisories/shared/categorySelect/CategorySelect.jsx
+++ b/frontend/src/components/advisories/shared/categorySelect/CategorySelect.jsx
@@ -27,7 +27,9 @@ export default function CategorySelect({
   onBlur,
   placeholder = "Select...",
   categoryKey = "category",
+  sortGroupsByLabel = true,
   defaultMenuLabel,
+  isDisabled = false,
   isMulti = false,
   isClearable = false,
 }) {
@@ -60,9 +62,11 @@ export default function CategorySelect({
     // Group options by category
     const groups = groupBy(categorizedOptions, categoryKey);
 
-    const grouped = sortBy(Object.entries(groups), ([label]) =>
-      label.toLowerCase(),
-    ).map(([label, categoryOptions]) => ({
+    const groupedEntries = sortGroupsByLabel
+      ? sortBy(Object.entries(groups), ([label]) => label.toLowerCase())
+      : Object.entries(groups);
+
+    const grouped = groupedEntries.map(([label, categoryOptions]) => ({
       label,
       options: sortOptionsByLabel(categoryOptions),
     }));
@@ -80,7 +84,7 @@ export default function CategorySelect({
     }
 
     return grouped;
-  }, [options, categoryKey]);
+  }, [options, categoryKey, sortGroupsByLabel]);
 
   return (
     <Select
@@ -94,6 +98,7 @@ export default function CategorySelect({
       className={classNames("bcgov-select", {
         "bcgov-select--has-selection": hasSelection,
       })}
+      isDisabled={isDisabled}
       isMulti={isMulti}
       isClearable={isClearable}
       formatOptionLabel={(option, { context }) => {
@@ -135,7 +140,9 @@ CategorySelect.propTypes = {
   onBlur: PropTypes.func,
   placeholder: PropTypes.string,
   categoryKey: PropTypes.string,
+  sortGroupsByLabel: PropTypes.bool,
   defaultMenuLabel: PropTypes.func,
+  isDisabled: PropTypes.bool,
   isMulti: PropTypes.bool,
   isClearable: PropTypes.bool,
 };

--- a/frontend/src/hooks/useCms.js
+++ b/frontend/src/hooks/useCms.js
@@ -338,7 +338,7 @@ export default function useCms() {
     [fetchCached],
   );
 
-const getStandardMessages = useCallback(
+  const getStandardMessages = useCallback(
     () =>
       fetchCached(
         "standardMessages",

--- a/frontend/src/hooks/useCms.js
+++ b/frontend/src/hooks/useCms.js
@@ -338,22 +338,14 @@ export default function useCms() {
     [fetchCached],
   );
 
-  const getStandardMessages = useCallback(() => {
-    const query = qs.stringify(
-      {
-        sort: ["precedence"],
-        fields: ["documentId", "title", "description", "scope"],
-        populate: {
-          eventType: {
-            fields: ["groupLabel", "precedence"],
-          },
-        },
-      },
-      { encodeValuesOnly: true },
-    );
-
-    return fetchCached("standardMessages", `/standard-messages?${query}`);
-  }, [fetchCached]);
+const getStandardMessages = useCallback(
+    () =>
+      fetchCached(
+        "standardMessages",
+        `/standard-messages?${querySort("groupLabel")}`,
+      ),
+    [fetchCached],
+  );
 
   /**
    * Determines whether today is a statutory holiday and updates component state.

--- a/frontend/src/hooks/useCms.js
+++ b/frontend/src/hooks/useCms.js
@@ -342,7 +342,17 @@ export default function useCms() {
     () =>
       fetchCached(
         "standardMessages",
-        `/standard-messages?${querySort("groupLabel")}`,
+        `/standard-messages?${qs.stringify(
+          {
+            filters: {
+              isActive: {
+                $eq: true,
+              },
+            },
+            sort: ["groupLabel"],
+          },
+          { encodeValuesOnly: true },
+        )}`,
       ),
     [fetchCached],
   );

--- a/frontend/src/router/pages/advisories/advisory/Advisory.jsx
+++ b/frontend/src/router/pages/advisories/advisory/Advisory.jsx
@@ -730,9 +730,8 @@ export default function Advisory({ mode }) {
           const newStandardMessages = standardMessageData.map((m) => ({
             label: m.title,
             value: m.documentId,
-            category: m.eventType?.groupLabel,
+            category: m.groupLabel,
             scope: m.scope,
-            eventTypePrecedence: m.eventType?.precedence,
             type: "standardMessage",
             obj: m,
           }));


### PR DESCRIPTION
### Jira Ticket

CMS-1776

### Description
<!-- What did you change, and why? -->
- Fixed the standard messages sorting by a custom order
- Grouped the standard messages by `groupLabel`
- Disabled the standard message field if an advisory has both parks and resources
- Filtered the standard messages by `isActive`
- Fixed the access statuses sorting by a custom order
