### PR TITLE
CMS-1722: Hook up eventTypeSubCategory

### DIFF
--- a/frontend/src/components/advisories/composite/advisoryHistory/AdvisoryHistory.jsx
+++ b/frontend/src/components/advisories/composite/advisoryHistory/AdvisoryHistory.jsx
@@ -112,7 +112,7 @@ export default function AdvisoryHistory({
                     ? `${text} by ${creatorName} requested`
                     : text,
                   actorName: requesterName || creatorName,
-                  date: ad.modifiedDate || ad.createdDate,
+                  date: ad.modifiedDate || ad.createdDate || ad.createdAt,
                 });
               } else {
                 if (status === "SCH") {

--- a/frontend/src/hooks/useCms.js
+++ b/frontend/src/hooks/useCms.js
@@ -301,7 +301,7 @@ export default function useCms() {
   );
 
   const getEventTypes = useCallback(
-    () => fetchCached("eventTypes", `/event-types?${querySort("eventType")}`),
+    () => fetchCached("eventTypes", `/event-types?populate=*`),
     [fetchCached],
   );
 

--- a/frontend/src/lib/advisories/utils/CmsDataUtil.js
+++ b/frontend/src/lib/advisories/utils/CmsDataUtil.js
@@ -167,15 +167,13 @@ export function getNaturalResourceDistricts(cmsData, setCmsData) {
 
 export function getEventTypes(cmsData, setCmsData) {
   if (!cmsData.eventTypes) {
-    const result = cmsAxios
-      .get(`/event-types?${querySort("eventType")}`)
-      .then((res) => {
-        const data = cmsData;
+    const result = cmsAxios.get(`/event-types?populate=*`).then((res) => {
+      const data = cmsData;
 
-        data.eventTypes = res.data.data;
-        setCmsData(data);
-        return res.data.data;
-      });
+      data.eventTypes = res.data.data;
+      setCmsData(data);
+      return res.data.data;
+    });
 
     return result;
   }

--- a/frontend/src/router/pages/advisories/advisory/Advisory.jsx
+++ b/frontend/src/router/pages/advisories/advisory/Advisory.jsx
@@ -658,12 +658,29 @@ export default function Advisory({ mode }) {
 
           setRecreationResources(newRecreationResources);
           const eventTypeData = res[9];
-          const newEventTypes = eventTypeData.map((et) => ({
-            label: et.eventType,
-            value: et.documentId,
-            category: et.groupLabel,
-            scope: et.scope,
-          }));
+          const newEventTypes = eventTypeData.flatMap((et) => {
+            const categories = et.eventTypeSubCategories
+              ?.map((sc) => sc?.subCategory)
+              .filter(Boolean);
+
+            if (!categories?.length) {
+              return [
+                {
+                  label: et.eventType,
+                  value: et.documentId,
+                  category: "Uncategorized",
+                  scope: et.scope,
+                },
+              ];
+            }
+
+            return categories.map((category) => ({
+              label: et.eventType,
+              value: et.documentId,
+              category,
+              scope: et.scope,
+            }));
+          });
 
           setEventTypes([...newEventTypes]);
           const accessStatusData = res[10];


### PR DESCRIPTION
### Jira Ticket

CMS-1722

### Description
Update REST API calls to use new Strapi eventTypeSubCategory collection to support multiple subcategories per event type and remove reliance on duplicated data.
Refactor eventType to use relationships instead of groupLabel.

#### Note: Cross dependency on https://github.com/bcgov/bcparks.ca/pull/1874

