### PR TITLE
CMS-1844: Optimize parks table endpoint

### DIFF
--- a/backend/migrations/20260713213244-add-performance-indexes.js
+++ b/backend/migrations/20260713213244-add-performance-indexes.js
@@ -1,0 +1,79 @@
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    // Create performance indexes for /parks query optimization
+    // These indexes optimize filtering, joining, and sorting operations
+
+    // Index for Parks.hasDates filter
+    await queryInterface.sequelize.query(
+      'CREATE INDEX IF NOT EXISTS "idx_Parks_hasDates" ON "Parks"("hasDates")',
+    );
+
+    // Index for Seasons.operatingYear filter (used in every season query)
+    await queryInterface.sequelize.query(
+      'CREATE INDEX IF NOT EXISTS "idx_Seasons_operatingYear" ON "Seasons"("operatingYear")',
+    );
+
+    // Composite index for Seasons join + operatingYear filter
+    // This allows DB to filter and join in a single index scan
+    await queryInterface.sequelize.query(
+      'CREATE INDEX IF NOT EXISTS "idx_Seasons_publishableId_operatingYear" ON "Seasons"("publishableId", "operatingYear")',
+    );
+
+    // Composite index for Features.active + Features.hasDates filters
+    // Allows efficient filtering without table scans
+    await queryInterface.sequelize.query(
+      'CREATE INDEX IF NOT EXISTS "idx_Features_active_hasDates" ON "Features"("active", "hasDates")',
+    );
+
+    // Composite index for Features join + active + hasDates filters
+    // Optimizes parkAreas.features query with required:true
+    await queryInterface.sequelize.query(
+      'CREATE INDEX IF NOT EXISTS "idx_Features_parkId_active_hasDates" ON "Features"("parkId", "active", "hasDates")',
+    );
+
+    // Used in the Season -> SeasonChangeLog include with notes filter
+    await queryInterface.sequelize.query(
+      'CREATE INDEX IF NOT EXISTS "idx_SeasonChangeLogs_seasonId" ON "SeasonChangeLogs"("seasonId")',
+    );
+
+    // Used in SeasonChangeLog -> User join
+    await queryInterface.sequelize.query(
+      'CREATE INDEX IF NOT EXISTS "idx_SeasonChangeLogs_userId" ON "SeasonChangeLogs"("userId")',
+    );
+
+    // Composite index for SeasonChangeLogs join + notes filter
+    // Optimizes the required:false include with non-empty notes filter
+    await queryInterface.sequelize.query(
+      'CREATE INDEX IF NOT EXISTS "idx_SeasonChangeLogs_seasonId_notes" ON "SeasonChangeLogs"("seasonId", "notes")',
+    );
+  },
+
+  async down(queryInterface, Sequelize) {
+    // Drop all performance indexes created in up migration
+    await queryInterface.sequelize.query(
+      'DROP INDEX IF EXISTS "idx_Parks_hasDates"',
+    );
+    await queryInterface.sequelize.query(
+      'DROP INDEX IF EXISTS "idx_Seasons_operatingYear"',
+    );
+    await queryInterface.sequelize.query(
+      'DROP INDEX IF EXISTS "idx_Seasons_publishableId_operatingYear"',
+    );
+    await queryInterface.sequelize.query(
+      'DROP INDEX IF EXISTS "idx_Features_active_hasDates"',
+    );
+    await queryInterface.sequelize.query(
+      'DROP INDEX IF EXISTS "idx_Features_parkId_active_hasDates"',
+    );
+    await queryInterface.sequelize.query(
+      'DROP INDEX IF EXISTS "idx_SeasonChangeLogs_seasonId"',
+    );
+    await queryInterface.sequelize.query(
+      'DROP INDEX IF EXISTS "idx_SeasonChangeLogs_userId"',
+    );
+    await queryInterface.sequelize.query(
+      'DROP INDEX IF EXISTS "idx_SeasonChangeLogs_seasonId_notes"',
+    );
+  },
+};

--- a/backend/routes/api/parks.js
+++ b/backend/routes/api/parks.js
@@ -1,6 +1,7 @@
 import { Op } from "sequelize";
 import { Router } from "express";
 import _ from "lodash";
+import sequelize from "../../db/connection.js";
 import {
   Park,
   Season,
@@ -10,7 +11,6 @@ import {
   DateType,
   Feature,
   ParkArea,
-  SeasonChangeLog,
   AccessGroup,
   GateDetail,
   User,
@@ -28,6 +28,14 @@ import * as USER_ROLES from "../../constants/userRoles.js";
 const router = Router();
 
 // Functions
+
+/**
+ * Builds Sequelize include configuration for Season model with date ranges.
+ * @param {number} minYear Minimum operating year to filter seasons by (inclusive)
+ * @param {boolean} [required=true] Whether seasons are required in the join
+ * @param {string|null} [seasonStatus=null] Optional status filter (e.g., 'published')
+ * @returns {Object} Sequelize include config for Season model with nested DateRanges
+ */
 function seasonModel(minYear, required = true, seasonStatus = null) {
   return {
     model: Season,
@@ -62,28 +70,17 @@ function seasonModel(minYear, required = true, seasonStatus = null) {
           },
         ],
       },
-      {
-        model: SeasonChangeLog,
-        as: "changeLogs",
-        attributes: ["id", "notes", "createdAt"],
-        required: false,
-        where: {
-          notes: {
-            [Op.ne]: "",
-          },
-        },
-        include: [
-          {
-            model: User,
-            as: "user",
-            attributes: ["id", "name"],
-          },
-        ],
-      },
     ],
   };
 }
 
