### PR TITLE
CMS-1756: ACT history section fixes

### DIFF
--- a/frontend/src/components/advisories/composite/advisoryHistory/AdvisoryHistory.jsx
+++ b/frontend/src/components/advisories/composite/advisoryHistory/AdvisoryHistory.jsx
@@ -112,7 +112,10 @@ export default function AdvisoryHistory({
                     ? `${text} by ${creatorName} requested`
                     : text,
                   actorName: requesterName || creatorName,
-                  date: ad.modifiedDate || ad.createdDate || ad.createdAt,
+                  date:
+                    text === "created"
+                      ? ad.createdDate || ad.createdAt
+                      : ad.modifiedDate || ad.createdDate || ad.createdAt,
                 });
               } else {
                 if (status === "SCH") {


### PR DESCRIPTION
### Jira Ticket

CMS-1756

### Description
Minor fix to AdvisoryHistory.  The rest of the changes are in the other repo https://github.com/bcgov/bcparks.ca/pull/1899 

- Use `createdDate` for 'created' log entries instead of `modifiedDate`

