### PR TITLE
CMS-1704: Separate blur and change events for CKEditor control

### DIFF
--- a/frontend/src/components/advisories/composite/advisoryForm/AdvisoryForm.jsx
+++ b/frontend/src/components/advisories/composite/advisoryForm/AdvisoryForm.jsx
@@ -732,10 +732,8 @@ export default function AdvisoryForm({
           <CKEditor
             id="custom-message"
             value={description}
-            onChange={(value) => {
-              setDescription(value);
-              markChanged();
-            }}
+            onBlur={setDescription}
+            onChange={markChanged}
           />
         </Form.Group>
 

--- a/frontend/src/components/advisories/composite/ckeditor/CKEditor.jsx
+++ b/frontend/src/components/advisories/composite/ckeditor/CKEditor.jsx
@@ -52,7 +52,7 @@ export default function StaffPortalCKEditor({
         onBlur(editor.getData());
       }}
       onChange={(_, editor) => {
-        onChange(editor.getData());
+        onChange(editor);
       }}
     />
   );

--- a/frontend/src/components/advisories/composite/ckeditor/CKEditor.jsx
+++ b/frontend/src/components/advisories/composite/ckeditor/CKEditor.jsx
@@ -16,7 +16,8 @@ import "ckeditor5/ckeditor5.css";
 
 export default function StaffPortalCKEditor({
   value,
-  onChange,
+  onBlur,
+  onChange = () => {},
   ...otherProps
 }) {
   return (
@@ -48,6 +49,9 @@ export default function StaffPortalCKEditor({
         ],
       }}
       onBlur={(_, editor) => {
+        onBlur(editor.getData());
+      }}
+      onChange={(_, editor) => {
         onChange(editor.getData());
       }}
     />
@@ -56,5 +60,6 @@ export default function StaffPortalCKEditor({
 
 StaffPortalCKEditor.propTypes = {
   value: PropTypes.string.isRequired,
-  onChange: PropTypes.func.isRequired,
+  onBlur: PropTypes.func.isRequired,
+  onChange: PropTypes.func,
 };


### PR DESCRIPTION
### Jira Ticket

CMS-1704

### Description
<!-- What did you change, and why? -->

Small fix for the "mark changed" / "Save draft?" modal logic. The CKEditor component wouldn't emit an event until you blur the input for performance reasons, but that could lead to a scenario where you make changes and press the browser back button without "markChanged" being called.

This calls markChanged onChange, and keeps the other logic happening onBlur as it was before.