### PR TITLE
CMS-1861: Display rec site link if it has isDisplayed

### DIFF
--- a/frontend/src/components/advisories/composite/advisorySummaryView/AdvisorySummaryView.jsx
+++ b/frontend/src/components/advisories/composite/advisorySummaryView/AdvisorySummaryView.jsx
@@ -94,7 +94,7 @@ export default function AdvisorySummaryView({
             <div>
               {advisory.recreationResources.map((resource) => (
                 <div key={resource.id} className="mb-3">
-                  {resource.recResourceId ? (
+                  {resource.recResourceId && resource.isDisplayed ? (
                     <a
                       href={`https://www.sitesandtrailsbc.ca/resource/${encodeURIComponent(resource.recResourceId)}`}
                       rel="noopener noreferrer"

--- a/frontend/src/components/advisories/composite/advisorySummaryView/AdvisorySummaryView.jsx
+++ b/frontend/src/components/advisories/composite/advisorySummaryView/AdvisorySummaryView.jsx
@@ -94,7 +94,7 @@ export default function AdvisorySummaryView({
             <div>
               {advisory.recreationResources.map((resource) => (
                 <div key={resource.id} className="mb-3">
-                  {resource.recResourceId && resource.isDisplayed ? (
+                  {resource.isDisplayed ? (
                     <a
                       href={`https://www.sitesandtrailsbc.ca/resource/${encodeURIComponent(resource.recResourceId)}`}
                       rel="noopener noreferrer"
@@ -108,7 +108,7 @@ export default function AdvisorySummaryView({
                       />
                     </a>
                   ) : (
-                    resource.resourceName
+                    `${resource.resourceName} (${resource.recResourceId})`
                   )}
                 </div>
               ))}


### PR DESCRIPTION
### Jira Ticket

CMS-1861

### Description
<!-- What did you change, and why? -->
- Display the recreation site as a link when `isDisplayed` is true, otherwise, display it as plain text
