### PR TITLE
CMS-1704: Update markChanged call sites, fix history state

### DIFF
--- a/frontend/src/components/advisories/composite/advisoryForm/AdvisoryForm.jsx
+++ b/frontend/src/components/advisories/composite/advisoryForm/AdvisoryForm.jsx
@@ -710,12 +710,10 @@ export default function AdvisoryForm({
           <StandardMessagePicker
             standardMessages={standardMessages}
             selectedStandardMessages={selectedStandardMessages}
-            setSelectedStandardMessages={(messages) => {
-              setSelectedStandardMessages(messages);
-              markChanged();
-            }}
+            setSelectedStandardMessages={setSelectedStandardMessages}
             selectedProtectedAreas={selectedProtectedAreas}
             selectedRecreationResources={selectedRecreationResources}
+            markChanged={markChanged}
           />
         </Form.Group>
 
@@ -934,7 +932,7 @@ export default function AdvisoryForm({
                         markChanged();
                       }}
                     />
-                    <label htmlFor={`file-upload-${idx}`} >
+                    <label htmlFor={`file-upload-${idx}`}>
                       <Btn
                         variant="outline-secondary"
                         as="span"

--- a/frontend/src/components/advisories/composite/advisoryForm/StandardMessagePicker.jsx
+++ b/frontend/src/components/advisories/composite/advisoryForm/StandardMessagePicker.jsx
@@ -23,6 +23,7 @@ export default function StandardMessagePicker({
   setSelectedStandardMessages,
   selectedProtectedAreas,
   selectedRecreationResources,
+  markChanged,
 }) {
   const hasBcpResourcesSelected = hasSelectedItems(selectedProtectedAreas);
   const hasRstResourcesSelected = hasSelectedItems(selectedRecreationResources);
@@ -79,6 +80,7 @@ export default function StandardMessagePicker({
       value={selectedStandardMessages}
       onChange={(messages) => {
         setSelectedStandardMessages(messages || []);
+        markChanged();
       }}
       placeholder={
         hasBothResourcesSelected
@@ -100,4 +102,5 @@ StandardMessagePicker.propTypes = {
   setSelectedStandardMessages: PropTypes.func.isRequired,
   selectedProtectedAreas: PropTypes.array,
   selectedRecreationResources: PropTypes.array,
+  markChanged: PropTypes.func.isRequired,
 };

--- a/frontend/src/config/keycloak.js
+++ b/frontend/src/config/keycloak.js
@@ -46,8 +46,12 @@ export function onSigninCallback() {
     url.searchParams.delete(param);
   }
 
+  // Preserve existing history state (idx/key/usr) so React Router's history
+  // data remains valid after we strip OIDC params from the URL.
+  const currentHistoryState = window.history.state ?? null;
+
   window.history.replaceState(
-    {},
+    currentHistoryState,
     document.title,
     `${url.pathname}${url.search}${url.hash}`,
   );

--- a/frontend/src/router/pages/advisories/advisory/Advisory.jsx
+++ b/frontend/src/router/pages/advisories/advisory/Advisory.jsx
@@ -132,9 +132,10 @@ export default function Advisory({ mode }) {
   const auth = useAuth();
   const initialized = !auth.isLoading;
   const isAuthenticated = auth.isAuthenticated;
+  const shouldBlockNavigation = useCallback(() => dataChanged.current, []);
 
   // Use a route blocker to show a confirmation dialog when the user attempts to navigate away with unsaved changes
-  const blocker = useBlocker(() => dataChanged.current);
+  const blocker = useBlocker(shouldBlockNavigation);
   // Ref to track if the route blocker is currently active, to prevent multiple blocker flows from stacking if more navigation is attempted while the dialog is open
   const isBlockerActive = useRef(false);
 
@@ -171,7 +172,7 @@ export default function Advisory({ mode }) {
     dataChanged.current = true;
   }, []);
 
-  useNavigationGuard(useCallback(() => dataChanged.current, []));
+  useNavigationGuard(shouldBlockNavigation);
 
   // Block internal route transitions while there are unsaved changes.
   // beforeunload is still handled by useNavigationGuard for document-level exits.
@@ -190,7 +191,9 @@ export default function Advisory({ mode }) {
 
       if (shouldProceed) {
         dataChanged.current = false;
-        blocker.proceed();
+        // Defer the proceed call to the next tick in the event loop
+        // to avoid race conditions with React router's internal state updates.
+        setTimeout(() => blocker.proceed(), 0);
         return;
       }
 


### PR DESCRIPTION
Only call markChanged on user interactions, not in effects

CMS-1704: Preserve history state in Keycloak callback

Tweak nav guard and blocker code to prevent race conditions

### Jira Ticket

CMS-1704

### Description
<!-- What did you change, and why? -->

Some fixes for the unexpected behavior with the navigation guard and the react router blocker. In the devtools, `history.state.idx` was turning into `NaN` when it's supposed to be a number.

- Keycloak was resetting the history state to an empty object in its callback method. I updated it to keep the existing state, so `idx` doesn't get corrupted. It seems to work locally but there are a lot of paths to test...

- StandardMessagePicker was firing setSelectedStandardMessages on mount in some scenarios, and this would call markChanged and flag the form as changed before the user did anything. We'll probably want to change the data flow for this component but for now I've just separated markChanged into its own prop so it will only be called when the user causes the change.

- Some tweaks to the navigationGuard and blocker code in Advisory.jsx suggested by Copilot. Changed a function to a useCallback; I don't know if that's a fix or just an optimization but it's still working with this change so I kept it in. Also wrapped a call to `blocker.proceed()` in a setTimeout to delay it until the next tick. I don't know if this is necessary or if it even does anything, but Copilot convinced me that it's safer to do it this way 🤷. 