### PR TITLE
CMS-1875: Add winter fee boolean fields to park area and feature

### DIFF
--- a/backend/migrations/20260721103000-add-winter-fee-flags-to-parkarea-and-feature.js
+++ b/backend/migrations/20260721103000-add-winter-fee-flags-to-parkarea-and-feature.js
@@ -1,0 +1,21 @@
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn("ParkAreas", "hasWinterFeeDates", {
+      type: Sequelize.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    });
+
+    await queryInterface.addColumn("Features", "hasWinterFeeDates", {
+      type: Sequelize.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeColumn("ParkAreas", "hasWinterFeeDates");
+    await queryInterface.removeColumn("Features", "hasWinterFeeDates");
+  },
+};

--- a/backend/models/feature.js
+++ b/backend/models/feature.js
@@ -77,6 +77,12 @@ export default (sequelize) => {
         defaultValue: false,
       },
 
+      hasWinterFeeDates: {
+        type: DataTypes.BOOLEAN,
+        allowNull: false,
+        defaultValue: false,
+      },
+
       datesCanSpan2Years: {
         type: DataTypes.BOOLEAN,
         allowNull: false,

--- a/backend/models/parkarea.js
+++ b/backend/models/parkarea.js
@@ -60,6 +60,12 @@ export default (sequelize) => {
         defaultValue: false,
       },
 
+      hasWinterFeeDates: {
+        type: DataTypes.BOOLEAN,
+        allowNull: false,
+        defaultValue: false,
+      },
+
       orcsAreaNumber: {
         type: DataTypes.STRING,
         allowNull: true,

--- a/backend/routes/api/parks.js
+++ b/backend/routes/api/parks.js
@@ -98,6 +98,7 @@ function featureModel(minYear, where = {}, seasonStatus = null) {
       "name",
       "hasBackcountryPermits",
       "hasReservations",
+      "hasWinterFeeDates",
       "inReservationSystem",
       "datesCanSpan2Years",
     ],
@@ -244,6 +245,7 @@ function buildFeatureOutput(feature, seasons, includeCurrentSeason = true) {
     name: feature.name,
     hasBackcountryPermits: feature.hasBackcountryPermits,
     hasReservations: feature.hasReservations,
+    hasWinterFeeDates: feature.hasWinterFeeDates,
     inReservationSystem: feature.inReservationSystem,
     datesCanSpan2Years: feature.datesCanSpan2Years,
     featureType: {
@@ -285,6 +287,7 @@ function buildParkAreaOutput(parkArea) {
     publishableId: parkArea.publishableId,
     name: parkArea.name,
     inReservationSystem: parkArea.inReservationSystem,
+    hasWinterFeeDates: parkArea.hasWinterFeeDates,
     features: parkArea.features.map((feature) =>
       buildFeatureOutput(feature, parkArea.seasons, false),
     ),
@@ -346,6 +349,7 @@ router.get(
             "publishableId",
             "name",
             "inReservationSystem",
+            "hasWinterFeeDates",
           ],
           include: [
             // Features that are part of the ParkArea

--- a/backend/strapi-sync/import-features/README.md
+++ b/backend/strapi-sync/import-features/README.md
@@ -23,6 +23,7 @@ Imports and updates `Feature` records from Strapi's `park-feature` collection by
 | `hasReservations`               | `hasReservations`       | Defaults to `false` if not provided           |
 | `hasBackcountryPermits`         | `hasBackcountryPermits` | Defaults to `false` if not provided           |
 | `hasDates`                      | `hasDates`              | Defaults to `false` if not provided           |
+| `hasWinterFee`                  | `hasWinterFeeDates`     | Defaults to `false` if not provided           |
 | `datesCanSpan2Years`            | `datesCanSpan2Years`    | Required boolean from Strapi (`true`/`false`) |
 | `parkFeatureType.featureTypeId` | `featureTypeId`         | DOOT Feature Type, matched by well-known key  |
 | `protectedArea.orcs`            | `parkId`                | DOOT Park, matched by well-known key          |

--- a/backend/strapi-sync/import-features/import-features.js
+++ b/backend/strapi-sync/import-features/import-features.js
@@ -106,6 +106,7 @@ export default async function importStrapiFeatures(transaction = null) {
         hasReservations,
         hasBackcountryPermits,
         hasDates,
+        hasWinterFee,
         datesCanSpan2Years,
         protectedArea,
         parkArea,
@@ -170,12 +171,22 @@ export default async function importStrapiFeatures(transaction = null) {
         inReservationSystem: inReservationSystem ?? false,
         hasReservations: hasReservations ?? false,
         hasBackcountryPermits: hasBackcountryPermits ?? false,
+        hasWinterFeeDates: hasWinterFee ?? false,
         hasDates: hasDates ?? false,
         datesCanSpan2Years,
         parkId,
         parkAreaId,
         featureTypeId,
       };
+
+      if (
+        matchedDootFeature?.hasWinterFeeDates &&
+        dootFeatureToSave.hasWinterFeeDates === false
+      ) {
+        console.warn(
+          `Winter fee flag removed for Feature ${parkFeatureName} (${orcsFeatureNumber}). Existing winter seasons may need manual review.`,
+        );
+      }
 
       if (matchedDootFeature) {
         if (isActive && !matchedDootFeature.active) {

--- a/backend/strapi-sync/import-park-areas/README.md
+++ b/backend/strapi-sync/import-park-areas/README.md
@@ -17,6 +17,7 @@ Imports and updates `ParkArea` records from Strapi's `park-area` collection by m
 | `parkAreaName`            | `name`                | Park area name                                 |
 | `isActive`                | `active`              | Defaults to `false` if not provided            |
 | `inReservationSystem`     | `inReservationSystem` | Defaults to `false` if not provided            |
+| `hasWinterFee`            | `hasWinterFeeDates`   | Defaults to `false` if not provided            |
 | `orcsAreaNumber`          | `orcsAreaNumber`      | Used for matching existing records             |
 | `protectedArea.orcs`      | `parkId`              | DOOT Park ID, matched by ORCS value            |
 | `parkAreaType.areaTypeId` | `parkAreaTypeId`      | DOOT Park Area Type, matched by well-known key |

--- a/backend/strapi-sync/import-park-areas/import-park-areas.js
+++ b/backend/strapi-sync/import-park-areas/import-park-areas.js
@@ -94,6 +94,7 @@ export default async function importStrapiParkAreas(transaction = null) {
         parkAreaName,
         isActive,
         inReservationSystem,
+        hasWinterFee,
         protectedArea,
       } = strapiParkArea;
 
@@ -149,12 +150,22 @@ export default async function importStrapiParkAreas(transaction = null) {
 
       const dootParkAreaToSave = {
         name: parkAreaName,
-        orcsAreaNumber: orcsAreaNumber,
+        orcsAreaNumber,
         active: isActive ?? false,
         inReservationSystem: inReservationSystem ?? false,
+        hasWinterFeeDates: hasWinterFee ?? false,
         parkId,
         parkAreaTypeId,
       };
+
+      if (
+        matchedDootParkArea?.hasWinterFeeDates &&
+        dootParkAreaToSave.hasWinterFeeDates === false
+      ) {
+        console.warn(
+          `Winter fee flag removed for ParkArea ${parkAreaName} (${orcsAreaNumber}). Existing winter seasons may need manual review.`,
+        );
+      }
 
       if (matchedDootParkArea) {
         if (isActive && !matchedDootParkArea.active) {


### PR DESCRIPTION
### Jira Ticket

CMS-1875

### Description
<!-- What did you change, and why? -->
- Added winter fee boolean fields `hasWinterFeeDates` to park area and feature
- Updated the import script to import Strapi `hasWinterFee` value to park area and feature
- For testing:
  - Run `npm run migrate` to add `hasWinterFeeDates` to park area and feature
  - Run `npm run cron-task` to import Strapi `hasWinterFee` value to park area and feature
