### PR TITLE
CMS-1839: DOOT bookmarkable form URLs

### DIFF
--- a/backend/routes/api/seasons.js
+++ b/backend/routes/api/seasons.js
@@ -12,6 +12,7 @@ import {
   getDateTypesForFeature,
   getDateTypesForPark,
 } from "../../utils/dateTypesHelpers.js";
+import { checkSeasonUserAccess } from "../../utils/seasonHelpers.js";
 
 import {
   Park,
@@ -718,7 +719,10 @@ router.get(
       ],
     });
 
+    // Throw a 404 if the season was not found.
     checkSeasonExists(seasonModel);
+    // Throw a 403 if the user doesn't have access to the park associated with the season.
+    await checkSeasonUserAccess(req, seasonId);
 
     // Get the previous year's Season Dates for this Feature
     const previousSeason = await getPreviousSeasonDates(seasonModel, {
@@ -829,7 +833,10 @@ router.get(
       ],
     });
 
+    // Throw a 404 if the season was not found.
     checkSeasonExists(seasonModel);
+    // Throw a 403 if the user doesn't have access to the park associated with the season.
+    await checkSeasonUserAccess(req, seasonId);
 
     // Get the previous year's Season Dates for this Feature
     const previousSeason = await getPreviousSeasonDates(seasonModel, {
@@ -993,7 +1000,10 @@ router.get(
       ],
     });
 
+    // Throw a 404 if the season was not found.
     checkSeasonExists(seasonModel);
+    // Throw a 403 if the user doesn't have access to the park associated with the season.
+    await checkSeasonUserAccess(req, seasonId);
 
     const { park } = seasonModel;
 
@@ -1153,7 +1163,10 @@ router.post(
       // Check if the season exists
       const season = await Season.findByPk(seasonId, { transaction });
 
+      // Throw a 404 if the season doesn't exist
       checkSeasonExists(season);
+      // Throw a 403 if the user doesn't have access to the park associated with the season
+      await checkSeasonUserAccess(req, seasonId);
 
       const newStatus = status ?? season.status;
       const shouldMarkSavedWithErrors =

--- a/backend/utils/seasonHelpers.js
+++ b/backend/utils/seasonHelpers.js
@@ -3,7 +3,19 @@
  * Used by create-seasons and create-winter-seasons scripts.
  */
 
-import { Dateable, Publishable } from "../models/index.js";
+import {
+  Dateable,
+  Publishable,
+  Park,
+  Season,
+  Feature,
+  ParkArea,
+  AccessGroup,
+  User,
+  UserAccessGroup,
+} from "../models/index.js";
+import checkUserRoles, { getRolesFromAuth } from "./checkUserRoles.js";
+import * as USER_ROLES from "../constants/userRoles.js";
 
 /**
  * Creates a new Publishable or Dateable ID and associates it with the given record, if it doesn't already have one.
@@ -56,4 +68,96 @@ export async function createDateableId(record, transaction) {
   );
 
   return { key, added };
+}
+
+/**
+ * Checks if the current user has access to the requested season.
+ * Access is granted when the user has ALL_PARK_ACCESS, otherwise by AccessGroup membership.
+ * @param {Object} req Express request object
+ * @param {number} seasonId The season ID to authorize
+ * @returns {Promise<boolean>} True when authorized, false when season is not found
+ */
+export async function checkSeasonUserAccess(req, seasonId) {
+  const hasAllParkAccess = checkUserRoles(getRolesFromAuth(req.auth), [
+    USER_ROLES.ALL_PARK_ACCESS,
+  ]);
+
+  if (hasAllParkAccess) {
+    return true;
+  }
+
+  const season = await Season.findByPk(seasonId, {
+    attributes: ["id"],
+    include: [
+      {
+        model: Park,
+        as: "park",
+        attributes: ["id"],
+        required: false,
+      },
+      {
+        model: Feature,
+        as: "feature",
+        attributes: ["id", "parkId"],
+        required: false,
+      },
+      {
+        model: ParkArea,
+        as: "parkArea",
+        attributes: ["id", "parkId"],
+        required: false,
+      },
+    ],
+  });
+
+  if (!season) {
+    return false;
+  }
+
+  const parkId =
+    season.park?.id ?? season.feature?.parkId ?? season.parkArea?.parkId;
+
+  if (!parkId) {
+    const error = new Error("Park not found for this season");
+
+    error.status = 404;
+    throw error;
+  }
+
+  const authorizedPark = await Park.findOne({
+    attributes: ["id"],
+    where: { id: parkId },
+    include: [
+      {
+        model: AccessGroup,
+        as: "accessGroups",
+        attributes: ["id"],
+        required: true,
+        include: [
+          {
+            model: User,
+            as: "users",
+            attributes: [],
+            where: { username: req.user?.username },
+            through: {
+              model: UserAccessGroup,
+              attributes: [],
+            },
+            required: true,
+          },
+        ],
+      },
+    ],
+  });
+
+  if (!authorizedPark) {
+    const error = new Error(
+      "Permission denied: You do not have access to this park.",
+    );
+
+    error.status = 403;
+    throw error;
+  }
+
+  return true;
 }

--- a/frontend/src/components/FormPanel.jsx
+++ b/frontend/src/components/FormPanel.jsx
@@ -605,13 +605,6 @@ If dates have already been published, they will not be updated until new dates a
     }
   }
 
