### PR TITLE
CMS-1582: Fix annual data copying issue: specify dateableId in queries

### DIFF
--- a/backend/tasks/populate-date-ranges/populate-annual-date-ranges.js
+++ b/backend/tasks/populate-date-ranges/populate-annual-date-ranges.js
@@ -84,8 +84,13 @@ export async function populateAnnualDateRangesForYear(
         transaction,
       });
 
+      // Only copy complete previous ranges; skip placeholders with null dates.
+      const completePrevRanges = prevDateRanges.filter(
+        (range) => range.startDate && range.endDate,
+      );
+
       // Skip to the next DateRangeAnnual if there are no previous DateRanges to copy
-      if (prevDateRanges.length === 0) continue;
+      if (completePrevRanges.length === 0) continue;
 
       let targetSeason = await Season.findOne({
         where: {
@@ -148,22 +153,15 @@ export async function populateAnnualDateRangesForYear(
         (range) => range.startDate && range.endDate,
       );
 
-      if (completeTargetRanges.length >= prevDateRanges.length) {
-        // Target season already has complete date ranges for this dateType
-        continue;
-      }
+      // Copy only date ranges that are missing in target season.
+      // Compare by transformed target-year start/end values rather than by index.
+      const existingTargetRangeKeys = new Set(
+        completeTargetRanges.map(
+          (range) => `${range.startDate}|${range.endDate}`,
+        ),
+      );
 
-      // Only copy ranges that don't already exist (avoiding duplicates)
-      const numRangesToCopy =
-        prevDateRanges.length - completeTargetRanges.length;
-
-      if (numRangesToCopy <= 0) {
-        continue;
-      }
-
-      // copy each previous DateRange to current season (only the missing ones)
-      for (let i = 0; i < numRangesToCopy; i++) {
-        const prevRange = prevDateRanges[i];
+      for (const prevRange of completePrevRanges) {
         const currentYear = targetSeason.operatingYear;
         const prevStartDate = parse(
           prevRange.startDate,
@@ -179,12 +177,21 @@ export async function populateAnnualDateRangesForYear(
         const newStartDate = addYears(prevStartDate, yearOffset);
         const newEndDate = addYears(prevEndDate, yearOffset);
 
+        const newStartDateStr = format(newStartDate, "yyyy-MM-dd");
+        const newEndDateStr = format(newEndDate, "yyyy-MM-dd");
+        const rangeKey = `${newStartDateStr}|${newEndDateStr}`;
+
+        // Skip ranges that already exist in target season after year transformation.
+        if (existingTargetRangeKeys.has(rangeKey)) continue;
+
+        existingTargetRangeKeys.add(rangeKey);
+
         dateRangesToCreate.push({
           dateableId,
           seasonId: targetSeason.id,
           dateTypeId,
-          startDate: format(newStartDate, "yyyy-MM-dd"),
-          endDate: format(newEndDate, "yyyy-MM-dd"),
+          startDate: newStartDateStr,
+          endDate: newEndDateStr,
         });
 
         console.log(

--- a/backend/tasks/populate-date-ranges/populate-annual-date-ranges.js
+++ b/backend/tasks/populate-date-ranges/populate-annual-date-ranges.js
@@ -2,6 +2,7 @@
 // based on previous year's DateRanges if isDateRangeAnnual is TRUE.
 
 import "../../env.js";
+import { addYears, format, getYear, parse } from "date-fns";
 
 import {
   Season,
@@ -164,26 +165,26 @@ export async function populateAnnualDateRangesForYear(
       for (let i = 0; i < numRangesToCopy; i++) {
         const prevRange = prevDateRanges[i];
         const currentYear = targetSeason.operatingYear;
-        const prevStartDate = new Date(prevRange.startDate);
-        const prevEndDate = new Date(prevRange.endDate);
-
-        const newStartDate = new Date(prevStartDate);
-        const newEndDate = new Date(prevEndDate);
+        const prevStartDate = parse(
+          prevRange.startDate,
+          "yyyy-MM-dd",
+          new Date(),
+        );
+        const prevEndDate = parse(prevRange.endDate, "yyyy-MM-dd", new Date());
 
         // Calculate the year difference between the previous end and start dates
         // to handle dates that span two calendar years (e.g., Nov 2026 to March 2027)
-        const yearDifference =
-          prevEndDate.getFullYear() - prevStartDate.getFullYear();
+        const yearOffset = currentYear - getYear(prevStartDate);
 
-        newStartDate.setFullYear(currentYear);
-        newEndDate.setFullYear(currentYear + yearDifference);
+        const newStartDate = addYears(prevStartDate, yearOffset);
+        const newEndDate = addYears(prevEndDate, yearOffset);
 
         dateRangesToCreate.push({
           dateableId,
           seasonId: targetSeason.id,
           dateTypeId,
-          startDate: newStartDate,
-          endDate: newEndDate,
+          startDate: format(newStartDate, "yyyy-MM-dd"),
+          endDate: format(newEndDate, "yyyy-MM-dd"),
         });
 
         console.log(

--- a/backend/tasks/populate-date-ranges/populate-annual-date-ranges.js
+++ b/backend/tasks/populate-date-ranges/populate-annual-date-ranges.js
@@ -31,27 +31,35 @@ export async function populateAnnualDateRangesForYear(
       ],
 
       where: { isDateRangeAnnual: true },
+      order: [
+        ["publishableId", "ASC"],
+        ["dateableId", "ASC"],
+        ["dateTypeId", "ASC"],
+        ["id", "ASC"],
+      ],
       transaction,
     });
 
     const dateRangesToCreate = [];
 
     for (const annual of annuals) {
+      const { id, publishableId, dateTypeId, dateableId, dateType } = annual;
+
       // Find the previous season for this DateRangeAnnual
 
-      if (!annual.dateType) {
-        throw new Error(`DateType missing for DateRangeAnnual ${annual.id}`);
+      if (!dateType) {
+        throw new Error(`DateType missing for DateRangeAnnual ${id}`);
       }
 
       // Season type based on the date type of the DateRangeAnnual
       const seasonType =
-        annual.dateType.dateTypeNumber === DATE_TYPE.WINTER_FEE
+        dateType.dateTypeNumber === DATE_TYPE.WINTER_FEE
           ? SEASON_TYPE.WINTER
           : SEASON_TYPE.REGULAR;
 
       const prevSeason = await Season.findOne({
         where: {
-          publishableId: annual.publishableId,
+          publishableId,
           operatingYear: targetYear - 1,
           seasonType,
         },
@@ -64,9 +72,14 @@ export async function populateAnnualDateRangesForYear(
       const prevDateRanges = await DateRange.findAll({
         where: {
           seasonId: prevSeason.id,
-          dateableId: annual.dateableId,
-          dateTypeId: annual.dateTypeId,
+          dateableId,
+          dateTypeId,
         },
+        order: [
+          ["startDate", "ASC"],
+          ["endDate", "ASC"],
+          ["id", "ASC"],
+        ],
         transaction,
       });
 
@@ -75,7 +88,7 @@ export async function populateAnnualDateRangesForYear(
 
       let targetSeason = await Season.findOne({
         where: {
-          publishableId: annual.publishableId,
+          publishableId,
           operatingYear: targetYear,
           seasonType: prevSeason.seasonType,
         },
@@ -87,14 +100,14 @@ export async function populateAnnualDateRangesForYear(
       if (!targetSeason) {
         // Determine the status of the new season based on annual dates
         const status = await resolveNewSeasonStatus(
-          annual.publishableId,
+          publishableId,
           prevSeason.seasonType,
           transaction,
         );
 
         targetSeason = await Season.create(
           {
-            publishableId: annual.publishableId,
+            publishableId,
             operatingYear: targetYear,
             status,
             readyToPublish: true,
@@ -106,9 +119,9 @@ export async function populateAnnualDateRangesForYear(
 
       // For winter seasons, only copy Winter fee date types
       if (targetSeason.seasonType === SEASON_TYPE.WINTER) {
-        if (annual.dateType.dateTypeNumber !== DATE_TYPE.WINTER_FEE) {
+        if (dateType.dateTypeNumber !== DATE_TYPE.WINTER_FEE) {
           console.log(
-            `Skipping non-winter fee dates for winter season ${targetSeason.operatingYear} (publishableId=${annual.publishableId})`,
+            `Skipping non-winter fee dates for winter season ${targetSeason.operatingYear} (publishableId=${publishableId})`,
           );
           continue;
         }
@@ -118,9 +131,14 @@ export async function populateAnnualDateRangesForYear(
       const existingTargetDateRanges = await DateRange.findAll({
         where: {
           seasonId: targetSeason.id,
-          dateableId: annual.dateableId,
-          dateTypeId: annual.dateTypeId,
+          dateableId,
+          dateTypeId,
         },
+        order: [
+          ["startDate", "ASC"],
+          ["endDate", "ASC"],
+          ["id", "ASC"],
+        ],
         transaction,
       });
 
@@ -163,13 +181,13 @@ export async function populateAnnualDateRangesForYear(
         dateRangesToCreate.push({
           dateableId,
           seasonId: targetSeason.id,
-          dateTypeId: annual.dateTypeId,
+          dateTypeId,
           startDate: newStartDate,
           endDate: newEndDate,
         });
 
         console.log(
-          `Copied DateRange from season ${prevSeason.operatingYear} to ${targetSeason.operatingYear} for publishableId=${annual.publishableId}`,
+          `Copied DateRange from season ${prevSeason.operatingYear} to ${targetSeason.operatingYear} for publishableId=${publishableId}`,
         );
       }
     }

--- a/backend/tasks/populate-date-ranges/populate-annual-date-ranges.js
+++ b/backend/tasks/populate-date-ranges/populate-annual-date-ranges.js
@@ -148,7 +148,7 @@ export async function populateAnnualDateRangesForYear(
         transaction,
       });
 
-      // If we have the same number of complete ranges as previous year, skip
+      // Only compare against complete target ranges
       const completeTargetRanges = existingTargetDateRanges.filter(
         (range) => range.startDate && range.endDate,
       );
@@ -170,12 +170,12 @@ export async function populateAnnualDateRangesForYear(
         );
         const prevEndDate = parse(prevRange.endDate, "yyyy-MM-dd", new Date());
 
-        // Calculate the year difference between the previous end and start dates
-        // to handle dates that span two calendar years (e.g., Nov 2026 to March 2027)
-        const yearOffset = currentYear - getYear(prevStartDate);
+        // Shift this previous range into the target operating year while preserving
+        // the start/end year relationship for cross-year ranges.
+        const targetYearOffset = currentYear - getYear(prevStartDate);
 
-        const newStartDate = addYears(prevStartDate, yearOffset);
-        const newEndDate = addYears(prevEndDate, yearOffset);
+        const newStartDate = addYears(prevStartDate, targetYearOffset);
+        const newEndDate = addYears(prevEndDate, targetYearOffset);
 
         const newStartDateStr = format(newStartDate, "yyyy-MM-dd");
         const newEndDateStr = format(newEndDate, "yyyy-MM-dd");

--- a/backend/tasks/populate-date-ranges/populate-annual-date-ranges.js
+++ b/backend/tasks/populate-date-ranges/populate-annual-date-ranges.js
@@ -9,7 +9,6 @@ import {
   DateRangeAnnual,
   DateType,
 } from "../../models/index.js";
-import { findDateableIdByPublishableId } from "../../utils/findDateableIdByPublishableId.js";
 import * as SEASON_TYPE from "../../constants/seasonType.js";
 import * as DATE_TYPE from "../../constants/dateType.js";
 import resolveNewSeasonStatus from "../../utils/resolveNewSeasonStatus.js";
@@ -61,10 +60,11 @@ export async function populateAnnualDateRangesForYear(
 
       if (!prevSeason) continue;
 
-      // Find DateRanges for the previous season and this dateType
+      // Find previous-season DateRanges for this dateable+dateType
       const prevDateRanges = await DateRange.findAll({
         where: {
           seasonId: prevSeason.id,
+          dateableId: annual.dateableId,
           dateTypeId: annual.dateTypeId,
         },
         transaction,
@@ -114,16 +114,11 @@ export async function populateAnnualDateRangesForYear(
         }
       }
 
-      // find dateableId for targetSeason's Park/ParkArea/Feature by publishableId
-      const dateableId = await findDateableIdByPublishableId(
-        targetSeason.publishableId,
-        transaction,
-      );
-
-      // check if target season already has DateRanges for this dateType
+      // check if target season already has DateRanges for this dateable+dateType
       const existingTargetDateRanges = await DateRange.findAll({
         where: {
           seasonId: targetSeason.id,
+          dateableId: annual.dateableId,
           dateTypeId: annual.dateTypeId,
         },
         transaction,
@@ -151,8 +146,8 @@ export async function populateAnnualDateRangesForYear(
       for (let i = 0; i < numRangesToCopy; i++) {
         const prevRange = prevDateRanges[i];
         const currentYear = targetSeason.operatingYear;
-        const prevStartDate = prevRange.startDate;
-        const prevEndDate = prevRange.endDate;
+        const prevStartDate = new Date(prevRange.startDate);
+        const prevEndDate = new Date(prevRange.endDate);
 
         const newStartDate = new Date(prevStartDate);
         const newEndDate = new Date(prevEndDate);


### PR DESCRIPTION
### Jira Ticket

CMS-1582

### Description
<!-- What did you change, and why? -->

Fixed an issue with the annual DateRange data copying script so dates are copied to the correct records.

Each DateRangeAnnual row maps to a specific dateable/dateType context, so the copy queries now use that exact context instead of broader matching.

Also fixed date parsing/transform logic so the script doesn’t crash on null/incomplete rows in local data.

Deduplication now compares actual transformed start/end date values (not array position/count), and we only copy complete previous ranges. Also renamed some variables and updated comments to align with the updated logic.

Now there are fewer inserted ranges than before, because the old logic was over-copying in some cases.

