### PR TITLE
CMS-1867: Show year range for applicable seasons

### DIFF
--- a/backend/routes/api/publish.js
+++ b/backend/routes/api/publish.js
@@ -202,7 +202,7 @@ router.get(
           {
             model: Feature,
             as: "features",
-            attributes: ["id", "name"],
+            attributes: ["id", "name", "datesCanSpan2Years"],
             include: [
               {
                 model: FeatureType,
@@ -215,7 +215,7 @@ router.get(
       }),
       Feature.findAll({
         where: { publishableId: { [Op.in]: publishableIds } },
-        attributes: ["id", "publishableId", "name"],
+        attributes: ["id", "publishableId", "name", "datesCanSpan2Years"],
         include: [
           { model: Park, as: "park", attributes: ["id", "name"] },
           { model: ParkArea, as: "parkArea", attributes: ["id", "name"] },
@@ -254,11 +254,29 @@ router.get(
       // Determine displayOperatingYear based on publishable type and season type
       let displayOperatingYear = season.operatingYear;
 
+      const operatingYear = Number(season.operatingYear);
+      const nextYear = operatingYear + 1;
+
+      // Show a display name for the operating year
       if (publishable?.type === "park") {
         displayOperatingYear =
           season.seasonType === SEASON_TYPE.WINTER
-            ? `${season.operatingYear} Winter fee`
-            : `${season.operatingYear} Tiers and gate`;
+            ? `${operatingYear} – ${nextYear} Winter fee`
+            : `${operatingYear} Tiers and gate`;
+      } else if (publishable?.type === "feature") {
+        // If Feature season dates can span 2 years, show both years
+        if (publishable.datesCanSpan2Years) {
+          displayOperatingYear = `${operatingYear} – ${nextYear}`;
+        }
+      } else if (publishable?.type === "parkArea") {
+        // If any Feature in the ParkArea has dates that can span 2 years, show both years
+        const canSpan2Years = publishable.features.some(
+          (feature) => feature.datesCanSpan2Years,
+        );
+
+        if (canSpan2Years) {
+          displayOperatingYear = `${operatingYear} – ${nextYear}`;
+        }
       }
 
       if (!publishable) {

--- a/frontend/src/components/FormPanel.jsx
+++ b/frontend/src/components/FormPanel.jsx
@@ -257,13 +257,15 @@ function SeasonForm({
     const operatingYear = season.operatingYear;
     const nextYear = operatingYear + 1;
 
-    if (season.datesCanSpan2Years) {
+    const isWinterSeason = season.seasonType === SEASON_TYPE.WINTER;
+
+    if (season.datesCanSpan2Years || isWinterSeason) {
       return `${operatingYear} – ${nextYear} dates`;
     }
 
     // Default: operating year
     return `${operatingYear} dates`;
-  }, [season?.datesCanSpan2Years, season?.operatingYear]);
+  }, [season?.datesCanSpan2Years, season?.operatingYear, season?.seasonType]);
 
   const seasonTitle = useMemo(() => {
     // Return blank while loading


### PR DESCRIPTION
CMS-1867: Show year range in form panel header for winter seasons
CMS-1867: Show year range in Publish table

### Jira Ticket

CMS-1867

### Description
<!-- What did you change, and why? -->

Updated the form panel to show a range of years for winter seasons (already implemented for 2-year Feature seasons)

Updated the Publish table to show a range of years for winter seasons and applicable Feature seasons, as well as ParkArea seasons with applicable features (`Feature.datesCanSpan2Years`)

<img width="1732" height="580" alt="image" src="https://github.com/user-attachments/assets/bf1e2133-2be9-4f0c-827e-69b8393b4ccf" />
