### PR TITLE
CMS-1704: Remove bottom margin for last paragraph in modal content

### DIFF
--- a/frontend/src/components/advisories/composite/advisoryForm/UnsavedChangesDialog.scss
+++ b/frontend/src/components/advisories/composite/advisoryForm/UnsavedChangesDialog.scss
@@ -2,4 +2,11 @@
   &.modal-content {
     border: none;
   }
+
+  .modal-body {
+    // No bottom margin for the last paragraph
+    p:last-child {
+      margin-bottom: 0;
+    }
+  }
 }


### PR DESCRIPTION
### Jira Ticket

CMS-1704

### Description
<!-- What did you change, and why? -->

QA requested a style change for the "Save changes?" modal dialog in ACT. This branch removes bottom margins for the last paragraph in the content so it will appear evenly spaced above and below.