### PR TITLE
CMS-1770: Pre-set "submitted" flag when previously saved with errors

### DIFF
--- a/frontend/src/components/FormPanel.jsx
+++ b/frontend/src/components/FormPanel.jsx
@@ -189,6 +189,7 @@ function SeasonForm({
     [seasonOptionsData],
   );
 
+  // Initialize the form data when the API data is loaded
   useEffect(() => {
     if (apiData) {
       // if the season if from a previous year then the user must be in the
@@ -199,6 +200,12 @@ function SeasonForm({
       ) {
         closePanel();
         return;
+      }
+
+      if (apiData.current.savedWithErrors) {
+        // Set the "submitted" flag to true, so the full form validation will run
+        // and re-validate on every change.
+        setSubmitted(true);
       }
 
       setData(apiData);

--- a/frontend/src/components/FormPanel.jsx
+++ b/frontend/src/components/FormPanel.jsx
@@ -206,6 +206,9 @@ function SeasonForm({
         // Set the "submitted" flag to true, so the full form validation will run
         // and re-validate on every change.
         setSubmitted(true);
+      } else {
+        // If loading new data, reset the submitted state to false.
+        setSubmitted(false);
       }
 
       setData(apiData);


### PR DESCRIPTION
### Jira Ticket

CMS-1770

### Description
<!-- What did you change, and why? -->

Requirements for the "Submit with errors" functionality: 
When you return to a form that was previously "Submitted with errors," run the full validation, show all errors, and re-validate on every field change.

This functionality already happens after you attempt to submit the form the first time (`submitted=true`) so this branch sets that flag to true as soon as the form loads, if `savedWithErrors` is true. I added this to the useEffect block that triggers when the API Data is first loaded.