+/**
+ * Builds Sequelize include configuration for Feature model with type and seasons.
+ * @param {number} minYear Minimum operating year to filter seasons by (inclusive)
+ * @param {Object} [where={}] Additional Sequelize WHERE conditions for features
+ * @param {string|null} [seasonStatus=null] Optional season status filter
+ * @returns {Object} Sequelize include config for Feature model with FeatureType and Seasons
+ */
 function featureModel(minYear, where = {}, seasonStatus = null) {
   return {
     model: Feature,
@@ -115,8 +112,16 @@ function featureModel(minYear, where = {}, seasonStatus = null) {
   };
 }
 
-// group dateRanges by date type name then by year
-// e.g. {Operation: {2024: [...], 2025: [...]}, Winter: {2024: [...], 2025: [...]}, ...}
+/**
+ * Groups date ranges hierarchically by type name and year.
+ * Optionally filters out PARK_GATE_OPEN type if hasGate is false.
+ * @param {Array<Object>} dateRanges Array of date range objects with dateType
+ * @param {boolean|null} [hasGate=null] If false, filter out PARK_GATE_OPEN type
+ * @returns {Object} Nested map: {dateTypeName: {year: [ranges]}}
+ * @example
+ * {"Operation": {2024: [...], 2025: [...]}, "Winter": {2024: [...]}}
+ *
+ */
 function groupDateRangesByTypeAndYear(dateRanges, hasGate = null) {
   // filter out invalid dateRanges
   let validRanges = dateRanges.filter((dateRange) => dateRange.dateType);
@@ -140,7 +145,13 @@ function groupDateRangesByTypeAndYear(dateRanges, hasGate = null) {
   );
 }
 
-// build a date range output object
+/**
+ * Creates standardized date range output object.
+ * @param {Object} dateRange Raw date range from database
+ * @param {number} operatingYear Operating year for context
+ * @param {boolean} readyToPublish Whether the season is ready to publish
+ * @returns {Object} Formatted date range with id, dates, type, and year
+ */
 function buildDateRangeObject(dateRange, operatingYear, readyToPublish) {
   return {
     id: dateRange.id,
@@ -160,7 +171,11 @@ function buildDateRangeObject(dateRange, operatingYear, readyToPublish) {
   };
 }
 
-// build a current season object
+/**
+ * Extracts most recent season for each season type (REGULAR and WINTER).
+ * @param {Array<Object>|null} seasons Array of season objects
+ * @returns {Object} {regular: season|null, winter: season|null} - Most recent of each type
+ */
 function buildCurrentSeasonOutput(seasons) {
   if (!seasons || seasons.length === 0) return { regular: null, winter: null };
 
@@ -182,7 +197,11 @@ function buildCurrentSeasonOutput(seasons) {
   };
 }
 
-// get all date ranges from seasons
+/**
+ * Flattens nested season.dateRanges into single array with season context.
+ * @param {Array<Object>} seasons Array of season objects containing dateRanges
+ * @returns {Array<Object>} Flattened array of standardized date range objects
+ */
 function getAllDateRanges(seasons) {
   return _.flatMap(seasons, (season) =>
     (season.dateRanges || []).map((dateRange) =>
@@ -195,24 +214,73 @@ function getAllDateRanges(seasons) {
   );
 }
 
-// build feature output object
-function buildFeatureOutput(feature, seasons, includeCurrentSeason = true) {
+/**
+ * Converts Sequelize instance to plain JavaScript object.
+ * @param {Object} season Sequelize instance or plain object
+ * @returns {Object} Plain JavaScript object
+ */
+function getPlainSeason(season) {
+  return typeof season.toJSON === "function" ? season.toJSON() : season;
+}
+
+/**
+ * Queries SeasonChangeLogs table to check for non-empty notes and returns a lookup map.
+ * @param {Array<string>} seasonIds Array of season IDs to check
+ * @returns {Promise<Map<string, boolean>>} Map of seasonId -> hasNotes (boolean)
+ */
+async function fetchAndMapSeasonNotes(seasonIds) {
+  if (seasonIds.length === 0) {
+    return new Map();
+  }
+
+  // Query the SeasonChangeLogs table for the given season IDs to check for notes
+  const notesResult = await sequelize.query(
+    `SELECT DISTINCT "s"."id" as "seasonId",
+      EXISTS(
+        SELECT 1 FROM "SeasonChangeLogs" scl
+        WHERE scl."seasonId" = s."id" AND TRIM(scl."notes") != ''
+      ) as "hasNotes"
+    FROM "Seasons" s
+    WHERE s."id" IN (${seasonIds.map(() => "?").join(",")})`,
+    {
+      replacements: seasonIds,
+      type: sequelize.QueryTypes.SELECT,
+    },
+  );
+
+  const seasonNotesMap = new Map();
+
+  notesResult.forEach((row) => {
+    seasonNotesMap.set(row.seasonId, row.hasNotes);
+  });
+
+  return seasonNotesMap;
+}
+
+/**
+ * Formats feature output with filtered seasons and optional currentSeason.
+ * @param {Object} feature Feature instance with id, dateableId, seasons, etc.
+ * @param {Array<Object>} seasons Parent seasons array to filter from
+ * @param {boolean} [includeCurrentSeason=true] Whether to include computed currentSeason
+ * @param {Map<string, boolean>} [seasonNotesMap=new Map()] seasonId -> hasNotes lookup
+ * @returns {Object} Formatted feature with id, name, seasons, groupedDateRanges, etc.
+ */
+function buildFeatureOutput(
+  feature,
+  seasons,
+  includeCurrentSeason = true,
+  seasonNotesMap = new Map(),
+) {
   // filter seasons if dateRange's dateableId matches feature's dateableId
   const filteredSeasons = (seasons || [])
     // first, filter seasons that have at least one matching dateRange
-    .filter((season) => {
-      // convert to plain object if it's a Sequelize instance
-      const plainSeason =
-        typeof season.toJSON === "function" ? season.toJSON() : season;
-
-      return (plainSeason.dateRanges || []).some(
+    .filter((season) =>
+      (getPlainSeason(season).dateRanges || []).some(
         (dateRange) => dateRange.dateableId === feature.dateableId,
-      );
-    })
+      ),
+    )
     .map((season) => {
-      // convert to plain object if it's a Sequelize instance
-      const plainSeason =
-        typeof season.toJSON === "function" ? season.toJSON() : season;
+      const plainSeason = getPlainSeason(season);
 
       return {
         ...plainSeason,
@@ -224,6 +292,7 @@ function buildFeatureOutput(feature, seasons, includeCurrentSeason = true) {
               feature.hasReservations ||
               dateRange.dateType?.name !== "Reservation",
           ),
+        hasNotes: !!seasonNotesMap.get(plainSeason.id),
       };
     });
 
@@ -258,14 +327,35 @@ function buildFeatureOutput(feature, seasons, includeCurrentSeason = true) {
   };
 
   if (includeCurrentSeason) {
-    output.currentSeason = buildCurrentSeasonOutput(feature.seasons);
+    const currentSeason = buildCurrentSeasonOutput(feature.seasons);
+
+    // Add hasNotes to current season objects and convert to plain objects
+    if (currentSeason.regular) {
+      currentSeason.regular = {
+        ...getPlainSeason(currentSeason.regular),
+        hasNotes: !!seasonNotesMap.get(currentSeason.regular.id),
+      };
+    }
+    if (currentSeason.winter) {
+      currentSeason.winter = {
+        ...getPlainSeason(currentSeason.winter),
+        hasNotes: !!seasonNotesMap.get(currentSeason.winter.id),
+      };
+    }
+    output.currentSeason = currentSeason;
   }
 
   return output;
 }
 
-// build park area output object
-function buildParkAreaOutput(parkArea) {
+/**
+ * Formats park area output with features, seasons, and metadata.
+ * Adds hasNotes from the provided map.
+ * @param {Object} parkArea ParkArea instance with seasons, features, parkAreaType
+ * @param {Map<string, boolean>} seasonNotesMap seasonId -> hasNotes lookup map
+ * @returns {Object} Formatted park area with id, name, features, seasons, currentSeason, etc.
+ */
+function buildParkAreaOutput(parkArea, seasonNotesMap) {
   // get date ranges for parkArea
   const parkAreaDateRanges = getAllDateRanges(parkArea.seasons)
     // Temporarily disabling display of Winter Fees
@@ -281,6 +371,20 @@ function buildParkAreaOutput(parkArea) {
   // get a current season
   const currentSeason = buildCurrentSeasonOutput(parkArea.seasons);
 
+  // Add hasNotes to current season objects and convert to plain objects
+  if (currentSeason.regular) {
+    currentSeason.regular = {
+      ...getPlainSeason(currentSeason.regular),
+      hasNotes: !!seasonNotesMap.get(currentSeason.regular.id),
+    };
+  }
+  if (currentSeason.winter) {
+    currentSeason.winter = {
+      ...getPlainSeason(currentSeason.winter),
+      hasNotes: !!seasonNotesMap.get(currentSeason.winter.id),
+    };
+  }
+
   return {
     id: parkArea.id,
     dateableId: parkArea.dateableId,
@@ -289,11 +393,14 @@ function buildParkAreaOutput(parkArea) {
     inReservationSystem: parkArea.inReservationSystem,
     hasWinterFeeDates: parkArea.hasWinterFeeDates,
     features: parkArea.features.map((feature) =>
-      buildFeatureOutput(feature, parkArea.seasons, false),
+      buildFeatureOutput(feature, parkArea.seasons, false, seasonNotesMap),
     ),
     featureTypes,
     parkAreaType: parkArea.parkAreaType,
-    seasons: parkArea.seasons,
+    seasons: parkArea.seasons.map((season) => ({
+      ...getPlainSeason(season),
+      hasNotes: !!seasonNotesMap.get(season.id),
+    })),
     currentSeason,
     groupedDateRanges: groupDateRangesByTypeAndYear(parkAreaDateRanges),
   };
@@ -317,10 +424,8 @@ router.get(
       typeof req.query.seasonStatus === "string"
         ? req.query.seasonStatus
         : null;
-    const hasAllParkAccess = checkUserRoles(getRolesFromAuth(req.auth), [
-      USER_ROLES.ALL_PARK_ACCESS,
-    ]);
 
+    // Main query: Fetch Parks with their Seasons
     const parks = await Park.findAll({
       attributes: [
         "id",
@@ -339,37 +444,6 @@ router.get(
         // Publishable Seasons for the Park
         seasonModel(operatingYear, true, seasonStatus),
 
-        // ParkAreas
-        {
-          model: ParkArea,
-          as: "parkAreas",
-          attributes: [
-            "id",
-            "dateableId",
-            "publishableId",
-            "name",
-            "inReservationSystem",
-            "hasWinterFeeDates",
-          ],
-          include: [
-            // Features that are part of the ParkArea
-            {
-              ...featureModel(operatingYear, {}, seasonStatus),
-              // Exclude parkAreas with no active features
-              required: true,
-            },
-            // Publishable Seasons for the ParkArea
-            seasonModel(operatingYear, true, seasonStatus),
-            // ParkAreaType for the ParkArea
-            {
-              model: ParkAreaType,
-              as: "parkAreaType",
-              attributes: ["id", "parkAreaTypeNumber", "name"],
-              required: true,
-            },
-          ],
-        },
-
         // Publishable Features that aren't part of a ParkArea
         featureModel(
           operatingYear,
@@ -381,13 +455,209 @@ router.get(
           },
           seasonStatus,
         ),
+      ],
+      order: [
+        ["name", "ASC"],
+        // For Features that ARE NOT part of a ParkArea
+        [{ model: Feature, as: "features" }, "name", "ASC"],
+      ],
+    });
 
-        // Filter AccessGroups on server-side based on user's access,
-        // and also return accessGroup IDs for client-side bundle filters
+    const parkIds = parks.map((park) => park.id);
+    const publishableIds = parks.map((park) => park.publishableId);
+
+    // Collect season IDs from parks for later hasNotes fetch
+    const parkSeasonIds = parks.flatMap((park) =>
+      park.seasons.map((season) => season.id),
+    );
+
+    // Query 2: Fetch ParkAreas with their Features and Seasons for the Parks in the main query
+    const parkAreasQuery = ParkArea.findAll({
+      attributes: [
+        "id",
+        "dateableId",
+        "publishableId",
+        "parkId",
+        "name",
+        "inReservationSystem",
+        "hasWinterFeeDates",
+      ],
+      where: { parkId: parkIds },
+      include: [
+        // Features that are part of the ParkArea
+        {
+          ...featureModel(operatingYear, {}, seasonStatus),
+          // Exclude parkAreas with no active features
+          required: true,
+        },
+        // Publishable Seasons for the ParkArea
+        seasonModel(operatingYear, true, seasonStatus),
+        // ParkAreaType for the ParkArea
+        {
+          model: ParkAreaType,
+          as: "parkAreaType",
+          attributes: ["id", "parkAreaTypeNumber", "name"],
+          required: true,
+        },
+      ],
+      order: [
+        ["name", "ASC"],
+        // For Features that ARE part of a ParkArea
+        [
+          { model: Feature, as: "features" },
+          { model: FeatureType, as: "featureType" },
+          "rank",
+          "ASC",
+        ],
+        [{ model: Feature, as: "features" }, "name", "ASC"],
+      ],
+    });
+
+    // Query 3: Fetch GateDetails for the Parks in the main query
+    const gateDetailsQuery = GateDetail.findAll({
+      attributes: ["publishableId", "hasGate"],
+      where: {
+        publishableId: {
+          [Op.in]: publishableIds,
+        },
+      },
+    });
+
+    const [parkAreas, allGateDetails] = await Promise.all([
+      parkAreasQuery,
+      gateDetailsQuery,
+    ]);
+
+    // Merge ParkAreas back into the main query results by parkId
+    const parkAreasByParkId = _.groupBy(parkAreas, "parkId");
+
+    parks.forEach((park) => {
+      park.parkAreas = parkAreasByParkId[park.id] || [];
+    });
+
+    // Collect all season IDs from parks, parkAreas, and their features
+    const allSeasonIds = new Set(parkSeasonIds);
+
+    parkAreas.forEach((parkArea) => {
+      parkArea.seasons?.forEach((season) => {
+        allSeasonIds.add(season.id);
+      });
+      parkArea.features?.forEach((feature) => {
+        feature.seasons?.forEach((season) => {
+          allSeasonIds.add(season.id);
+        });
+      });
+    });
+
+    // Collect season IDs from park features
+    parks.forEach((park) => {
+      park.features?.forEach((feature) => {
+        feature.seasons?.forEach((season) => {
+          allSeasonIds.add(season.id);
+        });
+      });
+    });
+
+    // Populate seasonNotesMap for all seasons (park, parkArea, and feature seasons) with single query
+    const seasonNotesMap = await fetchAndMapSeasonNotes(
+      Array.from(allSeasonIds),
+    );
+
+    // Build lookup map for GateDetails by publishableId
+    const gateDetailMap = new Map();
+
+    allGateDetails.forEach((gate) => {
+      gateDetailMap.set(gate.publishableId, gate.hasGate);
+    });
+
+    const output = parks.map((park) => {
+      const [regularSeasons, winterSeasons] = _.partition(
+        park.seasons,
+        (season) => season.seasonType === SEASON_TYPE.REGULAR,
+      );
+      // Get date ranges for park
+      // For regular seasons, exclude Winter fee dates
+      const parkDateRanges = getAllDateRanges(regularSeasons).filter(
+        (dateRange) =>
+          dateRange.dateType?.dateTypeNumber !== DATE_TYPE.WINTER_FEE,
+      );
+      // For winter seasons, only include Winter fee dates
+      const parkWinterDateRanges = getAllDateRanges(winterSeasons).filter(
+        (dateRange) =>
+          dateRange.dateType?.dateTypeNumber === DATE_TYPE.WINTER_FEE,
+      );
+      // Get hasGate for park
+      const parkHasGate = gateDetailMap.get(park.publishableId) ?? null;
+
+      return {
+        id: park.id,
+        dateableId: park.dateableId,
+        publishableId: park.publishableId,
+        name: park.name,
+        orcs: park.orcs,
+        hasGate: parkHasGate,
+        hasTier1Dates: park.hasTier1Dates,
+        hasTier2Dates: park.hasTier2Dates,
+        hasWinterFeeDates: park.hasWinterFeeDates,
+        inReservationSystem: park.inReservationSystem,
+        groupedDateRanges: groupDateRangesByTypeAndYear(
+          parkDateRanges,
+          parkHasGate,
+        ),
+        winterGroupedDateRanges:
+          groupDateRangesByTypeAndYear(parkWinterDateRanges),
+        features: park.features.map((feature) =>
+          buildFeatureOutput(feature, feature.seasons, true, seasonNotesMap),
+        ),
+        parkAreas: park.parkAreas.map((parkArea) =>
+          buildParkAreaOutput(parkArea, seasonNotesMap),
+        ),
+        // Park-level "currentSeason" is derived on the frontend from the seasons array
+        seasons: park.seasons.map((season) => ({
+          id: season.id,
+          publishableId: season.publishableId,
+          operatingYear: season.operatingYear,
+          status: season.status,
+          readyToPublish: season.readyToPublish,
+          hasNotes: !!seasonNotesMap.get(season.id),
+          dateRanges: season.dateRanges.map((dateRange) =>
+            buildDateRangeObject(
+              dateRange,
+              season.operatingYear,
+              season.readyToPublish,
+            ),
+          ),
+          seasonType: season.seasonType,
+        })),
+      };
+    });
+
+    res.json(output);
+  }),
+);
+
+// GET /parks/metadata
+// Returns supplemental park data needed for table filtering.
+// Separated from main `/parks` payload so data can be lazy-loaded.
+// Frontend merges this into parks array by park id once resolved, then enables filters.
+router.get(
+  "/metadata",
+  asyncHandler(async (req, res) => {
+    const hasAllParkAccess = checkUserRoles(getRolesFromAuth(req.auth), [
+      USER_ROLES.ALL_PARK_ACCESS,
+    ]);
+
+    const parks = await Park.findAll({
+      attributes: ["id", "managementAreas"],
+      where: { hasDates: true },
+      include: [
         {
           model: AccessGroup,
           as: "accessGroups",
           attributes: ["id"],
+          through: {
+            attributes: [],
+          },
           required: !hasAllParkAccess,
           include: hasAllParkAccess
             ? []
@@ -406,114 +676,15 @@ router.get(
               ],
         },
       ],
-      order: [
-        ["name", "ASC"],
-        [{ model: ParkArea, as: "parkAreas" }, "name", "ASC"],
-        // For Features that ARE part of a ParkArea
-        [
-          { model: ParkArea, as: "parkAreas" },
-          { model: Feature, as: "features" },
-          { model: FeatureType, as: "featureType" },
-          "rank",
-          "ASC",
-        ],
-        [
-          { model: ParkArea, as: "parkAreas" },
-          { model: Feature, as: "features" },
-          "name",
-          "ASC",
-        ],
-        // For Features that ARE NOT part of a ParkArea
-        [{ model: Feature, as: "features" }, "name", "ASC"],
-      ],
     });
 
-    // constrain GateDetail query to only publishableIds in parks
-    const publishableIds = parks.map((park) => park.publishableId);
+    const output = parks.map((park) => ({
+      id: park.id,
+      section: park.managementAreas.map((area) => area.section),
+      managementArea: park.managementAreas.map((area) => area.mgmtArea),
+      accessGroups: park.accessGroups,
+    }));
 
-    const allGateDetails = await GateDetail.findAll({
-      attributes: ["publishableId", "hasGate"],
-      where: {
-        publishableId: {
-          [Op.in]: publishableIds,
-        },
-      },
-    });
-
-    const gateDetailMap = new Map();
-
-    allGateDetails.forEach((gate) => {
-      gateDetailMap.set(gate.publishableId, gate.hasGate);
-    });
-
-    const output = parks.map((park) => {
-      const [regularSeasons, winterSeasons] = _.partition(
-        park.seasons,
-        (season) => season.seasonType === SEASON_TYPE.REGULAR,
-      );
-      // get date ranges for park
-      // For regular seasons, exclude Winter fee dates
-      const parkDateRanges = getAllDateRanges(regularSeasons).filter(
-        (dateRange) =>
-          dateRange.dateType?.dateTypeNumber !== DATE_TYPE.WINTER_FEE,
-      );
-      // For winter seasons, only include Winter fee dates
-      const parkWinterDateRanges = getAllDateRanges(winterSeasons).filter(
-        (dateRange) =>
-          dateRange.dateType?.dateTypeNumber === DATE_TYPE.WINTER_FEE,
-      );
-      // get hasGate for park
-      const parkHasGate = gateDetailMap.get(park.publishableId) ?? null;
-
-      // get current season
-      const currentSeason = buildCurrentSeasonOutput(park.seasons);
-
-      return {
-        id: park.id,
-        dateableId: park.dateableId,
-        publishableId: park.publishableId,
-        name: park.name,
-        orcs: park.orcs,
-        hasGate: parkHasGate,
-        hasTier1Dates: park.hasTier1Dates,
-        hasTier2Dates: park.hasTier2Dates,
-        hasWinterFeeDates: park.hasWinterFeeDates,
-        section: park.managementAreas.map((area) => area.section),
-        managementArea: park.managementAreas.map((area) => area.mgmtArea),
-        accessGroups: park.accessGroups,
-        inReservationSystem: park.inReservationSystem,
-        currentSeason,
-        groupedDateRanges: groupDateRangesByTypeAndYear(
-          parkDateRanges,
-          parkHasGate,
-        ),
-        winterGroupedDateRanges:
-          groupDateRangesByTypeAndYear(parkWinterDateRanges),
-        features: park.features.map((feature) =>
-          buildFeatureOutput(feature, feature.seasons, true),
-        ),
-        parkAreas: park.parkAreas.map((parkArea) =>
-          buildParkAreaOutput(parkArea),
-        ),
-        seasons: park.seasons.map((season) => ({
-          id: season.id,
-          publishableId: season.publishableId,
-          operatingYear: season.operatingYear,
-          status: season.status,
-          readyToPublish: season.readyToPublish,
-          dateRanges: season.dateRanges.map((dateRange) =>
-            buildDateRangeObject(
-              dateRange,
-              season.operatingYear,
-              season.readyToPublish,
-            ),
-          ),
-          seasonType: season.seasonType,
-        })),
-      };
-    });
-
-    // Return all rows
     res.json(output);
   }),
 );

--- a/backend/routes/api/seasons.js
+++ b/backend/routes/api/seasons.js
@@ -1240,4 +1240,55 @@ router.post(
   }),
 );
 
+/**
+ * Retrieves all changelog notes for a specific season.
+ * Returns SeasonChangeLog entries sorted by most recent first.
+ * GET /api/seasons/:seasonId/notes
+ */
+router.get(
+  "/:seasonId/notes",
+  asyncHandler(async (req, res) => {
+    const { seasonId } = req.params;
+
+    const season = await Season.findByPk(seasonId, {
+      attributes: ["id"],
+    });
+
+    // Throw a 404 if the season doesn't exist
+    checkSeasonExists(season);
+    // Throw a 403 if the user doesn't have access to the park associated with the season
+    await checkSeasonUserAccess(req, seasonId);
+
+    // Fetch all changelog notes for the season
+    const changeLog = await SeasonChangeLog.findAll({
+      where: {
+        seasonId,
+        [Op.and]: sequelize.where(
+          sequelize.fn("TRIM", sequelize.col("notes")),
+          Op.ne,
+          "",
+        ),
+      },
+      attributes: ["id", "notes", "createdAt"],
+      include: [
+        {
+          model: User,
+          as: "user",
+          attributes: ["name"],
+        },
+      ],
+      order: [["createdAt", "DESC"]],
+    });
+
+    const output = changeLog.map((entry) => ({
+      id: entry.id,
+      note: entry.notes,
+      createdAt: entry.createdAt,
+      createdBy: entry.user?.name || "Unknown",
+    }));
+
+    return res.json(output);
+  }),
+);
+
 export default router;

--- a/frontend/src/components/InternalNotesRow.jsx
+++ b/frontend/src/components/InternalNotesRow.jsx
@@ -5,6 +5,7 @@ import Accordion from "react-bootstrap/Accordion";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faChevronDown, faChevronUp } from "@fa-kit/icons/classic/solid";
 import { formatDateShort } from "@/lib/utils";
+import { useApiGet } from "@/hooks/useApi";
 
 // Formats createdAt date
 // e.g. "2024-06-20T18:25:43.511Z" -> "Thu, Jun 20"
@@ -18,10 +19,34 @@ function formatCreatedAt(value) {
   return formatDateShort(date);
 }
 
-export default function InternalNotesRow({ notes }) {
+export default function InternalNotesRow({ seasonId }) {
+  const [hasRequestedNotes, setHasRequestedNotes] = useState(false);
   const [isOpen, setIsOpen] = useState(false);
+  const {
+    data: fetchedNotes,
+    loading,
+    error,
+    fetchData,
+  } = useApiGet(`/seasons/${seasonId}/notes`, { instant: false });
 
-  if (!notes || notes.length === 0) return null;
+  const visibleNotes = Array.isArray(fetchedNotes) ? fetchedNotes : [];
+
+  // Toggles the open state and fetches notes if opening for the first time
+  async function toggleOpen() {
+    const openingRow = !isOpen;
+
+    setIsOpen(openingRow);
+
+    if (openingRow && !hasRequestedNotes) {
+      try {
+        await fetchData();
+        setHasRequestedNotes(true);
+      } catch {
+        // Keep this false so collapsing and reopening retries the request.
+        setHasRequestedNotes(false);
+      }
+    }
+  }
 
   return (
     <tr className={classNames("table-row--note")}>
@@ -31,27 +56,48 @@ export default function InternalNotesRow({ notes }) {
       <td>
         <Accordion activeKey={isOpen ? "internal-notes" : null}>
           <Accordion.Collapse
-            id={`internal-notes-${notes[0].id}`}
+            id={`internal-notes-${seasonId}`}
             eventKey="internal-notes"
           >
-            <ul className="list-unstyled">
-              {notes.map((note) => (
-                <li key={note.id}>
-                  <div>{note.note}</div>
-                  <p className="text-muted">
-                    {formatCreatedAt(note.createdAt)} by {note.createdBy}
+            <>
+              {loading && <p className="mb-0 text-muted">Loading notes...</p>}
+
+              {!loading && error && (
+                <p className="mb-0 text-danger">
+                  Unable to load internal notes.
+                </p>
+              )}
+
+              {!loading && !error && visibleNotes.length > 0 && (
+                <ul className="list-unstyled">
+                  {visibleNotes.map((note) => (
+                    <li key={note.id}>
+                      <div>{note.note}</div>
+                      <p className="text-muted">
+                        {formatCreatedAt(note.createdAt)} by {note.createdBy}
+                      </p>
+                    </li>
+                  ))}
+                </ul>
+              )}
+
+              {!loading &&
+                !error &&
+                hasRequestedNotes &&
+                visibleNotes.length === 0 && (
+                  <p className="mb-0 text-muted">
+                    No internal notes found for this season.
                   </p>
-                </li>
-              ))}
-            </ul>
+                )}
+            </>
           </Accordion.Collapse>
 
           <button
             type="button"
             className="btn btn-text text-link text-decoration-underline p-0"
-            onClick={() => setIsOpen((open) => !open)}
+            onClick={toggleOpen}
             aria-expanded={isOpen}
-            aria-controls={`internal-notes-${notes[0].id}`}
+            aria-controls={`internal-notes-${seasonId}`}
           >
             {isOpen ? "Hide internal notes" : "Show internal notes"}
             <FontAwesomeIcon
@@ -66,15 +112,5 @@ export default function InternalNotesRow({ notes }) {
 }
 
 InternalNotesRow.propTypes = {
-  notes: PropTypes.arrayOf(
-    PropTypes.shape({
-      id: PropTypes.number.isRequired,
-      note: PropTypes.string.isRequired,
-      createdAt: PropTypes.oneOfType([
-        PropTypes.string,
-        PropTypes.instanceOf(Date),
-      ]),
-      createdBy: PropTypes.string,
-    }),
-  ),
+  seasonId: PropTypes.number.isRequired,
 };

--- a/frontend/src/components/MultiSelect.jsx
+++ b/frontend/src/components/MultiSelect.jsx
@@ -9,6 +9,7 @@ export default function MultiSelect({
   onInput,
   value = [],
   children,
+  disabled = false,
 }) {
   function OptionCheckbox({ option }) {
     const id = `option-${option.value}`;
@@ -91,6 +92,7 @@ export default function MultiSelect({
         className="btn btn-outline-primary dropdown-toggle"
         aria-expanded={expanded}
         onClick={toggleExpanded}
+        disabled={disabled}
       >
         {children}
       </button>
@@ -117,5 +119,6 @@ MultiSelect.propTypes = {
   ).isRequired,
   onInput: PropTypes.func.isRequired,
   value: PropTypes.arrayOf(PropTypes.string),
+  disabled: PropTypes.bool,
   children: PropTypes.node,
 };

--- a/frontend/src/components/SubmitPageTable.jsx
+++ b/frontend/src/components/SubmitPageTable.jsx
@@ -18,24 +18,6 @@ import * as DATE_TYPE from "@/constants/dateType";
 import * as SEASON_TYPE from "@/constants/seasonType";
 import * as SEASON_STATUS from "@/constants/seasonStatus";
 
-// Functions
-// Get internal notes for a season, sorted by createdAt date
-function getInternalNotes(season) {
-  return (season?.changeLogs || [])
-    .filter((log) => typeof log?.notes === "string" && log.notes.trim())
-    .sort(
-      (left, right) =>
-        new Date(right.createdAt).valueOf() -
-        new Date(left.createdAt).valueOf(),
-    )
-    .map((log) => ({
-      id: log.id,
-      note: log.notes.trim(),
-      createdAt: log.createdAt,
-      createdBy: log.user?.name || "Unknown user",
-    }));
-}
-
 // renders all date ranges for a given year as a list
 // e.g. [{ startDate: "Mon Jan 1", endDate: "Tue Jan 2" }, { startDate: "Mon Dec 30", endDate: "Tue Dec 31" }]
 // => Mon, 1 Jan – Tue, 2 Jan / Mon, 30 Dec – Tue, 31 Dec
@@ -308,7 +290,6 @@ function FeaturesByFeatureTypeWithAreas({
       {/* 2 - park area level */}
       {parkAreas.map((parkArea) => {
         const regularSeason = parkArea.currentSeason.regular;
-        const regularSeasonInternalNotes = getInternalNotes(regularSeason);
 
         const featuresInCurrentGroup = parkArea.features;
 
@@ -347,8 +328,8 @@ function FeaturesByFeatureTypeWithAreas({
                   />
                 </React.Fragment>
               ))}
-              {isApprover && (
-                <InternalNotesRow notes={regularSeasonInternalNotes} />
+              {isApprover && regularSeason.hasNotes && (
+                <InternalNotesRow seasonId={regularSeason.id} />
               )}
             </React.Fragment>
           )
@@ -376,7 +357,6 @@ function FeaturesByFeatureTypeNoAreas({
       {/* features that don't belong to park area  */}
       {features.map((feature) => {
         const regularSeason = feature.currentSeason.regular;
-        const regularSeasonInternalNotes = getInternalNotes(regularSeason);
 
         return (
           <React.Fragment key={feature.id}>
@@ -401,8 +381,8 @@ function FeaturesByFeatureTypeNoAreas({
               groupedDateRanges={feature.groupedDateRanges}
               currentYear={regularSeason.operatingYear}
             />
-            {isApprover && (
-              <InternalNotesRow notes={regularSeasonInternalNotes} />
+            {isApprover && regularSeason.hasNotes && (
+              <InternalNotesRow seasonId={regularSeason.id} />
             )}
           </React.Fragment>
         );
@@ -427,8 +407,6 @@ function Table({ park, formPanelHandler, sortOrder }) {
   const features = park.features || [];
   const regularSeason = park.currentSeason.regular;
   const winterSeason = park?.currentSeason.winter || {};
-  const regularSeasonInternalNotes = getInternalNotes(regularSeason);
-  const winterSeasonInternalNotes = getInternalNotes(winterSeason);
 
   if (!sortOrder?.length) return <></>;
 
@@ -478,8 +456,8 @@ function Table({ park, formPanelHandler, sortOrder }) {
                   groupedDateRanges={park.groupedDateRanges}
                   currentYear={regularSeason.operatingYear}
                 />
-                {isApprover && (
-                  <InternalNotesRow notes={regularSeasonInternalNotes} />
+                {isApprover && regularSeason.hasNotes && (
+                  <InternalNotesRow seasonId={regularSeason.id} />
                 )}
               </>
             )}
@@ -510,8 +488,8 @@ function Table({ park, formPanelHandler, sortOrder }) {
                   groupedDateRanges={park.winterGroupedDateRanges}
                   currentYear={winterSeason.operatingYear}
                 />
-                {isApprover && (
-                  <InternalNotesRow notes={winterSeasonInternalNotes} />
+                {isApprover && winterSeason.hasNotes && (
+                  <InternalNotesRow seasonId={winterSeason.id} />
                 )}
               </>
             )}

--- a/frontend/src/router/pages/SubmitPage.jsx
+++ b/frontend/src/router/pages/SubmitPage.jsx
@@ -20,19 +20,81 @@ import {
   shouldShowTiersAndGateSection,
   shouldShowWinterFeeSection,
 } from "@/lib/submitPageFilters";
-import { groupBy } from "lodash-es";
+import { groupBy, maxBy } from "lodash-es";
+
+// Build the currentSeason object for a Park from its seasons array.
+// Same logic used in the backend for Feature-level currentSeason objects.
+function getCurrentSeason(seasons = []) {
+  if (!seasons || seasons.length === 0) return { regular: null, winter: null };
+
+  // group seasons by seasonType
+  const seasonsByType = groupBy(seasons, "seasonType");
+
+  // find the most recent season (highest operatingYear) for each type
+  const regularSeason = seasonsByType.regular
+    ? maxBy(seasonsByType.regular, "operatingYear")
+    : null;
+
+  const winterSeason = seasonsByType.winter
+    ? maxBy(seasonsByType.winter, "operatingYear")
+    : null;
+
+  return {
+    regular: regularSeason,
+    winter: winterSeason,
+  };
+}
 
 function SubmitPage() {
   const params = useParams();
   const navigate = useNavigate();
 
+  // Load Park data for the table
   const { data, loading, error, fetchData } = useApiGet("/parks");
+
+  // Load metadata for each park (park section, management area, access groups) and filter options for the filter panel
+  const {
+    data: metadataRaw,
+    loading: metadataLoading,
+    error: metadataError,
+  } = useApiGet("/parks/metadata");
+
   const {
     data: filterOptionsData,
     loading: filterOptionsLoading,
     error: filterOptionsError,
   } = useApiGet("/filter-options");
-  const parks = useMemo(() => data ?? [], [data]);
+
+  // disable filters until Park metadata is loaded
+  const metadataLoaded = metadataRaw && !metadataLoading;
+
+  // Build a lookup map from the metadata array: parkId -> { section, managementArea, accessGroups }
+  const metadataById = useMemo(
+    () =>
+      new Map(
+        (metadataRaw ?? []).map(({ id, ...metadataFields }) => [
+          id,
+          metadataFields,
+        ]),
+      ),
+    [metadataRaw],
+  );
+
+  // Transform the API response to include currentSeason objects for each Park.
+  // Once metadata is available, merge section/managementArea/accessGroups per park.
+  const parks = useMemo(
+    () =>
+      (data ?? []).map((park) => ({
+        ...park,
+
+        // Merge in metadata for this park
+        ...(metadataById.get(park.id) ?? {}),
+
+        // Build the currentSeason object for this park
+        currentSeason: getCurrentSeason(park.seasons),
+      })),
+    [data, metadataById],
+  );
 
   const filterOptions = useMemo(
     () => filterOptionsData ?? {},
@@ -175,6 +237,20 @@ function SubmitPage() {
   const flattenedFilteredResults = useMemo(() => {
     // Flatten the parks, areas, and features into a single "results" array
     // and exclude any areas or features that don't match the filters.
+
+    // Skip all filter logic until metadata has been merged in
+    // (section, managementArea, accessGroups)
+    if (!metadataLoaded) {
+      return parks.map((park) => ({
+        ...park,
+        matchesFilters: true,
+        entityType: "park",
+        parkName: park.name,
+        showTiersAndGate: true,
+        showWinterFee: park.hasWinterFeeDates,
+      }));
+    }
+
     const results = parks.flatMap((park) => {
       // If the Park doesn't match the Park-level "hard" filters, exclude it entirely.
       if (parkFiltersActive && !checkParkHard(park, filters)) {
@@ -249,7 +325,7 @@ function SubmitPage() {
     });
 
     return results;
-  }, [parks, filters, parkFiltersActive]);
+  }, [parks, filters, parkFiltersActive, metadataLoaded]);
 
   // Count the number of "results" - Parks, Areas, and Features with a status
   const numResults = useMemo(
@@ -338,6 +414,10 @@ function SubmitPage() {
       return <p>Error loading parks data: {error.message}</p>;
     }
 
+    if (metadataError) {
+      return <p>Error loading parks metadata: {metadataError.message}</p>;
+    }
+
     return (
       <div className="paginated-table">
         <div className="mb-3">
@@ -373,6 +453,7 @@ function SubmitPage() {
           updateFilter("status", value);
         }}
         value={filters.status}
+        disabled={!metadataLoaded}
       >
         Filter by status{" "}
         {filters.status.length > 0 && `(${filters.status.length})`}
@@ -413,6 +494,7 @@ function SubmitPage() {
                   setPage(1);
                   updateFilter("name", e.target.value);
                 }}
+                disabled={!metadataLoaded}
               />
               <FontAwesomeIcon
                 className="append-content"
@@ -433,6 +515,7 @@ function SubmitPage() {
               type="button"
               onClick={() => setShowFilterPanel(!showFilterPanel)}
               className="btn btn-outline-primary align-self-end me-2"
+              disabled={!metadataLoaded}
             >
               <FontAwesomeIcon icon={faFilter} className="me-1" />
               All filters


### PR DESCRIPTION
### Jira Ticket

CMS-1844

### Description
<!-- What did you change, and why? -->

Several optimizations to improve performance of the main /parks query that runs on every visit to the homepage. (And currently it also re-runs every time we submit an edit form). 

My local db has lots of test data, and probably less cpu/ram allocated than the servers. Locally, my parks endpoint was taking ~5.5 seconds to respond and this branch gets it down to about 0.5s. On the servers it takes 0.7-1.2 seconds so it might be diminishing returns, but if we can reduce it to max 500ms everywhere, I'd be pleased. No guarantees that it'll be a tenth of the time, but I expect it to be noticeable. It should be more gentle on the backend server's resources as well.

## `currentSeason` moved to the frontend
`currentSeason` was duplicated data from the `seasons` array. I moved the `currentSeason` assignment to the frontend so it can be a reference instead of sending duplicated data.

This is just fort the Park-level where we already have the seasons array. The feature-level currentSeason is not changed.

## `metadata` endpoint
Created a separate `/parks/metadata` endpoint to send the supplemental data needed for the filters. The /parks endpoint will only send data needed to display the table, and the filters will be disabled until the metadata is loaded in. (The metadata endpoint is faster than the main one, so there's no noticeable delay). The data is merged together automatically with a useMemo. If we ever set up server-side pagination, this will still work automatically because we can fetch all the metadata, and then the relevant bits will be merged into the individual page data as the page changes.

## Indexes
Added indexes to support the joins we're doing in this query. On my local environment it didn't actually speed it up that much, but maybe it'll be noticeable after many more seasons are added to the db.

I thought this would be a night-and-day performance gain on my slow local environment 🤷 I guess not!

I used raw queries instead of Sequelize `addIndex` so we can do "IF NOT EXIST" and make the migration idempotent.

## Parallelization
Split some of the nested queries into separate queries. We still need to run the main query first to get the IDs for the later queries, but then we can run the rest in parallel. This makes the main query a lot lighter and the whole operation much faster overall. This was the biggest performance gain in this branch.

# Fetch internal notes on demand
Moved the deeply-nested changelog->notes out of the main query, and now we're fetching them on demand in the InternalNotesRow component. I replaced it with an EXISTS query to simply check if there are notes without returning them. If we remove this (or move it to the metadata) I think we can speed it up even more.