-  // Handle 404 errors by closing the panel
-  useEffect(() => {
-    if (error && error?.response?.status === 404) {
-      closePanel();
-    }
-  }, [error, closePanel]);
-
   if (loading) {
     return (
       <>
@@ -624,10 +617,16 @@ If dates have already been published, they will not be updated until new dates a
   }
 
   if (error || !season) {
+    const errorCode = error?.response?.status ?? error?.status;
+
     return (
       <>
         <Offcanvas.Header closeButton>
-          <Offcanvas.Title>Error loading season data</Offcanvas.Title>
+          <Offcanvas.Title>
+            {errorCode
+              ? `Error ${errorCode} loading season data`
+              : "Error loading season data"}
+          </Offcanvas.Title>
         </Offcanvas.Header>
         <Offcanvas.Body></Offcanvas.Body>
       </>

--- a/frontend/src/components/FormPanel.jsx
+++ b/frontend/src/components/FormPanel.jsx
@@ -1,4 +1,11 @@
-import { useCallback, useContext, useEffect, useMemo, useState } from "react";
+import {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  useRef,
+} from "react";
 import Offcanvas from "react-bootstrap/Offcanvas";
 import Form from "react-bootstrap/Form";
 import PropTypes from "prop-types";
@@ -105,9 +112,10 @@ function SeasonForm({
   seasonId,
   level,
   closePanel,
+  handleStatusCancelClose,
   onDataUpdate,
   setDataChanged,
-  openModal,
+  modal,
 }) {
   // Global flash message context
   const flashMessage = useContext(globalFlashMessageContext);
@@ -121,6 +129,12 @@ function SeasonForm({
   const [notes, setNotes] = useState("");
   const [deletedDateRangeIds, setDeletedDateRangeIds] = useState([]);
   const [submitWithErrors, setSubmitWithErrors] = useState(false);
+  const hasShownStatusPrompt = useRef(false);
+
+  // Reset status prompt tracking when switching to a different season form.
+  useEffect(() => {
+    hasShownStatusPrompt.current = false;
+  }, [seasonId, level]);
 
   // Determine if the user is allowed to bypass validation errors and submit/approve the form
   const allowSubmitWithErrors = useMemo(() => {
@@ -157,9 +171,19 @@ function SeasonForm({
 
   useEffect(() => {
     if (apiData) {
+      // if the season if from a previous year then the user must be in the
+      // approver role to edit it. If not, close the form panel.
+      if (
+        apiData.current.operatingYear < new Date().getFullYear() &&
+        !approver
+      ) {
+        closePanel();
+        return;
+      }
+
       setData(apiData);
     }
-  }, [apiData]);
+  }, [apiData, approver, closePanel]);
 
   // Constants
   const {
@@ -169,6 +193,41 @@ function SeasonForm({
     previousWinter: previousWinterSeasonDates,
     ...seasonMetadata
   } = data || {};
+
+  // Check season status and prompt user if needed (e.g., editing approved or published seasons)
+  useEffect(() => {
+    if (!season || hasShownStatusPrompt.current) return;
+
+    async function checkStatusAndPrompt() {
+      hasShownStatusPrompt.current = true;
+
+      if (season.status === "approved") {
+        const proceed = await modal.open(
+          "Edit approved dates?",
+          "Dates will need to be reviewed again to be approved.",
+          "Edit",
+          "Cancel",
+        );
+
+        if (!proceed) {
+          handleStatusCancelClose();
+        }
+      } else if (season.status === "published") {
+        const proceed = await modal.open(
+          "Edit public dates on API?",
+          "Dates will need to be reviewed again to be approved and published. If reservations have already begun, visitors will be affected.",
+          "Continue to edit",
+          "Cancel",
+        );
+
+        if (!proceed) {
+          handleStatusCancelClose();
+        }
+      }
+    }
+
+    checkStatusAndPrompt();
+  }, [season?.status, modal, handleStatusCancelClose, season]);
 
   // Derive the header text from the season data
   const yearHeaderText = useMemo(() => {
@@ -480,7 +539,7 @@ function SeasonForm({
   // prompt the user to confirm moving back to draft.
   async function promptAndSave(close = true) {
     if (season.status !== STATUS.REQUESTED.value) {
-      const proceed = await openModal(
+      const proceed = await modal.open(
         "Move back to draft?",
         `The dates will be moved back to draft and need to be submitted again to be reviewed.
 
@@ -545,6 +604,13 @@ If dates have already been published, they will not be updated until new dates a
       console.error("Error submitting season:", saveError);
     }
   }
+
+  // Handle 404 errors by closing the panel
+  useEffect(() => {
+    if (error && error?.response?.status === 404) {
+      closePanel();
+    }
+  }, [error, closePanel]);
 
   if (loading) {
     return (
@@ -714,9 +780,10 @@ SeasonForm.propTypes = {
   seasonId: PropTypes.number.isRequired,
   level: PropTypes.string.isRequired,
   closePanel: PropTypes.func.isRequired,
+  handleStatusCancelClose: PropTypes.func.isRequired,
   onDataUpdate: PropTypes.func.isRequired,
   setDataChanged: PropTypes.func.isRequired,
-  openModal: PropTypes.func.isRequired,
+  modal: PropTypes.object.isRequired,
 };
 
 function FormPanel({ show, setShow, formData, onDataUpdate }) {
@@ -724,20 +791,35 @@ function FormPanel({ show, setShow, formData, onDataUpdate }) {
   // Synced with the computed value in the SeasonForm component
   const [dataChanged, setDataChanged] = useState(false);
   const modal = useConfirmation();
+  const closingFromStatusPrompt = useRef(false);
 
   // Prevent navigating away if the data has changed
   useNavigationGuard(dataChanged);
 
   // Functions
 
-  // Hides the form panel and resets the dataChanged state
-  function closePanel() {
+  // Hides the form panel and resets the dataChanged state and modal
+  const closePanel = useCallback(() => {
+    closingFromStatusPrompt.current = false;
     setShow(false);
     setDataChanged(false);
-  }
+  }, [setShow, setDataChanged]);
+
+  // Close the panel when the status modal is dismissed
+  const handleStatusCancelClose = useCallback(() => {
+    closingFromStatusPrompt.current = true;
+    setShow(false);
+    setDataChanged(false);
+  }, [setShow, setDataChanged]);
 
   // Prompts the user if data has changed before closing
-  async function promptAndClose() {
+  const promptAndClose = useCallback(async () => {
+    // If we're closing due to the status modal being dismissed, don't prompt
+    if (closingFromStatusPrompt.current) {
+      closePanel();
+      return;
+    }
+
     if (dataChanged) {
       const proceed = await modal.open(
         "Discard changes?",
@@ -753,7 +835,7 @@ function FormPanel({ show, setShow, formData, onDataUpdate }) {
     }
 
     closePanel();
-  }
+  }, [dataChanged, modal, closePanel]);
 
   // Hide the form if no seasonId is provided
   return (
@@ -766,12 +848,14 @@ function FormPanel({ show, setShow, formData, onDataUpdate }) {
       >
         {formData.seasonId && (
           <SeasonForm
+            key={`${formData.level}-${formData.seasonId}`}
             seasonId={formData.seasonId}
             level={formData.level}
             closePanel={closePanel}
+            handleStatusCancelClose={handleStatusCancelClose}
             onDataUpdate={onDataUpdate}
             setDataChanged={setDataChanged}
-            openModal={modal.open}
+            modal={modal}
           />
         )}
       </Offcanvas>

--- a/frontend/src/components/InternalNotesRow.jsx
+++ b/frontend/src/components/InternalNotesRow.jsx
@@ -70,7 +70,10 @@ InternalNotesRow.propTypes = {
     PropTypes.shape({
       id: PropTypes.number.isRequired,
       note: PropTypes.string.isRequired,
-      createdAt: PropTypes.string,
+      createdAt: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.instanceOf(Date),
+      ]),
       createdBy: PropTypes.string,
     }),
   ),

--- a/frontend/src/router/index.jsx
+++ b/frontend/src/router/index.jsx
@@ -29,6 +29,19 @@ const RouterConfig = createBrowserRouter(
               path: "",
               element: <EditAndReview />,
             },
+            // Edit season form routes
+            {
+              path: "edit/park/:seasonId",
+              element: <EditAndReview />,
+            },
+            {
+              path: "edit/park-area/:seasonId",
+              element: <EditAndReview />,
+            },
+            {
+              path: "edit/feature/:seasonId",
+              element: <EditAndReview />,
+            },
             // Export
             {
               path: "export",

--- a/frontend/src/router/pages/EditAndReview.jsx
+++ b/frontend/src/router/pages/EditAndReview.jsx
@@ -1,7 +1,7 @@
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faMagnifyingGlass, faFilter } from "@fa-kit/icons/classic/solid";
 import { useApiGet } from "@/hooks/useApi";
-import useConfirmation from "@/hooks/useConfirmation";
+import { useParams, useNavigate } from "react-router-dom";
 import EditAndReviewTable from "@/components/EditAndReviewTable";
 import LoadingBar from "@/components/LoadingBar";
 import MultiSelect from "@/components/MultiSelect";
@@ -10,7 +10,6 @@ import PaginationControls from "@/components/PaginationControls";
 import FilterPanel from "@/components/FilterPanel";
 import FilterStatus from "@/components/FilterStatus";
 import FormPanel from "@/components/FormPanel";
-import ConfirmationDialog from "@/components/ConfirmationDialog";
 import * as STATUS from "@/constants/seasonStatus.js";
 import RefreshTableContext from "@/contexts/RefreshTableContext";
 import {
@@ -24,6 +23,9 @@ import {
 import { groupBy } from "lodash-es";
 
 function EditAndReview() {
+  const params = useParams();
+  const navigate = useNavigate();
+  
   const { data, loading, error, fetchData } = useApiGet("/parks");
   const {
     data: filterOptionsData,
@@ -105,50 +107,41 @@ function EditAndReview() {
   const [showFormPanel, setShowFormPanel] = useState(false);
   const [showFilterPanel, setShowFilterPanel] = useState(false);
 
-  const modal = useConfirmation();
+  // Initialize form from URL parameters if provided
+  useEffect(() => {
+    if (params.seasonId) {
+      // Extract level from pathname (park, park-area, or feature)
+      const pathname = window.location.pathname;
+      const match = pathname.match(/\/edit\/([^/]+)\/\d+/u);
+      const level = match ? match[1] : "";
+
+      if (level) {
+        setFormData({
+          seasonId: parseInt(params.seasonId, 10),
+          level,
+        });
+        setShowFormPanel(true);
+      }
+    }
+  }, [params.seasonId]);
 
   // open form panel when the Edit button is clicked
-  async function formPanelHandler(formDataObj) {
+  function formPanelHandler(formDataObj) {
     const regularSeason = formDataObj.currentSeason.regular;
     const winterSeason = formDataObj.currentSeason.winter || {};
     const isWinterSeason = formDataObj.isWinterSeason || false;
     const season = isWinterSeason ? winterSeason : regularSeason;
-    const status = season.status;
 
-    // If the season is already approved, prompt to continue
-    if (status === "approved") {
-      const proceed = await modal.open(
-        "Edit approved dates?",
-        "Dates will need to be reviewed again to be approved.",
-        "Edit",
-        "Cancel",
-      );
-
-      // If the user cancels in the confirmation modal, don't open the edit form
-      if (!proceed) {
-        return;
-      }
-    }
-    // If the season is already published to the CMS, prompt to continue
-    else if (status === "published") {
-      const proceed = await modal.open(
-        "Edit public dates on API?",
-        "Dates will need to be reviewed again to be approved and published. If reservations have already begun, visitors will be affected.",
-        "Continue to edit",
-        "Cancel",
-      );
-
-      // If the user cancels in the confirmation modal, don't open the edit form
-      if (!proceed) {
-        return;
-      }
-    }
-
-    setFormData({
+    const newFormData = {
       seasonId: season.id,
       level: formDataObj.level,
-    });
+    };
+
+    setFormData(newFormData);
     setShowFormPanel(true);
+
+    // Update URL to match the opened form
+    navigate(`/edit/${formDataObj.level}/${season.id}`);
   }
 
   function resetFilters() {
@@ -320,6 +313,13 @@ function EditAndReview() {
     fetchData();
   }
 
+  // Clear URL when form panel closes
+  useEffect(() => {
+    if (!showFormPanel && params.seasonId) {
+      navigate("/", { replace: true });
+    }
+  }, [showFormPanel, params.seasonId, navigate]);
+
   // Slice the list of parks for pagination
   const pageData = useMemo(() => {
     const start = pageSize * (page - 1);
@@ -448,8 +448,6 @@ function EditAndReview() {
         />
 
         <ParksTableWrapper />
-
-        <ConfirmationDialog {...modal.props} />
 
         <FormPanel
           show={showFormPanel}


### PR DESCRIPTION
### Jira Ticket

CMS-1839

### Description
This change introduces unique, shareable URLs for each season form, enabling users to copy and share direct links to a specific Park, Area, or Feature.
The React application routing and form templates have been updated so that every season form is associated with its own URL using the seasonId of the record. URLs follow the format:
https://alpha-dev-staff.bcparks.ca/dates/edit/park-area/12345
where 12345 represents the seasonId of the ParkArea.
When users navigate between forms within the application, the browser URL updates automatically to reflect the currently open form. Users can also navigate directly to a specific form by entering or pasting one of these URLs into the browser address bar. When accessed directly, the application loads and automatically opens the corresponding edit form in the form panel.

The “Edit public dates on API?” and “Edit approved dates?” dialogs have been moved from EditAndReview.jsx to FormPanel.jsx. However, they now have a slightly different behaviour compared to before. Instead of blocking navigation to the form panel, the dialogs now load on top of it. If you click “Cancel” or "Close", the form panel will close along with the dialog. 

This pattern will be more flexible when we start using the form panel on other screens because it’s not tied to the data from the main table on the EditAndReview screen. 

Note: Support for other years will be added later as part of the ongoing "Edit Published Tab" development.  

