### PR TITLE
CMS-1771: Add "Submit with errors" checkbox to Season edit form

### DIFF
--- a/backend/routes/api/seasons.js
+++ b/backend/routes/api/seasons.js
@@ -60,6 +60,7 @@ function checkSeasonExists(season) {
  * If "save" is true, it will first save the changes to the Season.
  * @param {number} seasonId The ID of the season to update
  * @param {string} status The new status to set for the season
+ * @param {boolean} savedWithErrors Whether the form was submitted with validation errors
  * @param {boolean} [readyToPublish] Optionally provide a new readyToPublish value to set
  * @param {Transaction} [transaction] Optional Sequelize transaction object for atomic operations
  * @returns {Promise<Season>} The updated season model
@@ -67,6 +68,7 @@ function checkSeasonExists(season) {
 async function updateStatus(
   seasonId,
   status,
+  savedWithErrors,
   readyToPublish = null,
   transaction = null,
 ) {
@@ -76,6 +78,9 @@ async function updateStatus(
 
   // Update season status
   season.status = status;
+
+  // Update the "savedWithErrors" flag
+  season.savedWithErrors = savedWithErrors;
 
   // Update the "Ready to publish" flag if provided
   if (readyToPublish !== null) {
@@ -262,6 +267,7 @@ const SEASON_ATTRIBUTES = [
   "editable",
   "publishableId",
   "seasonType",
+  "savedWithErrors",
 ];
 
 /**
@@ -490,6 +496,7 @@ async function getWinterSeason(park, operatingYear) {
  * @param {string} params.newStatus New status for the season
  * @param {boolean|null} params.newReadyToPublish New readyToPublish value
  * @param {string} params.notes Notes for the change log
+ * @param {boolean} params.savedWithErrors Whether the form was submitted with validation errors
  * @param {number} params.userId User ID making the changes
  * @param {Transaction} params.transaction Database transaction
  * @param {boolean} params.isWinterSeason Whether this is a winter season
@@ -504,6 +511,7 @@ async function saveSeasonData({
   newStatus,
   newReadyToPublish,
   notes,
+  savedWithErrors,
   userId,
   transaction,
   isWinterSeason = false,
@@ -596,6 +604,7 @@ async function saveSeasonData({
   const saveSeason = updateStatus(
     season.id,
     newStatus,
+    savedWithErrors,
     newReadyToPublish,
     transaction,
   );
@@ -1079,6 +1088,7 @@ router.post(
     const seasonId = Number(req.params.seasonId);
     const {
       notes = "",
+      savedWithErrors = false,
       deletedDateRangeIds = [],
       dateRangeAnnuals = [],
       gateDetail = {},
@@ -1146,6 +1156,18 @@ router.post(
       checkSeasonExists(season);
 
       const newStatus = status ?? season.status;
+      const shouldMarkSavedWithErrors =
+        newStatus !== STATUS.REQUESTED && savedWithErrors;
+
+      // Require an explanation note if the form is submitted with validation errors
+      if (shouldMarkSavedWithErrors && !notes.trim()) {
+        const error = new Error(
+          "Validation error: Missing explanation note for saving with errors.",
+        );
+
+        error.status = 400;
+        throw error;
+      }
 
       // If readyToPublish is null or undefined, set it to the current value
       const newReadyToPublish = readyToPublish ?? season.readyToPublish;
@@ -1163,6 +1185,7 @@ router.post(
         newStatus,
         newReadyToPublish,
         notes,
+        savedWithErrors: shouldMarkSavedWithErrors,
         userId: req.user.id,
         transaction,
         isWinterSeason,

--- a/frontend/src/components/DatePicker.jsx
+++ b/frontend/src/components/DatePicker.jsx
@@ -57,7 +57,7 @@ function DootDatePickerComponent({
         <FontAwesomeIcon className="append-content" icon={faCalendarCheck} />
       </div>
 
-      <ErrorSlot element={elements.dateField(id, dateField)} />
+      <ErrorSlot elementId={elements.dateField(id, dateField).id} />
     </>
   );
 }

--- a/frontend/src/components/DateRangeFields.jsx
+++ b/frontend/src/components/DateRangeFields.jsx
@@ -96,7 +96,7 @@ function DateRange({
         </div>
       </div>
 
-      <ErrorSlot element={elements.dateRange(idOrTempId)} />
+      <ErrorSlot elementId={elements.dateRange(idOrTempId).id} />
     </div>
   );
 }
@@ -251,7 +251,7 @@ export default function DateRangeFields({
       )}
 
       <ErrorSlot
-        element={elements.dateableDateType(dateableId, dateType.name)}
+        elementId={elements.dateableDateType(dateableId, dateType.name).id}
       />
     </>
   );

--- a/frontend/src/components/FormErrorSummary.jsx
+++ b/frontend/src/components/FormErrorSummary.jsx
@@ -1,0 +1,134 @@
+import PropTypes from "prop-types";
+import { groupBy, orderBy, partition } from "lodash-es";
+import { useCallback, useMemo } from "react";
+
+/**
+ * Scrolls the page to reveal the validation error slot for the given element ID.
+ * @param {string} errorId The validation element ID to scroll to
+ * @returns {void}
+ */
+function scrollToError(errorId) {
+  // Find the error message element in the DOM by its error ID
+  const errorElement = document.querySelector(
+    `[data-error-slot-id="${errorId}"]`,
+  );
+
+  if (errorElement) {
+    errorElement.scrollIntoView({ behavior: "smooth", block: "center" });
+  }
+}
+
+// Displays a list of validation errors, with links to scroll the fields into view
+function ErrorList({ errors }) {
+  // Sort the output alphabetically
+  const sortedErrors = useMemo(
+    () => orderBy(errors, ["name", "message"], ["asc", "asc"]),
+    [errors],
+  );
+
+  return (
+    <ul>
+      {sortedErrors.map((error) => (
+        <li key={`${error.id}-${error.message}`}>
+          <button
+            type="button"
+            onClick={() => scrollToError(error.id)}
+            className="btn btn-text text-decoration-underline p-0 text-start align-top"
+          >
+            {error.name}: {error.message}
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+ErrorList.propTypes = {
+  errors: PropTypes.array.isRequired,
+};
+
+export default function FormErrorSummary({
+  multipleFeatures = false,
+  errors,
+  dateableNameMap,
+}) {
+  const numErrors = errors.length;
+
+  const headline =
+    numErrors === 1
+      ? "There is 1 entry that may be incorrect"
+      : `There are ${numErrors} entries that may be incorrect`;
+
+  const [featureErrors, formErrors] = partition(
+    errors,
+    (error) => error.dateableId,
+  );
+
+  const getFeatureName = useCallback(
+    (dateableId) => dateableNameMap.get(dateableId) || "",
+    [dateableNameMap],
+  );
+
+  const groupedFeatureErrors = useMemo(() => {
+    // For Park- and Feature-level forms, we don't need this variable.
+    if (!multipleFeatures) return [];
+
+    // For ParkArea-level forms with multiple features, group errors by the Feature's DateableId
+    const groupedErrors = groupBy(featureErrors, "dateableId");
+    const groupedByName = Object.entries(groupedErrors).map(
+      ([dateableId, errorsArray]) => ({
+        name: getFeatureName(Number(dateableId)),
+        errors: errorsArray,
+        dateableId, // for template keys
+      }),
+    );
+
+    return groupedByName;
+  }, [multipleFeatures, featureErrors, getFeatureName]);
+
+  return (
+    <div
+      className="alert alert-danger fade show px-5 py-4 text-black"
+      role="alert"
+    >
+      <h3 className="h5">{headline}</h3>
+
+      {multipleFeatures &&
+        groupedFeatureErrors.map((feature) => (
+          <div key={feature.dateableId} className="mb-2">
+            <div className="fw-bold mb-1">{feature.name}</div>
+            <ErrorList errors={feature.errors} />
+          </div>
+        ))}
+
+      {!multipleFeatures && featureErrors.length > 0 && (
+        <div className="mb-2">
+          <ErrorList errors={featureErrors} />
+        </div>
+      )}
+
+      {formErrors.length > 0 && (
+        <>
+          {featureErrors.length > 0 && <hr />}
+
+          <div className="mb-2">
+            <ErrorList errors={formErrors} />
+          </div>
+        </>
+      )}
+
+      <p className="mb-0">
+        Please review the dates to ensure they are correct, and revise them if
+        needed. If you’ve confirmed the information is correct, proceed to
+        submit anyway.
+      </p>
+    </div>
+  );
+}
+
+// Prop types
+FormErrorSummary.propTypes = {
+  multipleFeatures: PropTypes.bool,
+  errors: PropTypes.array.isRequired,
+  dateableNameMap: PropTypes.instanceOf(Map).isRequired,
+};

--- a/frontend/src/components/FormPanel.jsx
+++ b/frontend/src/components/FormPanel.jsx
@@ -10,6 +10,7 @@ import ParkSeasonForm from "@/components/SeasonForms/ParkSeasonForm";
 import AreaSeasonForm from "@/components/SeasonForms/AreaSeasonForm";
 import FeatureSeasonForm from "@/components/SeasonForms/FeatureSeasonForm";
 import ConfirmationDialog from "@/components/ConfirmationDialog";
+import ErrorSummary from "@/components/FormErrorSummary";
 
 import { useApiGet, useApiPost } from "@/hooks/useApi";
 import useAccess from "@/hooks/useAccess";
@@ -199,6 +200,38 @@ function SeasonForm({
   // Find the "Park gate open" date type id
   const gateTypeId = dateTypesByStrapiId[1]?.id;
 
+  // Build a map of Dateable IDs to their Feature names, for display in the Error Summary
+  const dateableNames = useMemo(() => {
+    if (!season) return new Map();
+
+    // For ParkArea-level forms, we need to translate Dateable IDs to names for each Feature in the area
+    if (level === "park-area") {
+      return new Map(
+        season.parkArea.features.map(({ dateableId, name }) => [
+          dateableId,
+          name,
+        ]),
+      );
+    }
+
+    // For Feature-level forms, we only need the Feature itself, so return a map with one entry
+    if (level === "feature") {
+      return new Map([[season.feature.dateableId, season.feature.name]]);
+    }
+
+    // For Park-level forms, we don't need to translate Dateable IDs to names, so return an empty map
+    return new Map();
+  }, [level, season]);
+
+  // Determine if this is a ParkArea-level form with multiple features.
+  // This affects the content of the Error Summary component.
+  const multipleFeatures = useMemo(() => {
+    // Return false if the season data isn't loaded or if it's not an applicable parkArea form
+    if (level !== "park-area" || !season?.parkArea?.features) return false;
+
+    return season.parkArea.features.length > 1;
+  }, [level, season]);
+
   // Clears and re-fetches the data
   function resetData() {
     setData(null);
@@ -346,6 +379,16 @@ function SeasonForm({
     const validationErrors = validation.validateForm();
 
     if (validationErrors.length && !allowInvalid) {
+      // Scroll the Error Summary component into view at the top of the form
+      const errorSummaryElement = document.getElementById("validation-errors");
+
+      if (errorSummaryElement) {
+        errorSummaryElement.scrollIntoView({
+          behavior: "smooth",
+          block: "start",
+        });
+      }
+
       // If there are validation errors and we're not allowing invalid saves, stop here
       throw new Error(
         `Validation failed with ${validationErrors.length} errors`,
@@ -529,6 +572,20 @@ If dates have already been published, they will not be updated until new dates a
         </Offcanvas.Header>
 
         <Offcanvas.Body>
+          <div id="validation-errors">
+            {validation.errors.length > 0 && (
+              <div className="row">
+                <div className="col-12 col-lg-7 col-xl-6 mb-4">
+                  <ErrorSummary
+                    multipleFeatures={multipleFeatures}
+                    errors={validation.errors}
+                    dateableNameMap={dateableNames}
+                  />
+                </div>
+              </div>
+            )}
+          </div>
+
           <h3>Public information</h3>
           <p>This information is displayed on bcparks.ca</p>
 

--- a/frontend/src/components/FormPanel.jsx
+++ b/frontend/src/components/FormPanel.jsx
@@ -1,5 +1,6 @@
 import { useCallback, useContext, useEffect, useMemo, useState } from "react";
 import Offcanvas from "react-bootstrap/Offcanvas";
+import Form from "react-bootstrap/Form";
 import PropTypes from "prop-types";
 import { isEqual, omit, keyBy } from "lodash-es";
 
@@ -119,6 +120,21 @@ function SeasonForm({
   const [data, setData] = useState(null);
   const [notes, setNotes] = useState("");
   const [deletedDateRangeIds, setDeletedDateRangeIds] = useState([]);
+  const [submitWithErrors, setSubmitWithErrors] = useState(false);
+
+  // Determine if the user is allowed to bypass validation errors and submit/approve the form
+  const allowSubmitWithErrors = useMemo(() => {
+    // Return false if the user is not an approver or submitter
+    if (!approver && !submitter) return false;
+
+    // Return false if the user hasn't provided any notes
+    if (!notes.trim()) return false;
+
+    // Return true if the "Submit with errors" checkbox is checked
+    if (submitWithErrors) return true;
+
+    return false;
+  }, [approver, submitter, submitWithErrors, notes]);
 
   // Track form submission state: run more validation rules after the first submit
   const [submitted, setSubmitted] = useState(false);
@@ -429,6 +445,13 @@ function SeasonForm({
         );
     }
 
+    // Send the value of the "Submit with validation errors" checkbox to the API
+    // Always send false for drafts, since drafts can always be saved with errors
+    payload.savedWithErrors =
+      status !== STATUS.REQUESTED.value &&
+      allowInvalid &&
+      validationErrors.length > 0;
+
     try {
       // Send the save request to the API
       await sendSave(payload);
@@ -439,6 +462,7 @@ function SeasonForm({
       // Reset the form state
       setNotes("");
       setDeletedDateRangeIds([]);
+      setSubmitWithErrors(false);
 
       if (close) {
         closePanel();
@@ -486,8 +510,8 @@ If dates have already been published, they will not be updated until new dates a
 
   async function onApprove() {
     try {
-      // Save and update status
-      await saveForm(false, false, STATUS.APPROVED.value); // Don't close the form after saving
+      // Save and update status, bypassing validation errors if the user has checked the "Submit with errors" checkbox
+      await saveForm(false, allowSubmitWithErrors, STATUS.APPROVED.value); // Don't close the form after saving
 
       // Start refreshing the main page data from the API
       onDataUpdate();
@@ -505,8 +529,8 @@ If dates have already been published, they will not be updated until new dates a
 
   async function onSubmit() {
     try {
-      // Save and update status
-      await saveForm(false, false, STATUS.PENDING_REVIEW.value); // Don't close the form after saving
+      // Save and update status, bypassing validation errors if the user has checked the "Submit with errors" checkbox
+      await saveForm(false, allowSubmitWithErrors, STATUS.PENDING_REVIEW.value); // Don't close the form after saving
 
       // Start refreshing the main page data from the API
       onDataUpdate();
@@ -635,6 +659,43 @@ If dates have already been published, they will not be updated until new dates a
               season.status !== STATUS.PUBLISHED.value
             }
           />
+
+          {/* Pseudo-validation for submitting with errors: User must provide an internal note */}
+          {validation.errors.length > 0 &&
+            submitWithErrors &&
+            !notes.trim() && (
+              <div
+                className="text-danger validation-errors mb-5"
+                data-error-slot-id="submit-with-errors-notes"
+              >
+                <div>
+                  Required when submitting with errors. Please explain why
+                  errors do not apply.
+                </div>
+              </div>
+            )}
+
+          {/* For users who can submit or approve, show a checkbox to and bypass validation */}
+          {validation.errors.length > 0 && (submitter || approver) && (
+            <div>
+              <div
+                className="alert alert-warning fade show px-5 py-4 text-black"
+                role="alert"
+              >
+                <h4>Submit anyway</h4>
+
+                <Form.Check
+                  label={
+                    "I have reviewed the errors and confirm the information is correct. An Internal note is required to explain why errors do not apply."
+                  }
+                  id={"submit-with-errors"}
+                  checked={submitWithErrors}
+                  onChange={(e) => setSubmitWithErrors(e.target.checked)}
+                />
+              </div>
+            </div>
+          )}
+
           <Buttons
             approver={approver}
             submitter={submitter}

--- a/frontend/src/components/GateForm.jsx
+++ b/frontend/src/components/GateForm.jsx
@@ -65,7 +65,7 @@ export default function GateForm({
             }}
           />
 
-          <ErrorSlot element={elements.HAS_GATE} />
+          <ErrorSlot elementId={elements.HAS_GATE.id} />
         </div>
         {gateDetail.hasGate && (
           <div>
@@ -144,7 +144,7 @@ export default function GateForm({
               />
             </Form>
 
-            <ErrorSlot element={elements.GATE_TIMES} />
+            <ErrorSlot elementId={elements.GATE_TIMES.id} />
           </div>
         )}
       </div>

--- a/frontend/src/components/InternalNotes.jsx
+++ b/frontend/src/components/InternalNotes.jsx
@@ -75,7 +75,7 @@ function InternalNotes({
         </small>
       </div>
 
-      <ErrorSlot element={elements.INTERNAL_NOTES} />
+      <ErrorSlot elementId={elements.INTERNAL_NOTES.id} />
     </div>
   );
 }

--- a/frontend/src/components/SeasonForms/AreaSeasonForm.jsx
+++ b/frontend/src/components/SeasonForms/AreaSeasonForm.jsx
@@ -93,7 +93,7 @@ function FeatureFormSectionComponent({
         </div>
       ))}
 
-      <ErrorSlot element={elements.dateableSection(feature.dateableId)} />
+      <ErrorSlot elementId={elements.dateableSection(feature.dateableId).id} />
     </div>
   );
 }

--- a/frontend/src/components/SeasonForms/FeatureSeasonForm.jsx
+++ b/frontend/src/components/SeasonForms/FeatureSeasonForm.jsx
@@ -181,7 +181,9 @@ function FormSection({ dateTypes, feature, season, previousSeasonDates }) {
             canSpan2Years={feature.datesCanSpan2Years}
           />
 
-          <ErrorSlot element={elements.dateableSection(feature.dateableId)} />
+          <ErrorSlot
+            elementId={elements.dateableSection(feature.dateableId).id}
+          />
         </div>
       ))}
     </div>

--- a/frontend/src/components/ValidationErrorSlot.jsx
+++ b/frontend/src/components/ValidationErrorSlot.jsx
@@ -3,23 +3,26 @@ import PropTypes from "prop-types";
 import { useValidationContext } from "@/hooks/useValidation/useValidation";
 
 // Displays validation error messages in named areas of the UI
-export default function ValidationErrorSlot({ element }) {
+export default function ValidationErrorSlot({ elementId }) {
   const validation = useValidationContext();
 
-  const errors = validation.groupedErrors[element] || [];
+  const errors = validation.groupedErrors[elementId] || [];
 
   if (!errors.length) return null;
 
   // Render all validation errors for this "element"
   return (
-    <div className="text-danger validation-errors my-2">
-      {errors.map((error, index) => (
-        <div key={index}>{error.message}</div>
+    <div
+      className="text-danger validation-errors my-2"
+      data-error-slot-id={elementId}
+    >
+      {errors.map((error) => (
+        <div key={`${error.id}-${error.message}`}>{error.message}</div>
       ))}
     </div>
   );
 }
 
 ValidationErrorSlot.propTypes = {
-  element: PropTypes.string.isRequired,
+  elementId: PropTypes.string.isRequired,
 };

--- a/frontend/src/hooks/useValidation/rules/completeDateRanges.js
+++ b/frontend/src/hooks/useValidation/rules/completeDateRanges.js
@@ -18,7 +18,12 @@ export default function completeDateRanges(seasonData, context) {
     if (dateRange.startDate && !dateRange.endDate) {
       context.addError(
         // Show the error below the empty end date field
-        elements.dateField(idOrTempId, "endDate"),
+        elements.dateField(
+          idOrTempId,
+          "endDate",
+          `${dateRange.dateType.name} end date`,
+          dateRange.dateableId,
+        ),
         "Enter an end date",
       );
     }
@@ -27,7 +32,12 @@ export default function completeDateRanges(seasonData, context) {
     if (dateRange.endDate && !dateRange.startDate) {
       context.addError(
         // Show the error below the empty start date field
-        elements.dateField(idOrTempId, "startDate"),
+        elements.dateField(
+          idOrTempId,
+          "startDate",
+          `${dateRange.dateType.name} start date`,
+          dateRange.dateableId,
+        ),
         "Enter a start date",
       );
     }

--- a/frontend/src/hooks/useValidation/rules/dateInOperatingYear.js
+++ b/frontend/src/hooks/useValidation/rules/dateInOperatingYear.js
@@ -38,7 +38,12 @@ export default function dateInOperatingYear(seasonData, context) {
     ) {
       context.addError(
         // Show the error below the start date field
-        elements.dateField(dateRange.id || dateRange.tempId, "startDate"),
+        elements.dateField(
+          dateRange.id || dateRange.tempId,
+          "startDate",
+          `${dateRange.dateType.name} start date`,
+          dateRange.dateableId,
+        ),
         yearErrorMessage,
       );
     }
@@ -49,7 +54,12 @@ export default function dateInOperatingYear(seasonData, context) {
     ) {
       context.addError(
         // Show the error below the end date field
-        elements.dateField(dateRange.id || dateRange.tempId, "endDate"),
+        elements.dateField(
+          dateRange.id || dateRange.tempId,
+          "endDate",
+          `${dateRange.dateType.name} end date`,
+          dateRange.dateableId,
+        ),
         yearErrorMessage,
       );
     }

--- a/frontend/src/hooks/useValidation/rules/noOverlapPrevious.js
+++ b/frontend/src/hooks/useValidation/rules/noOverlapPrevious.js
@@ -43,7 +43,11 @@ export default function noOverlapPrevious(seasonData, context) {
     if (overlaps) {
       context.addError(
         // Show error below the date range
-        elements.dateRange(dateRange.id || dateRange.tempId),
+        elements.dateRange(
+          dateRange.id || dateRange.tempId,
+          dateRange.dateType.name,
+          dateRange.dateableId,
+        ),
         "The dates must not overlap with existing dates submitted in the previous season.",
       );
     }

--- a/frontend/src/hooks/useValidation/rules/requiredDateRanges.js
+++ b/frontend/src/hooks/useValidation/rules/requiredDateRanges.js
@@ -24,8 +24,13 @@ export default function requiredDateRanges(seasonData, context) {
   requiredRanges.forEach((dateRange) => {
     if (!dateRange.startDate) {
       context.addError(
-        // Show the error below the end date field
-        elements.dateField(dateRange.id || dateRange.tempId, "startDate"),
+        // Show the error below the start date field
+        elements.dateField(
+          dateRange.id || dateRange.tempId,
+          "startDate",
+          `${dateRange.dateType.name} start date`,
+          dateRange.dateableId,
+        ),
         "Required",
       );
     }
@@ -33,7 +38,12 @@ export default function requiredDateRanges(seasonData, context) {
     if (!dateRange.endDate) {
       context.addError(
         // Show the error below the end date field
-        elements.dateField(dateRange.id || dateRange.tempId, "endDate"),
+        elements.dateField(
+          dateRange.id || dateRange.tempId,
+          "endDate",
+          `${dateRange.dateType.name} end date`,
+          dateRange.dateableId,
+        ),
         "Required",
       );
     }

--- a/frontend/src/hooks/useValidation/rules/startDateBeforeEndDate.js
+++ b/frontend/src/hooks/useValidation/rules/startDateBeforeEndDate.js
@@ -18,7 +18,11 @@ export default function startDateBeforeEndDate(seasonData, context) {
     if (!isBefore(dateRange.startDate, dateRange.endDate)) {
       context.addError(
         // Show error below the date range
-        elements.dateRange(dateRange.id || dateRange.tempId),
+        elements.dateRange(
+          dateRange.id || dateRange.tempId,
+          dateRange.dateType.name,
+          dateRange.dateableId,
+        ),
         "Enter an end date that comes after the start date",
       );
     }

--- a/frontend/src/hooks/useValidation/rules/winterDateYears.js
+++ b/frontend/src/hooks/useValidation/rules/winterDateYears.js
@@ -43,8 +43,13 @@ export default function winterDateYears(seasonData, context) {
 
     if (startDate && !isWithinInterval(startDate, validStartDates)) {
       context.addError(
-        // Show the error below the empty end date field
-        elements.dateField(idOrTempId, "startDate"),
+        // Show the error below the empty start date field
+        elements.dateField(
+          idOrTempId,
+          "startDate",
+          `${winterDateRange.dateType.name} start date`,
+          winterDateRange.dateableId,
+        ),
         `The start date must be between October 1 and December 31, ${operatingYear}`,
       );
     }
@@ -52,7 +57,12 @@ export default function winterDateYears(seasonData, context) {
     if (endDate && !isBefore(endDate, april1)) {
       context.addError(
         // Show the error below the empty end date field
-        elements.dateField(idOrTempId, "endDate"),
+        elements.dateField(
+          idOrTempId,
+          "endDate",
+          `${winterDateRange.dateType.name} end date`,
+          winterDateRange.dateableId,
+        ),
         `The end date must be before April 1, ${operatingYear + 1}`,
       );
     }

--- a/frontend/src/hooks/useValidation/useValidation.js
+++ b/frontend/src/hooks/useValidation/useValidation.js
@@ -17,29 +17,47 @@ import winterAndReservationNoOverlap from "./rules/winterAndReservationNoOverlap
 import winterDateYears from "./rules/winterDateYears.js";
 import reservationAndWinterNoOverlap from "./rules/reservationAndWinterNoOverlap.js";
 
-// Constants for named "validation error slots" in the UI
+// Constants for named "validation error slots" in the UI:
+// `id` is used to identify the DOM element for the error message
+// `name` is a human-readable name for the element (shown in the ErrorSummary component)
+// `dateableId` is the ID of the dateable feature for grouping errors in the ErrorSummary component
 const elements = {
   // Under the "Has gate? Yes/No" radio buttons
-  HAS_GATE: "hasGate",
+  HAS_GATE: { id: "hasGate", name: "Gate" },
 
   // Under the gate hours time range inputs
-  GATE_TIMES: "gateTimes",
+  GATE_TIMES: { id: "gateTimes", name: "Gate Times" },
 
   // Under the "internal notes" textarea
-  INTERNAL_NOTES: "internalNotes",
+  INTERNAL_NOTES: { id: "internalNotes", name: "Internal notes" },
 
   // Under an individual date range by its ID
-  dateRange: (idOrTempId) => `dateRange-${idOrTempId}`,
+  dateRange: (idOrTempId, displayName = "", dateableId = null) => ({
+    id: `dateRange-${idOrTempId}`,
+    name: displayName,
+    dateableId,
+  }),
 
   // Under an individual date input field by its dateRange ID and its field name
-  dateField: (idOrTempId, fieldName) => `dateField-${idOrTempId}-${fieldName}`,
+  dateField: (idOrTempId, fieldName, displayName = "", dateableId = null) => ({
+    id: `dateField-${idOrTempId}-${fieldName}`,
+    name: displayName,
+    dateableId,
+  }),
 
   // Under all the date ranges for a dateable feature, by date type
-  dateableDateType: (dateableId, dateTypeName) =>
-    `dateableDateType-${dateableId}-${dateTypeName}`,
+  dateableDateType: (dateableId, dateTypeName) => ({
+    id: `dateableDateType-${dateableId}-${dateTypeName}`,
+    name: dateTypeName,
+    dateableId,
+  }),
 
   // Under a form section for a dateable entity, such as a Feature, by its dateableId
-  dateableSection: (dateableId) => `formSection-${dateableId}`,
+  dateableSection: (dateableId, displayName = "") => ({
+    id: `formSection-${dateableId}`,
+    name: displayName,
+    dateableId,
+  }),
 };
 
 /**
@@ -90,7 +108,7 @@ function validate(seasonData, seasonContext) {
 
   // Provide a method to add validation errors in the context
   validationContext.addError = (element, message) => {
-    errors.push({ element, message });
+    errors.push({ ...element, message });
   };
 
   // Provide the flat array of Frontcountry Campground Feature Reservation dates in the context,
@@ -202,8 +220,8 @@ export default function useValidation(seasonData, context) {
   // If there are no errors, the form is valid
   const isValid = useMemo(() => errors.length === 0, [errors]);
 
-  // Group errors by element for display in the ValidationErrorSlot component
-  const groupedErrors = useMemo(() => groupBy(errors, "element"), [errors]);
+  // Group errors by element ID for display in the ValidationErrorSlot component
+  const groupedErrors = useMemo(() => groupBy(errors, "id"), [errors]);
 
   return {
     isValid,


### PR DESCRIPTION
### Jira Ticket

CMS-1771

### Description
<!-- What did you change, and why? -->

This adds the "Submit with validation errors" checkbox to the frontend (the label is "Submit anyway")
If checked (and an internal note is provided), it will bypass validation errors the same way it already does if you save a draft.

An internal note is required for this, so I added a simple check in the form with a red error that looks like other (real) validation errors. (Simpler than adding it as some kind of "super validation rule" that can't be bypassed)

Updated the /save API endpoint to update this value when you submit.

