### PR TITLE
CMS-1769: Count unique fields with errors

### DIFF
--- a/frontend/src/components/FormErrorSummary.jsx
+++ b/frontend/src/components/FormErrorSummary.jsx
@@ -1,5 +1,5 @@
 import PropTypes from "prop-types";
-import { groupBy, orderBy, partition } from "lodash-es";
+import { groupBy, orderBy, partition, uniqBy } from "lodash-es";
 import { useCallback, useMemo } from "react";
 
 /**
@@ -52,7 +52,7 @@ export default function FormErrorSummary({
   errors,
   dateableNameMap,
 }) {
-  const numErrors = errors.length;
+  const numErrors = uniqBy(errors, "id").length;
 
   const headline =
     numErrors === 1


### PR DESCRIPTION
### Jira Ticket

CMS-1769

### Description
<!-- What did you change, and why? -->

A follow-up to #635 , this changes the logic for counting the "number of entries" reported in the ErrorSummary component.

Some fields may have more than one error (like "start date before end date" and "reservation dates within operating dates") and we only want to count the fields, not the total number of errors. This branch groups the errors by "Error slot ID" so the number displayed will match the number of Red error lists in the form.

Copilot said it makes no functional difference to do useMemo for this, since the array will always be really small. Otherwise I would have done it 😆 