### PR TITLE
CMS-1297: Calculate Feature-level winter fee dates

### DIFF
--- a/backend/routes/api/parks.js
+++ b/backend/routes/api/parks.js
@@ -229,11 +229,11 @@ function buildFeatureOutput(feature, seasons, includeCurrentSeason = true) {
 
   // Temporarily disabling display of excluded types
   // @TODO: Remove this filter when FCFS logic is revised
-  const excludedDateTypes = new Set(["First come, first served"]);
+  const excludedDateTypes = new Set([DATE_TYPE.FIRST_COME_FIRST_SERVED]);
 
   // get date ranges for park.feature
   const featureDateRanges = getAllDateRanges(filteredSeasons).filter(
-    (dateRange) => !excludedDateTypes.has(dateRange.dateType?.name),
+    (dateRange) => !excludedDateTypes.has(dateRange.dateType?.dateTypeNumber),
   );
 
   const output = {

--- a/backend/routes/api/parks.js
+++ b/backend/routes/api/parks.js
@@ -228,9 +228,8 @@ function buildFeatureOutput(feature, seasons, includeCurrentSeason = true) {
     });
 
   // Temporarily disabling display of excluded types
-  // @TODO: Remove this filter when Winter fee logic is revised (CMS-898)
   // @TODO: Remove this filter when FCFS logic is revised
-  const excludedDateTypes = new Set(["Winter fee", "First come, first served"]);
+  const excludedDateTypes = new Set(["First come, first served"]);
 
   // get date ranges for park.feature
   const featureDateRanges = getAllDateRanges(filteredSeasons).filter(
@@ -267,10 +266,7 @@ function buildFeatureOutput(feature, seasons, includeCurrentSeason = true) {
 // build park area output object
 function buildParkAreaOutput(parkArea) {
   // get date ranges for parkArea
-  const parkAreaDateRanges = getAllDateRanges(parkArea.seasons)
-    // Temporarily disabling display of Winter Fees
-    // @TODO: Remove this filter when Winter fee logic is revised (CMS-898)
-    .filter((dateRange) => dateRange.dateType?.name !== "Winter fee");
+  const parkAreaDateRanges = getAllDateRanges(parkArea.seasons);
 
   // Get a distinct list of feature types in the park area for filtering purposes
   const featureTypes = _.uniqBy(

--- a/backend/routes/api/seasons.js
+++ b/backend/routes/api/seasons.js
@@ -684,12 +684,14 @@ async function saveSeasonData({
  * Detects whether the request changes any Operation date ranges.
  * Checks both updated/created dateRanges and deleted dateRange IDs.
  * @param {Object} params Parameters for operation-date change detection
+ * @param {number} params.seasonId Season ID being saved
  * @param {Array} params.dateRanges DateRanges from the request payload
  * @param {Array<number>} params.deletedDateRangeIds DateRange IDs marked for deletion
  * @param {Transaction} params.transaction Database transaction
  * @returns {Promise<boolean>} True when Operation dates are changed
  */
 async function hasOperationDateChanges({
+  seasonId,
   dateRanges,
   deletedDateRangeIds,
   transaction,
@@ -710,24 +712,10 @@ async function hasOperationDateChanges({
     return false;
   }
 
-  const hasOperationInPayload = (dateRanges || []).some((dateRange) =>
-    operationDateTypeIds.has(dateRange.dateTypeId),
-  );
-
-  if (hasOperationInPayload) {
-    return true;
-  }
-
-  if (!deletedDateRangeIds?.length) {
-    return false;
-  }
-
-  const deletedOperationDate = await DateRange.findOne({
-    attributes: ["id"],
+  const existingOperationRanges = await DateRange.findAll({
+    attributes: ["id", "dateTypeId", "dateableId", "startDate", "endDate"],
     where: {
-      id: {
-        [Op.in]: deletedDateRangeIds,
-      },
+      seasonId,
       dateTypeId: {
         [Op.in]: Array.from(operationDateTypeIds),
       },
@@ -735,7 +723,62 @@ async function hasOperationDateChanges({
     transaction,
   });
 
-  return Boolean(deletedOperationDate);
+  const existingById = new Map(
+    existingOperationRanges.map((range) => [range.id, range]),
+  );
+
+  // New operation ranges (no ID) are always a change.
+  const hasOperationCreate = (dateRanges || []).some(
+    (dateRange) =>
+      !dateRange.id && operationDateTypeIds.has(dateRange.dateTypeId),
+  );
+
+  if (hasOperationCreate) {
+    return true;
+  }
+
+  // Updated operation ranges: same ID but changed values.
+  const hasOperationUpdate = (dateRanges || []).some((dateRange) => {
+    if (!dateRange.id) {
+      return false;
+    }
+
+    const existing = existingById.get(dateRange.id);
+
+    if (!existing) {
+      return false;
+    }
+
+    const incomingTypeId = dateRange.dateTypeId;
+
+    // Existing operation range changed to a non-operation type.
+    if (!operationDateTypeIds.has(incomingTypeId)) {
+      return true;
+    }
+
+    const incomingStart = dateRange.startDate ?? null;
+    const incomingEnd = dateRange.endDate ?? null;
+    const existingStart = existing.startDate ?? null;
+    const existingEnd = existing.endDate ?? null;
+    const incomingDateableId = dateRange.dateableId ?? existing.dateableId;
+
+    return (
+      incomingDateableId !== existing.dateableId ||
+      incomingStart !== existingStart ||
+      incomingEnd !== existingEnd
+    );
+  });
+
+  if (hasOperationUpdate) {
+    return true;
+  }
+
+  if (!deletedDateRangeIds?.length) {
+    return false;
+  }
+
+  // Deleting an existing operation range is a change.
+  return deletedDateRangeIds.some((id) => existingById.has(id));
 }
 
 // Get all form data and DateRanges for a Feature Season
@@ -1273,6 +1316,7 @@ router.post(
       // Determine if this is a winter season based on seasonType
       const isWinterSeason = season.seasonType === SEASON_TYPE.WINTER;
       const operationDateChanged = await hasOperationDateChanges({
+        seasonId: season.id,
         dateRanges,
         deletedDateRangeIds,
         transaction,

--- a/backend/routes/api/seasons.js
+++ b/backend/routes/api/seasons.js
@@ -34,7 +34,7 @@ import { checkPermissions } from "../../middleware/permissions.js";
 import * as USER_ROLES from "../../constants/userRoles.js";
 
 // import { createFirstComeFirstServedDateRange } from "../../utils/firstComeFirstServedHelper.js";
-// import propagateWinterFeeDates from "../../utils/propagateWinterFeeDates.js";
+import propagateWinterFeeDates from "../../utils/propagateWinterFeeDates.js";
 import checkUserRoles, {
   getRolesFromAuth,
 } from "../../utils/checkUserRoles.js";
@@ -1230,6 +1230,12 @@ router.post(
         transaction,
         isWinterSeason,
       });
+
+      // Recalculate Feature-level Winter fee dates whenever an approver saves this
+      // season as approved (including edit-published updates by operating year).
+      if (newStatus === STATUS.APPROVED) {
+        await propagateWinterFeeDates(season.id, transaction);
+      }
 
       await transaction.commit();
       res.sendStatus(200);

--- a/backend/routes/api/seasons.js
+++ b/backend/routes/api/seasons.js
@@ -35,6 +35,7 @@ import * as USER_ROLES from "../../constants/userRoles.js";
 
 // import { createFirstComeFirstServedDateRange } from "../../utils/firstComeFirstServedHelper.js";
 import propagateWinterFeeDates from "../../utils/propagateWinterFeeDates.js";
+import hasOperationDateChanges from "../../utils/hasOperationDateChanges.js";
 import checkUserRoles, {
   getRolesFromAuth,
 } from "../../utils/checkUserRoles.js";
@@ -678,103 +679,6 @@ async function saveSeasonData({
     saveDateRangeAnnuals,
     saveGateDetail,
   ]);
-}
-
-/**
- * Detects whether the request changes any Operation date ranges.
- * Checks both updated/created dateRanges and deleted dateRange IDs.
- * @param {Object} params Parameters for operation-date change detection
- * @param {number} params.seasonId Season ID being saved
- * @param {Array} params.dateRanges DateRanges from the request payload
- * @param {Array<number>} params.deletedDateRangeIds DateRange IDs marked for deletion
- * @param {Transaction} params.transaction Database transaction
- * @returns {Promise<boolean>} True when Operation dates are changed
- */
-async function hasOperationDateChanges({
-  seasonId,
-  dateRanges,
-  deletedDateRangeIds,
-  transaction,
-}) {
-  const operationDateType = await DateType.findOne({
-    attributes: ["id"],
-    where: {
-      dateTypeNumber: DATE_TYPE.OPERATION,
-    },
-    transaction,
-  });
-
-  if (!operationDateType) {
-    return false;
-  }
-
-  const operationDateTypeId = operationDateType.id;
-
-  const existingOperationRanges = await DateRange.findAll({
-    attributes: ["id", "dateTypeId", "dateableId", "startDate", "endDate"],
-    where: {
-      seasonId,
-      dateTypeId: operationDateTypeId,
-    },
-    transaction,
-  });
-
-  const existingById = new Map(
-    existingOperationRanges.map((range) => [range.id, range]),
-  );
-
-  // New operation ranges (no ID) are always a change.
-  const hasOperationCreate = (dateRanges || []).some(
-    (dateRange) =>
-      !dateRange.id && dateRange.dateTypeId === operationDateTypeId,
-  );
-
-  if (hasOperationCreate) {
-    return true;
-  }
-
-  // Updated operation ranges: same ID but changed values.
-  const hasOperationUpdate = (dateRanges || []).some((dateRange) => {
-    if (!dateRange.id) {
-      return false;
-    }
-
-    const existing = existingById.get(dateRange.id);
-
-    if (!existing) {
-      return false;
-    }
-
-    const incomingTypeId = dateRange.dateTypeId;
-
-    // Existing operation range changed to a non-operation type.
-    if (incomingTypeId !== operationDateTypeId) {
-      return true;
-    }
-
-    const incomingStart = dateRange.startDate ?? null;
-    const incomingEnd = dateRange.endDate ?? null;
-    const existingStart = existing.startDate ?? null;
-    const existingEnd = existing.endDate ?? null;
-    const incomingDateableId = dateRange.dateableId ?? existing.dateableId;
-
-    return (
-      incomingDateableId !== existing.dateableId ||
-      incomingStart !== existingStart ||
-      incomingEnd !== existingEnd
-    );
-  });
-
-  if (hasOperationUpdate) {
-    return true;
-  }
-
-  if (!deletedDateRangeIds?.length) {
-    return false;
-  }
-
-  // Deleting an existing operation range is a change.
-  return deletedDateRangeIds.some((id) => existingById.has(id));
 }
 
 // Get all form data and DateRanges for a Feature Season

--- a/backend/routes/api/seasons.js
+++ b/backend/routes/api/seasons.js
@@ -696,7 +696,7 @@ async function hasOperationDateChanges({
   deletedDateRangeIds,
   transaction,
 }) {
-  const operationDateTypes = await DateType.findAll({
+  const operationDateType = await DateType.findOne({
     attributes: ["id"],
     where: {
       dateTypeNumber: DATE_TYPE.OPERATION,
@@ -704,21 +704,17 @@ async function hasOperationDateChanges({
     transaction,
   });
 
-  const operationDateTypeIds = new Set(
-    operationDateTypes.map((dateType) => dateType.id),
-  );
-
-  if (operationDateTypeIds.size === 0) {
+  if (!operationDateType) {
     return false;
   }
+
+  const operationDateTypeId = operationDateType.id;
 
   const existingOperationRanges = await DateRange.findAll({
     attributes: ["id", "dateTypeId", "dateableId", "startDate", "endDate"],
     where: {
       seasonId,
-      dateTypeId: {
-        [Op.in]: Array.from(operationDateTypeIds),
-      },
+      dateTypeId: operationDateTypeId,
     },
     transaction,
   });
@@ -730,7 +726,7 @@ async function hasOperationDateChanges({
   // New operation ranges (no ID) are always a change.
   const hasOperationCreate = (dateRanges || []).some(
     (dateRange) =>
-      !dateRange.id && operationDateTypeIds.has(dateRange.dateTypeId),
+      !dateRange.id && dateRange.dateTypeId === operationDateTypeId,
   );
 
   if (hasOperationCreate) {
@@ -752,7 +748,7 @@ async function hasOperationDateChanges({
     const incomingTypeId = dateRange.dateTypeId;
 
     // Existing operation range changed to a non-operation type.
-    if (!operationDateTypeIds.has(incomingTypeId)) {
+    if (incomingTypeId !== operationDateTypeId) {
       return true;
     }
 
@@ -1338,7 +1334,7 @@ router.post(
         isWinterSeason,
       });
 
-      // Recalculate feature-level Winter fee dates when park-level Winter fee dates are updated,
+      // Recalculate feature-level Winter fee dates when a Winter season is saved,
       // or when feature-level Operation dates are changed.
       if (isWinterSeason || operationDateChanged) {
         await propagateWinterFeeDates(season.id, transaction);

--- a/backend/routes/api/seasons.js
+++ b/backend/routes/api/seasons.js
@@ -680,6 +680,64 @@ async function saveSeasonData({
   ]);
 }
 
+/**
+ * Detects whether the request changes any Operation date ranges.
+ * Checks both updated/created dateRanges and deleted dateRange IDs.
+ * @param {Object} params Parameters for operation-date change detection
+ * @param {Array} params.dateRanges DateRanges from the request payload
+ * @param {Array<number>} params.deletedDateRangeIds DateRange IDs marked for deletion
+ * @param {Transaction} params.transaction Database transaction
+ * @returns {Promise<boolean>} True when Operation dates are changed
+ */
+async function hasOperationDateChanges({
+  dateRanges,
+  deletedDateRangeIds,
+  transaction,
+}) {
+  const operationDateTypes = await DateType.findAll({
+    attributes: ["id"],
+    where: {
+      dateTypeNumber: DATE_TYPE.OPERATION,
+    },
+    transaction,
+  });
+
+  const operationDateTypeIds = new Set(
+    operationDateTypes.map((dateType) => dateType.id),
+  );
+
+  if (operationDateTypeIds.size === 0) {
+    return false;
+  }
+
+  const hasOperationInPayload = (dateRanges || []).some((dateRange) =>
+    operationDateTypeIds.has(dateRange.dateTypeId),
+  );
+
+  if (hasOperationInPayload) {
+    return true;
+  }
+
+  if (!deletedDateRangeIds?.length) {
+    return false;
+  }
+
+  const deletedOperationDate = await DateRange.findOne({
+    attributes: ["id"],
+    where: {
+      id: {
+        [Op.in]: deletedDateRangeIds,
+      },
+      dateTypeId: {
+        [Op.in]: Array.from(operationDateTypeIds),
+      },
+    },
+    transaction,
+  });
+
+  return Boolean(deletedOperationDate);
+}
+
 // Get all form data and DateRanges for a Feature Season
 router.get(
   "/feature/:seasonId",
@@ -1214,6 +1272,11 @@ router.post(
 
       // Determine if this is a winter season based on seasonType
       const isWinterSeason = season.seasonType === SEASON_TYPE.WINTER;
+      const operationDateChanged = await hasOperationDateChanges({
+        dateRanges,
+        deletedDateRangeIds,
+        transaction,
+      });
 
       // Process season data
       await saveSeasonData({
@@ -1231,9 +1294,9 @@ router.post(
         isWinterSeason,
       });
 
-      // Recalculate Feature-level Winter fee dates whenever an approver saves this
-      // season as approved (including edit-published updates by operating year).
-      if (newStatus === STATUS.APPROVED) {
+      // Recalculate feature-level Winter fee dates when park-level Winter fee dates are updated,
+      // or when feature-level Operation dates are changed.
+      if (isWinterSeason || operationDateChanged) {
         await propagateWinterFeeDates(season.id, transaction);
       }
 

--- a/backend/tasks/create-winter-seasons/README.md
+++ b/backend/tasks/create-winter-seasons/README.md
@@ -6,7 +6,7 @@ Creation rules:
 
 - Park-level Winter seasons are created from `park.hasWinterFeeDates = true`.
 - ParkArea/Feature-level Winter seasons are created from `feature.hasWinterFeeDates = true`.
-- `parkArea.hasWinterFeeDates` is ignored for season creation.
+- `parkArea.hasWinterFeeDates` is ignored for season creation, because ParkArea publishables do not own the feature-level Winter fee DateRanges used by this flow.
 
 ## What does the script do?
 
@@ -97,6 +97,6 @@ Done creating winter seasons for 2027
 - Winter seasons are created with `readyToPublish = true`
 - Park-level creation is driven by `park.hasWinterFeeDates`
 - ParkArea/Feature-level creation is driven by `feature.hasWinterFeeDates`
-- `parkArea.hasWinterFeeDates` is not used by this script
+- `parkArea.hasWinterFeeDates` is not used by this script, because this flow creates Winter seasons from feature-level ownership (or park-level ownership), not a ParkArea-level Winter fee DateRange source.
 - If you need to add winter fee capability to additional parks, set `hasWinterFeeDates = true` on those parks first
 - The operating year parameter is required and must be a valid number (e.g., 2027)

--- a/backend/tasks/create-winter-seasons/README.md
+++ b/backend/tasks/create-winter-seasons/README.md
@@ -1,6 +1,12 @@
 # create-winter-seasons.js
 
-This script creates winter seasons for parks that have winter fee dates (`hasWinterFeeDates = true`) and migrates Winter fee DateRanges from regular seasons to winter seasons. It ensures that Winter fee DateRanges only exist in winter seasons, not in regular seasons.
+This script creates Winter seasons and placeholder Winter fee DateRanges for the specified operating year.
+
+Creation rules:
+
+- Park-level Winter seasons are created from `park.hasWinterFeeDates = true`.
+- ParkArea/Feature-level Winter seasons are created from `feature.hasWinterFeeDates = true`.
+- `parkArea.hasWinterFeeDates` is ignored for season creation.
 
 ## What does the script do?
 
@@ -8,21 +14,31 @@ This script creates winter seasons for parks that have winter fee dates (`hasWin
    - Finds all parks where `hasWinterFeeDates = true`
    - Ensures each park has required `publishableId` and `dateableId` (creates them if missing)
 
-2. **Creates winter seasons for the specified operating year:**
-   - Creates new seasons with `seasonType = "winter"`
-   - Sets `status = "REQUESTED"` and `readyToPublish = true` (requires manual approval)
-   - Skips creation if a winter season already exists for the park and year
+2. **Identifies and processes features with winter fee dates:**
+   - Finds all active features where `hasWinterFeeDates = true`
+   - Ensures each feature has required `dateableId` (creates it if missing)
+   - If a feature belongs to a park area, creates/uses the Winter season on the parent park area's `publishableId`
+   - If a feature is independent (no park area), creates/uses a Winter season on the feature's own `publishableId`
 
-3. **Creates Winter fee DateRanges in winter seasons:**
+3. **Creates winter seasons for the specified operating year:**
+   - Creates new seasons with `seasonType = "winter"`
+   - Sets `status` using `resolveNewSeasonStatus(...)` and `readyToPublish = true`
+   - Skips creation if a Winter season already exists for the same publishable/year
+
+4. **Creates Winter fee DateRanges in winter seasons:**
    - Creates new Winter fee DateRanges linked to the winter seasons
-   - Sets `startDate = null` and `endDate = null` (to be filled later by park staff)
+   - Sets `startDate = null` and `endDate = null` (placeholder; later filled/calculated)
    - Uses the "Winter fee" DateType from the database
 
-4. **All operations are performed inside a transaction** for safety and atomicity.
+5. **Creates DateRangeAnnual only for park-level Winter fee setup:**
+   - Park-level Winter fee DateRanges get `DateRangeAnnual` entries
+   - ParkArea/Feature-level Winter fee DateRanges do not get `DateRangeAnnual` entries
+
+6. **All operations are performed inside a transaction** for safety and atomicity.
 
 ## How does it find Winter fee DateType?
 
-- The script queries the database for a DateType with `name = "Winter fee"`
+- The script queries the database for a DateType with `dateTypeNumber = WINTER_FEE`
 - If this DateType doesn't exist, the script exits with an error
 - This DateType must exist in your database before running the script
 
@@ -40,20 +56,24 @@ node tasks/create-winter-seasons/create-winter-seasons.js 2027
 ## Output
 
 ```
-Creating Winter Seasons for 2027
-Found Winter fee DateType: 5
+STARTING CREATE-WINTER-SEASONS FOR OPERATING YEAR 2027
+
 Found 12 Parks with Winter Fee Dates
+Found 8 Features with Winter Fee Dates
 Created winter season for Cypress Provincial Park (Publishable 123) - 2027
 Created winter fee date range for Cypress Provincial Park (Season 456)
+Created winter season for Cypress Frontcountry Area (park area) (Publishable 789) - 2027
+Created winter fee date range for Cypress Frontcountry Campground (Cypress Frontcountry Area) (Season 987)
 ...
 
 Summary:
-Added 0 missing Park Publishables
-Added 0 missing Park Dateables
+Added 0 missing Publishables
+Added 0 missing Dateables
 Added 11 new Winter Seasons
 Added 11 new Winter Fee DateRanges
-Committing transaction...
-Done
+Added 3 new Park-level Winter Fee DateRangeAnnuals
+
+Done creating winter seasons for 2027
 ```
 
 - The script logs each park being processed and the actions taken
@@ -74,8 +94,9 @@ Done
 
 - The script assumes your Sequelize models and associations are set up as in the rest of the BC Parks Staff Portal project
 - You can safely run this script multiple times; it will not create duplicates and will skip existing records
-- Winter seasons are created with `readyToPublish = true` and must be manually approved before publishing
-- The script only processes parks with `hasWinterFeeDates = true` - other parks are ignored
+- Winter seasons are created with `readyToPublish = true`
+- Park-level creation is driven by `park.hasWinterFeeDates`
+- ParkArea/Feature-level creation is driven by `feature.hasWinterFeeDates`
+- `parkArea.hasWinterFeeDates` is not used by this script
 - If you need to add winter fee capability to additional parks, set `hasWinterFeeDates = true` on those parks first
-- Winter fee DateRanges are **moved**, not copied - they will no longer exist in regular seasons after running this script
 - The operating year parameter is required and must be a valid number (e.g., 2027)

--- a/backend/tasks/create-winter-seasons/create-winter-seasons.js
+++ b/backend/tasks/create-winter-seasons/create-winter-seasons.js
@@ -1,4 +1,7 @@
-// This script creates winter seasons for parks that have hasWinterFeeDates = true.
+// This script creates winter seasons using these drivers:
+// - Park-level winter seasons: park.hasWinterFeeDates = true
+// - ParkArea/Feature-level winter seasons: feature.hasWinterFeeDates = true
+// - parkArea.hasWinterFeeDates is intentionally ignored
 // It will skip creating a season if one already exists for the given operating year and publishable.
 
 import "../../env.js";
@@ -9,6 +12,7 @@ import {
   DateType,
   Feature,
   Park,
+  ParkArea,
   Season,
 } from "../../models/index.js";
 import * as DATE_TYPE from "../../constants/dateType.js";
@@ -40,8 +44,8 @@ export default async function createWinterSeasons(
   let winterDateRangeAnnualsAdded = 0;
 
   /**
-   * Creates a new Publishable ID for a Park/Feature when missing.
-   * @param {Park} record The record to check and update
+   * Creates a new Publishable ID for a Park/Feature/ParkArea when missing.
+   * @param {Park|Feature|ParkArea} record The record to check and update
    * @returns {Promise<number>} The record's Publishable ID
    */
   async function createPublishable(record) {
@@ -53,8 +57,8 @@ export default async function createWinterSeasons(
   }
 
   /**
-   * Creates a new Dateable ID a Park/Feature when missing.
-   * @param {Park} record The record to check and update
+   * Creates a new Dateable ID a Park/Feature/ParkArea when missing.
+   * @param {Park|Feature|ParkArea} record The record to check and update
    * @returns {Promise<number>} The record's Dateable ID
    */
   async function createDateable(record) {
@@ -132,6 +136,7 @@ export default async function createWinterSeasons(
     const existingDateRange = await DateRange.findOne({
       where: {
         seasonId,
+        dateableId,
         dateTypeId: winterFeeDateTypeId,
       },
       transaction,
@@ -227,11 +232,6 @@ export default async function createWinterSeasons(
     `Found ${parksWithWinterFees.length} Parks with Winter Fee Dates`,
   );
 
-  if (parksWithWinterFees.length === 0) {
-    console.log("No parks with winter fee dates found. Exiting.");
-    return;
-  }
-
   // Process each park
   const parkQueries = parksWithWinterFees.map(async (park) => {
     // Ensure the park has a publishableId
@@ -266,7 +266,8 @@ export default async function createWinterSeasons(
 
   await Promise.all(parkQueries);
 
-  // Create winter seasons for Features flagged for winter fees
+  // Create winter seasons for Features flagged for winter fees.
+  // This is the only driver for ParkArea/Feature-level winter seasons.
   const featuresWithWinterFees = await Feature.findAll({
     attributes: [
       "id",
@@ -280,6 +281,14 @@ export default async function createWinterSeasons(
       hasWinterFeeDates: true,
       active: true,
     },
+    include: [
+      {
+        model: ParkArea,
+        as: "parkArea",
+        attributes: ["id", "name", "publishableId", "dateableId"],
+        required: false,
+      },
+    ],
     transaction,
   });
 
@@ -288,40 +297,59 @@ export default async function createWinterSeasons(
   );
 
   const featureQueries = featuresWithWinterFees.map(async (feature) => {
-    const publishableId = await createPublishable(feature);
-    const dateableId = await createDateable(feature);
+    const featureDateableId =
+      feature.dateableId || (await createDateable(feature));
+
+    // Feature belongs to a ParkArea:
+    // create/update winter season under ParkArea publishable, keyed by feature dateable.
+    // Do not consult parkArea.hasWinterFeeDates.
+    if (feature.parkArea) {
+      const parkAreaPublishableId =
+        feature.parkArea.publishableId ||
+        (await createPublishable(feature.parkArea));
+
+      const parkAreaWinterSeasonId = await createWinterSeason(
+        parkAreaPublishableId,
+        operatingYear,
+        `${feature.parkArea.name} (park area)`,
+      );
+
+      await createWinterFeeDateRange(
+        parkAreaWinterSeasonId,
+        featureDateableId,
+        winterFeeDateType.id,
+        `${feature.name} (${feature.parkArea.name})`,
+      );
+
+      return;
+    }
+
+    // Independent Features (without a ParkArea) own Winter seasons.
+    const featurePublishableId = await createPublishable(feature);
 
     const winterSeasonId = await createWinterSeason(
-      publishableId,
+      featurePublishableId,
       operatingYear,
       feature.name,
     );
 
-    if (winterSeasonId) {
-      await createWinterFeeDateRange(
-        winterSeasonId,
-        dateableId,
-        winterFeeDateType.id,
-        feature.name,
-      );
-
-      await ensureWinterDateRangeAnnual(
-        publishableId,
-        dateableId,
-        winterFeeDateType.id,
-      );
-    }
+    await createWinterFeeDateRange(
+      winterSeasonId,
+      featureDateableId,
+      winterFeeDateType.id,
+      feature.name,
+    );
   });
 
   await Promise.all(featureQueries);
 
   console.log(`\nSummary:`);
-  console.log(`Added ${publishablesAdded} missing Park Publishables`);
-  console.log(`Added ${dateablesAdded} missing Park Dateables`);
+  console.log(`Added ${publishablesAdded} missing Publishables`);
+  console.log(`Added ${dateablesAdded} missing Dateables`);
   console.log(`Added ${winterSeasonsAdded} new Winter Seasons`);
   console.log(`Added ${winterDateRangesAdded} new Winter Fee DateRanges`);
   console.log(
-    `Added ${winterDateRangeAnnualsAdded} new Winter Fee DateRangeAnnuals`,
+    `Added ${winterDateRangeAnnualsAdded} new Park-level Winter Fee DateRangeAnnuals`,
   );
 
   console.log(`Done creating winter seasons for ${operatingYear}\n`);

--- a/backend/tasks/create-winter-seasons/create-winter-seasons.js
+++ b/backend/tasks/create-winter-seasons/create-winter-seasons.js
@@ -1,8 +1,17 @@
 // This script creates winter seasons using these drivers:
-// - Park-level winter seasons: park.hasWinterFeeDates = true
-// - ParkArea/Feature-level winter seasons: feature.hasWinterFeeDates = true
+//
+// Park-level
+// - winter seasons: park.hasWinterFeeDates = true
+// - DateRangeAnnual for the winter fee date type
+// - winter fee dates
+//
+// ParkArea/Feature-level
+// - winter seasons: feature.hasWinterFeeDates = true
+// - feature-level winter fee dates
 // - parkArea.hasWinterFeeDates is intentionally ignored
-// It will skip creating a season if one already exists for the given operating year and publishable.
+//
+// It skips creating a season when one already exists
+// for the given operating year and publishable.
 
 import "../../env.js";
 

--- a/backend/tasks/create-winter-seasons/create-winter-seasons.js
+++ b/backend/tasks/create-winter-seasons/create-winter-seasons.js
@@ -3,7 +3,15 @@
 
 import "../../env.js";
 
-import { DateRange, DateType, Park, Season } from "../../models/index.js";
+import {
+  DateRange,
+  DateRangeAnnual,
+  DateType,
+  Feature,
+  Park,
+  Season,
+} from "../../models/index.js";
+import * as DATE_TYPE from "../../constants/dateType.js";
 import * as SEASON_TYPE from "../../constants/seasonType.js";
 import resolveNewSeasonStatus from "../../utils/resolveNewSeasonStatus.js";
 import {
@@ -29,9 +37,10 @@ export default async function createWinterSeasons(
   let dateablesAdded = 0;
   let winterSeasonsAdded = 0;
   let winterDateRangesAdded = 0;
+  let winterDateRangeAnnualsAdded = 0;
 
   /**
-   * Creates a new Publishable ID and associates it with the given record, if it doesn't already have one.
+   * Creates a new Publishable ID for a Park/Feature when missing.
    * @param {Park} record The record to check and update
    * @returns {Promise<number>} The record's Publishable ID
    */
@@ -44,7 +53,7 @@ export default async function createWinterSeasons(
   }
 
   /**
-   * Creates a new Dateable ID and associates it with the given record, if it doesn't already have one.
+   * Creates a new Dateable ID a Park/Feature when missing.
    * @param {Park} record The record to check and update
    * @returns {Promise<number>} The record's Dateable ID
    */
@@ -57,13 +66,13 @@ export default async function createWinterSeasons(
   }
 
   /**
-   * Creates a new Winter Season for the given Publishable ID and operating year, if it doesn't already exist.
+   * Creates a new Winter Season for a publishable/year pair if one does not exist.
    * @param {number} publishableId The Publishable ID to check
    * @param {number} year The operating year for the season
-   * @param {string} parkName The park name for logging
+   * @param {string} itemName The park or feature name for logging
    * @returns {Promise<number|null>} The ID of the created Season, or existing season ID
    */
-  async function createWinterSeason(publishableId, year, parkName) {
+  async function createWinterSeason(publishableId, year, itemName) {
     // Check if a winter season already exists for this Publishable ID and Operating Year
     const existingSeason = await Season.findOne({
       where: {
@@ -99,25 +108,25 @@ export default async function createWinterSeasons(
 
     winterSeasonsAdded++;
     console.log(
-      `Created winter season for ${parkName} (Publishable ${publishableId}) - ${year}`,
+      `Created winter season for ${itemName} (Publishable ${publishableId}) - ${year}`,
     );
 
     return newSeason.id;
   }
 
   /**
-   * Creates a DateRange for the given season and dateable with Winter fee date type.
+   * Creates a placeholder Winter fee DateRange for the season/dateable when missing.
    * @param {number} seasonId The Season ID
    * @param {number} dateableId The Dateable ID
    * @param {number} winterFeeDateTypeId The Winter fee DateType ID
-   * @param {string} parkName The park name for logging
+   * @param {string} itemName The park or feature name for logging
    * @returns {Promise<number|null>} The ID of the created DateRange, or existing DateRange ID
    */
   async function createWinterFeeDateRange(
     seasonId,
     dateableId,
     winterFeeDateTypeId,
-    parkName,
+    itemName,
   ) {
     // Check if a winter fee date range already exists for this season
     const existingDateRange = await DateRange.findOne({
@@ -147,16 +156,49 @@ export default async function createWinterSeasons(
 
     winterDateRangesAdded++;
     console.log(
-      `Created winter fee date range for ${parkName} (Season ${seasonId})`,
+      `Created winter fee date range for ${itemName} (Season ${seasonId})`,
     );
 
     return newDateRange.id;
   }
 
-  // Get the Winter fee DateType
+  /**
+   * Creates a DateRangeAnnual entry for a winter season Dateable, if missing.
+   * @param {number} publishableId Publishable ID for the season
+   * @param {number} dateableId Dateable ID for the winter date range
+   * @param {number} winterFeeDateTypeId Winter fee DateType ID
+   * @returns {Promise<void>}
+   */
+  async function ensureWinterDateRangeAnnual(
+    publishableId,
+    dateableId,
+    winterFeeDateTypeId,
+  ) {
+    const [, created] = await DateRangeAnnual.findOrCreate({
+      where: {
+        publishableId,
+        dateableId,
+        dateTypeId: winterFeeDateTypeId,
+      },
+      defaults: {
+        publishableId,
+        dateableId,
+        dateTypeId: winterFeeDateTypeId,
+        isDateRangeAnnual: false,
+      },
+      transaction,
+    });
+
+    if (created) {
+      winterDateRangeAnnualsAdded++;
+    }
+  }
+
+  // Get the Winter fee DateType (used for both park and feature level dates)
   const winterFeeDateType = await DateType.findOne({
+    attributes: ["id"],
     where: {
-      name: "Winter fee",
+      dateTypeNumber: DATE_TYPE.WINTER_FEE,
     },
     transaction,
   });
@@ -213,16 +255,74 @@ export default async function createWinterSeasons(
         winterFeeDateType.id,
         park.name,
       );
+
+      await ensureWinterDateRangeAnnual(
+        publishableId,
+        dateableId,
+        winterFeeDateType.id,
+      );
     }
   });
 
   await Promise.all(parkQueries);
+
+  // Create winter seasons for Features flagged for winter fees
+  const featuresWithWinterFees = await Feature.findAll({
+    attributes: [
+      "id",
+      "name",
+      "publishableId",
+      "dateableId",
+      "hasWinterFeeDates",
+      "active",
+    ],
+    where: {
+      hasWinterFeeDates: true,
+      active: true,
+    },
+    transaction,
+  });
+
+  console.log(
+    `Found ${featuresWithWinterFees.length} Features with Winter Fee Dates`,
+  );
+
+  const featureQueries = featuresWithWinterFees.map(async (feature) => {
+    const publishableId = await createPublishable(feature);
+    const dateableId = await createDateable(feature);
+
+    const winterSeasonId = await createWinterSeason(
+      publishableId,
+      operatingYear,
+      feature.name,
+    );
+
+    if (winterSeasonId) {
+      await createWinterFeeDateRange(
+        winterSeasonId,
+        dateableId,
+        winterFeeDateType.id,
+        feature.name,
+      );
+
+      await ensureWinterDateRangeAnnual(
+        publishableId,
+        dateableId,
+        winterFeeDateType.id,
+      );
+    }
+  });
+
+  await Promise.all(featureQueries);
 
   console.log(`\nSummary:`);
   console.log(`Added ${publishablesAdded} missing Park Publishables`);
   console.log(`Added ${dateablesAdded} missing Park Dateables`);
   console.log(`Added ${winterSeasonsAdded} new Winter Seasons`);
   console.log(`Added ${winterDateRangesAdded} new Winter Fee DateRanges`);
+  console.log(
+    `Added ${winterDateRangeAnnualsAdded} new Winter Fee DateRangeAnnuals`,
+  );
 
   console.log(`Done creating winter seasons for ${operatingYear}\n`);
 }

--- a/backend/tasks/create-winter-seasons/create-winter-seasons.js
+++ b/backend/tasks/create-winter-seasons/create-winter-seasons.js
@@ -57,7 +57,7 @@ export default async function createWinterSeasons(
   }
 
   /**
-   * Creates a new Dateable ID a Park/Feature/ParkArea when missing.
+   * Creates a new Dateable ID for a Park/Feature/ParkArea when missing.
    * @param {Park|Feature|ParkArea} record The record to check and update
    * @returns {Promise<number>} The record's Dateable ID
    */
@@ -213,6 +213,44 @@ export default async function createWinterSeasons(
     throw new Error("Winter fee DateType not found.");
   }
 
+  /**
+   * Ensures a Winter season and placeholder Winter fee DateRange exist.
+   * Optionally ensures DateRangeAnnual when required for this level.
+   * @param {Object} params Winter setup parameters
+   * @param {number} params.publishableId Publishable ID owning the Winter season
+   * @param {number} params.dateableId Dateable ID for the Winter fee DateRange
+   * @param {string} params.itemName Name used for logging
+   * @param {boolean} [params.createDateRangeAnnual=false] Whether to create DateRangeAnnual
+   * @returns {Promise<void>}
+   */
+  async function ensureWinterSeasonSetup({
+    publishableId,
+    dateableId,
+    itemName,
+    createDateRangeAnnual = false,
+  }) {
+    const winterSeasonId = await createWinterSeason(
+      publishableId,
+      operatingYear,
+      itemName,
+    );
+
+    await createWinterFeeDateRange(
+      winterSeasonId,
+      dateableId,
+      winterFeeDateType.id,
+      itemName,
+    );
+
+    if (createDateRangeAnnual) {
+      await ensureWinterDateRangeAnnual(
+        publishableId,
+        dateableId,
+        winterFeeDateType.id,
+      );
+    }
+  }
+
   // Get all Parks that have winter fee dates
   const parksWithWinterFees = await Park.findAll({
     attributes: [
@@ -240,28 +278,12 @@ export default async function createWinterSeasons(
     // Ensure the park has a dateableId
     const dateableId = await createDateable(park);
 
-    // Create a winter season for this park
-    const winterSeasonId = await createWinterSeason(
+    await ensureWinterSeasonSetup({
       publishableId,
-      operatingYear,
-      park.name,
-    );
-
-    // Create winter fee date range for the winter season
-    if (winterSeasonId) {
-      await createWinterFeeDateRange(
-        winterSeasonId,
-        dateableId,
-        winterFeeDateType.id,
-        park.name,
-      );
-
-      await ensureWinterDateRangeAnnual(
-        publishableId,
-        dateableId,
-        winterFeeDateType.id,
-      );
-    }
+      dateableId,
+      itemName: park.name,
+      createDateRangeAnnual: true,
+    });
   });
 
   await Promise.all(parkQueries);
@@ -296,6 +318,31 @@ export default async function createWinterSeasons(
     `Found ${featuresWithWinterFees.length} Features with Winter Fee Dates`,
   );
 
+  // Multiple features can share the same parent ParkArea.
+  // Ensure each ParkArea publishable only once (serially) to avoid race-created orphan rows.
+  const parkAreaPublishableById = new Map();
+
+  const parentParkAreasById = [];
+  const seenParkAreaIds = new Set();
+
+  for (const feature of featuresWithWinterFees) {
+    const parkArea = feature.parkArea;
+
+    if (!parkArea?.id || seenParkAreaIds.has(parkArea.id)) {
+      continue;
+    }
+
+    seenParkAreaIds.add(parkArea.id);
+    parentParkAreasById.push(parkArea);
+  }
+
+  for (const parkArea of parentParkAreasById) {
+    const publishableId =
+      parkArea.publishableId || (await createPublishable(parkArea));
+
+    parkAreaPublishableById.set(parkArea.id, publishableId);
+  }
+
   const featureQueries = featuresWithWinterFees.map(async (feature) => {
     const featureDateableId =
       feature.dateableId || (await createDateable(feature));
@@ -305,21 +352,15 @@ export default async function createWinterSeasons(
     // Do not consult parkArea.hasWinterFeeDates.
     if (feature.parkArea) {
       const parkAreaPublishableId =
+        parkAreaPublishableById.get(feature.parkArea.id) ||
         feature.parkArea.publishableId ||
         (await createPublishable(feature.parkArea));
 
-      const parkAreaWinterSeasonId = await createWinterSeason(
-        parkAreaPublishableId,
-        operatingYear,
-        `${feature.parkArea.name} (park area)`,
-      );
-
-      await createWinterFeeDateRange(
-        parkAreaWinterSeasonId,
-        featureDateableId,
-        winterFeeDateType.id,
-        `${feature.name} (${feature.parkArea.name})`,
-      );
+      await ensureWinterSeasonSetup({
+        publishableId: parkAreaPublishableId,
+        dateableId: featureDateableId,
+        itemName: `${feature.name} (${feature.parkArea.name})`,
+      });
 
       return;
     }
@@ -327,18 +368,11 @@ export default async function createWinterSeasons(
     // Independent Features (without a ParkArea) own Winter seasons.
     const featurePublishableId = await createPublishable(feature);
 
-    const winterSeasonId = await createWinterSeason(
-      featurePublishableId,
-      operatingYear,
-      feature.name,
-    );
-
-    await createWinterFeeDateRange(
-      winterSeasonId,
-      featureDateableId,
-      winterFeeDateType.id,
-      feature.name,
-    );
+    await ensureWinterSeasonSetup({
+      publishableId: featurePublishableId,
+      dateableId: featureDateableId,
+      itemName: feature.name,
+    });
   });
 
   await Promise.all(featureQueries);

--- a/backend/utils/hasOperationDateChanges.js
+++ b/backend/utils/hasOperationDateChanges.js
@@ -1,0 +1,92 @@
+import * as DATE_TYPE from "../constants/dateType.js";
+import { DateRange, DateType } from "../models/index.js";
+
+/**
+ * Detects whether the request changes any Operation date ranges.
+ * Checks both updated/created dateRanges and deleted dateRange IDs.
+ * @param {Object} params Parameters for operation-date change detection
+ * @param {number} params.seasonId Season ID being saved
+ * @param {Array} params.dateRanges DateRanges from the request payload
+ * @param {Array<number>} params.deletedDateRangeIds DateRange IDs marked for deletion
+ * @param {Transaction} params.transaction Database transaction
+ * @returns {Promise<boolean>} True when Operation dates are changed
+ */
+export default async function hasOperationDateChanges({
+  seasonId,
+  dateRanges,
+  deletedDateRangeIds,
+  transaction,
+}) {
+  const operationDateType = await DateType.findOne({
+    attributes: ["id"],
+    where: {
+      dateTypeNumber: DATE_TYPE.OPERATION,
+    },
+    transaction,
+  });
+
+  if (!operationDateType) {
+    return false;
+  }
+
+  const operationDateTypeId = operationDateType.id;
+
+  const existingOperationRanges = await DateRange.findAll({
+    attributes: ["id", "dateTypeId", "dateableId", "startDate", "endDate"],
+    where: {
+      seasonId,
+      dateTypeId: operationDateTypeId,
+    },
+    transaction,
+  });
+
+  const existingById = new Map(
+    existingOperationRanges.map((range) => [range.id, range]),
+  );
+
+  // New operation ranges (no ID) are always a change.
+  const hasOperationCreate = (dateRanges || []).some(
+    (dateRange) =>
+      !dateRange.id && dateRange.dateTypeId === operationDateTypeId,
+  );
+
+  if (hasOperationCreate) {
+    return true;
+  }
+
+  // Updated operation ranges: same ID but changed values.
+  const hasOperationUpdate = (dateRanges || []).some((dateRange) => {
+    if (!dateRange.id) {
+      return false;
+    }
+
+    const existing = existingById.get(dateRange.id);
+
+    if (!existing) {
+      return false;
+    }
+
+    const incomingStart = dateRange.startDate ?? null;
+    const incomingEnd = dateRange.endDate ?? null;
+    const existingStart = existing.startDate ?? null;
+    const existingEnd = existing.endDate ?? null;
+    const incomingDateableId = dateRange.dateableId ?? existing.dateableId;
+
+    return (
+      incomingDateableId !== existing.dateableId ||
+      incomingStart !== existingStart ||
+      incomingEnd !== existingEnd
+    );
+  });
+
+  if (hasOperationUpdate) {
+    return true;
+  }
+
+  if (!deletedDateRangeIds?.length) {
+    return false;
+  }
+
+  // Deleting an existing operation range is a change.
+  return deletedDateRangeIds.some((id) => existingById.has(id));
+}

--- a/backend/utils/propagateWinterFeeDates.js
+++ b/backend/utils/propagateWinterFeeDates.js
@@ -17,7 +17,7 @@ import { APPROVED } from "../constants/seasonStatus.js";
 import consolidateRanges from "./consolidateDateRanges.js";
 import getOverlappingDateRanges from "./getOverlappingDateRanges.js";
 
-async function getSeasonWithOwner(seasonId, transaction = null) {
+async function getSeason(seasonId, transaction = null) {
   return await Season.findByPk(seasonId, {
     include: [
       {
@@ -36,8 +36,6 @@ async function getSeasonWithOwner(seasonId, transaction = null) {
     transaction,
   });
 }
-
-// Helper functions
 
 /**
  * Returns the Park record associated with the given Season.
@@ -395,7 +393,7 @@ export default async function propagateWinterFeeDates(
   seasonId,
   transaction = null,
 ) {
-  const sourceSeason = await getSeasonWithOwner(seasonId, transaction);
+  const sourceSeason = await getSeason(seasonId, transaction);
 
   if (!sourceSeason) {
     throw new Error(`Season ${seasonId} not found for Winter fee propagation.`);

--- a/backend/utils/propagateWinterFeeDates.js
+++ b/backend/utils/propagateWinterFeeDates.js
@@ -1,5 +1,5 @@
 // Recalculate Feature-level Winter fee dates from Park-level Winter fee dates.
-// This runs on Winter fee or Operation date saves so derived Winter ranges stay current.
+// This runs on Winter fee date or Operation date saves so derived Winter ranges stay current.
 
 import { Op } from "sequelize";
 
@@ -80,23 +80,21 @@ async function getDateTypeIds(transaction = null) {
     throw new Error("Winter fee DateType not found.");
   }
 
-  const featureOperationType = await DateType.findOne({
+  const operationType = await DateType.findOne({
     attributes: ["id"],
     where: {
       dateTypeNumber: DATE_TYPE.OPERATION,
-      featureLevel: true,
     },
     transaction,
   });
 
-  if (!featureOperationType) {
-    throw new Error("Feature-level Operation DateType not found.");
+  if (!operationType) {
+    throw new Error("Operation DateType not found.");
   }
 
   return {
-    parkWinterTypeId: winterType.id,
-    featureWinterTypeId: winterType.id,
-    featureOperationTypeId: featureOperationType.id,
+    winterTypeId: winterType.id,
+    operationTypeId: operationType.id,
   };
 }
 
@@ -104,14 +102,14 @@ async function getDateTypeIds(transaction = null) {
  * Gets the Park-level Winter fee season and its complete date ranges for an operating year.
  * @param {Park} park Park record that owns the winter season
  * @param {number} operatingYear Operating year to look up
- * @param {number} parkWinterTypeId Winter fee DateType ID
+ * @param {number} winterTypeId Winter fee DateType ID
  * @param {Transaction} [transaction] Optional Sequelize transaction
  * @returns {Promise<{season: Season|null, ranges: Array}>} The Park winter season and its consolidated Winter fee ranges.
  */
 async function getParkWinterDateRanges(
   park,
   operatingYear,
-  parkWinterTypeId,
+  winterTypeId,
   transaction = null,
 ) {
   const parkWinterSeason = await Season.findOne({
@@ -135,7 +133,7 @@ async function getParkWinterDateRanges(
     where: {
       seasonId: parkWinterSeason.id,
       dateableId: park.dateableId,
-      dateTypeId: parkWinterTypeId,
+      dateTypeId: winterTypeId,
       startDate: {
         [Op.ne]: null,
       },
@@ -156,14 +154,14 @@ async function getParkWinterDateRanges(
  * Gets the consolidated Feature-level Operation date ranges for a given year.
  * @param {Feature} feature Feature record to inspect
  * @param {number} operatingYear Operating year to look up
- * @param {number} featureOperationTypeId Operation DateType ID
+ * @param {number} operationTypeId Operation DateType ID
  * @param {Transaction} [transaction] Optional Sequelize transaction
  * @returns {Promise<Array>} Consolidated Operation date ranges for the Feature.
  */
 async function getFeatureOperationRanges(
   feature,
   operatingYear,
-  featureOperationTypeId,
+  operationTypeId,
   transaction = null,
 ) {
   const operationRanges = await DateRange.findAll({
@@ -182,7 +180,7 @@ async function getFeatureOperationRanges(
     ],
     where: {
       dateableId: feature.dateableId,
-      dateTypeId: featureOperationTypeId,
+      dateTypeId: operationTypeId,
       startDate: {
         [Op.ne]: null,
       },
@@ -273,7 +271,7 @@ async function syncWinterSeasonState({
  * @param {Feature} feature Feature record to recalculate
  * @param {number} operatingYear Operating year to process
  * @param {Array} overlaps Consolidated Winter fee overlap ranges for this Feature
- * @param {number} featureWinterTypeId Winter fee DateType ID
+ * @param {number} winterTypeId Winter fee DateType ID
  * @param {boolean|null} parkWinterReadyToPublish Ready-to-publish state to copy from the Park winter season
  * @param {Transaction} [transaction] Optional Sequelize transaction
  * @returns {Promise<boolean>} True when the Feature winter season was updated, false when it did not exist
@@ -282,7 +280,7 @@ async function syncFeatureWinterSeason(
   feature,
   operatingYear,
   overlaps,
-  featureWinterTypeId,
+  winterTypeId,
   parkWinterReadyToPublish,
   transaction = null,
 ) {
@@ -302,7 +300,7 @@ async function syncFeatureWinterSeason(
   await rebuildWinterDateRanges({
     seasonId: winterSeason.id,
     dateableId: feature.dateableId,
-    dateTypeId: featureWinterTypeId,
+    dateTypeId: winterTypeId,
     ranges: overlaps,
     createPlaceholderWhenEmpty: true,
     transaction,
@@ -325,7 +323,7 @@ async function syncFeatureWinterSeason(
  * @param {number} parkAreaDateableId Parent ParkArea Dateable ID
  * @param {number} operatingYear Operating year to process
  * @param {Array} overlaps Consolidated Winter fee overlap ranges for this Feature
- * @param {number} featureWinterTypeId Winter fee DateType ID
+ * @param {number} winterTypeId Winter fee DateType ID
  * @param {boolean|null} parkWinterReadyToPublish Ready-to-publish state to copy from the Park winter season
  * @param {Transaction} [transaction] Optional Sequelize transaction
  * @returns {Promise<boolean>} True when the parent ParkArea winter season was updated, false when it did not exist
@@ -336,7 +334,7 @@ async function syncFeatureWinterDatesOnParkAreaSeason(
   parkAreaDateableId,
   operatingYear,
   overlaps,
-  featureWinterTypeId,
+  winterTypeId,
   parkWinterReadyToPublish,
   transaction = null,
 ) {
@@ -356,7 +354,7 @@ async function syncFeatureWinterDatesOnParkAreaSeason(
   await rebuildWinterDateRanges({
     seasonId: winterSeason.id,
     dateableId: feature.dateableId,
-    dateTypeId: featureWinterTypeId,
+    dateTypeId: winterTypeId,
     ranges: overlaps,
     createPlaceholderWhenEmpty: true,
     transaction,
@@ -367,7 +365,7 @@ async function syncFeatureWinterDatesOnParkAreaSeason(
       where: {
         seasonId: winterSeason.id,
         dateableId: parkAreaDateableId,
-        dateTypeId: featureWinterTypeId,
+        dateTypeId: winterTypeId,
       },
       transaction,
     });
@@ -412,13 +410,12 @@ export default async function propagateWinterFeeDates(
 
   const operatingYear = sourceSeason.operatingYear;
 
-  const { parkWinterTypeId, featureWinterTypeId, featureOperationTypeId } =
-    await getDateTypeIds(transaction);
+  const { winterTypeId, operationTypeId } = await getDateTypeIds(transaction);
 
   const parkWinter = await getParkWinterDateRanges(
     park,
     operatingYear,
-    parkWinterTypeId,
+    winterTypeId,
     transaction,
   );
 
@@ -482,7 +479,7 @@ export default async function propagateWinterFeeDates(
     const operationRanges = await getFeatureOperationRanges(
       feature,
       operatingYear,
-      featureOperationTypeId,
+      operationTypeId,
       transaction,
     );
 
@@ -495,7 +492,7 @@ export default async function propagateWinterFeeDates(
           feature.parkArea.dateableId,
           operatingYear,
           overlaps,
-          featureWinterTypeId,
+          winterTypeId,
           parkWinter.season?.readyToPublish,
           transaction,
         )
@@ -503,7 +500,7 @@ export default async function propagateWinterFeeDates(
           feature,
           operatingYear,
           overlaps,
-          featureWinterTypeId,
+          winterTypeId,
           parkWinter.season?.readyToPublish,
           transaction,
         );

--- a/backend/utils/propagateWinterFeeDates.js
+++ b/backend/utils/propagateWinterFeeDates.js
@@ -1,43 +1,40 @@
-// For Winter fee dates collected at the Park level,
-// This script will propagate the dates down to the Frontcountry camping Feature and Area levels.
+// Recalculate Feature-level Winter fee dates from Park-level Winter fee dates.
+// This runs on approved saves so updates to Winter fee or Operation dates are reflected.
 
-import _ from "lodash";
+import { Op } from "sequelize";
 
 import {
-  Season,
-  Park,
-  ParkArea,
-  Feature,
-  FeatureType,
   DateRange,
   DateType,
+  Feature,
+  Park,
+  ParkArea,
+  Season,
 } from "../models/index.js";
+import * as DATE_TYPE from "../constants/dateType.js";
+import * as SEASON_TYPE from "../constants/seasonType.js";
 import { APPROVED } from "../constants/seasonStatus.js";
 import consolidateRanges from "./consolidateDateRanges.js";
 import getOverlappingDateRanges from "./getOverlappingDateRanges.js";
 
-const FRONTCOUNTRY_CAMPING_TYPE_NAME = "Frontcountry campground";
-const PARK_WINTER_FEE_DATE_TYPE_NAME = "Winter fee";
-const FEATURE_WINTER_FEE_DATE_TYPE_NAME = "Winter fee";
-const FEATURE_OPERATING_DATE_TYPE_NAME = "Operation";
-
-// Query part helpers
-function seasonsQueryPart(operatingYear) {
-  return {
-    model: Season,
-    as: "seasons",
-    where: { operatingYear },
-    required: false,
-  };
-}
-
-function frontcountryFeaturesQueryPart(featureTypeId) {
-  return {
-    model: Feature,
-    as: "features",
-    where: { featureTypeId },
-    required: true,
-  };
+async function getSeasonWithOwner(seasonId, transaction = null) {
+  return await Season.findByPk(seasonId, {
+    include: [
+      {
+        model: Park,
+        as: "park",
+      },
+      {
+        model: ParkArea,
+        as: "parkArea",
+      },
+      {
+        model: Feature,
+        as: "feature",
+      },
+    ],
+    transaction,
+  });
 }
 
 // Helper functions
@@ -68,323 +65,305 @@ async function getSeasonPark(season, transaction = null) {
 }
 
 /**
- * Gets all Frontcountry camping Seasons in the Park for the operating year.
- * This can include Park, Area, and Feature Seasons.
- * @param {Park} park The Park record to get Seasons for
- * @param {number} operatingYear The operating year to filter Seasons by
+ * Returns the DateType IDs needed for winter-fee propagation.
  * @param {Transaction} [transaction] Optional Sequelize transaction
- * @returns {Promise<Object>} An object containing arrays of Seasons by level: park, parkArea, and feature.
- * @throws {Error} If the Frontcountry campground FeatureType is not found
+ * @returns {Promise<Object>} DateType IDs used by the winter-fee propagation flow.
  */
-async function getAllFrontcountrySeasons(
-  park,
-  operatingYear,
-  transaction = null,
-) {
-  // Find the FeatureTypeId for "Frontcountry campground"
-  const frontcountryType = await FeatureType.findOne({
-    where: { name: FRONTCOUNTRY_CAMPING_TYPE_NAME },
+async function getDateTypeIds(transaction = null) {
+  const winterType = await DateType.findOne({
     attributes: ["id"],
+    where: {
+      dateTypeNumber: DATE_TYPE.WINTER_FEE,
+    },
     transaction,
   });
 
-  if (!frontcountryType) {
-    throw new Error("Frontcountry campground FeatureType not found.");
+  if (!winterType) {
+    throw new Error("Winter fee DateType not found.");
   }
 
-  const FRONTCOUNTRY_CAMPING_TYPE_ID = frontcountryType.id;
-
-  // Get all Seasons in the Park for the operating year
-  const parkSeasons = await Park.findByPk(park.id, {
-    include: [
-      // Park seasons
-      seasonsQueryPart(operatingYear),
-
-      // ParkAreas
-      {
-        model: ParkArea,
-        as: "parkAreas",
-        include: [
-          // Frontcountry camping Features within Areas
-          frontcountryFeaturesQueryPart(FRONTCOUNTRY_CAMPING_TYPE_ID),
-
-          // Area seasons
-          seasonsQueryPart(operatingYear),
-        ],
-      },
-
-      // Features directly in the Park, and Features within Areas
-      {
-        ...frontcountryFeaturesQueryPart(FRONTCOUNTRY_CAMPING_TYPE_ID),
-
-        include: [
-          // Feature seasons
-          seasonsQueryPart(operatingYear),
-        ],
-      },
-    ],
+  const featureOperationType = await DateType.findOne({
+    attributes: ["id"],
+    where: {
+      dateTypeNumber: DATE_TYPE.OPERATION,
+      featureLevel: true,
+    },
     transaction,
   });
 
-  // If no season satisfies the criteria, return an empty structure
-  if (!parkSeasons) {
-    return {
-      park: [],
-      parkArea: [],
-      feature: [],
-    };
+  if (!featureOperationType) {
+    throw new Error("Feature-level Operation DateType not found.");
   }
 
-  // Return all of the Seasons, organized by level
   return {
-    park: parkSeasons.seasons,
-
-    parkArea: parkSeasons.parkAreas.flatMap((parkArea) => parkArea.seasons),
-
-    feature: parkSeasons.features.flatMap((feature) => feature.seasons),
+    parkWinterTypeId: winterType.id,
+    featureWinterTypeId: winterType.id,
+    featureOperationTypeId: featureOperationType.id,
   };
 }
 
 /**
- * Adds winter fee dates for a given Season. Winter fee DateRanges are created
- * based on the overlapping date ranges between the provided winterDates and
- * the operating dates for any Dateables in the Season.
- * @param {Season} season Season record to add winter fee dates for
- * @param {Array} winterDates array of Winter fee DateRanges to add to the Areas and Features
- * @param {number} featureWinterTypeId DB ID of the Area/Feature-level Winter fee DateType
- * @param {number} featureOperatingTypeId DB ID of the Area/Feature-level Operation dates DateType
+ * Gets the Park-level Winter fee season and its complete date ranges for an operating year.
+ * @param {Park} park Park record that owns the winter season
+ * @param {number} operatingYear Operating year to look up
+ * @param {number} parkWinterTypeId Winter fee DateType ID
  * @param {Transaction} [transaction] Optional Sequelize transaction
- * @returns {Promise<Array | boolean>} Array of results from bulkCreate
- * for the winter fee DateRanges, or false if no dates need to be added
+ * @returns {Promise<{season: Season|null, ranges: Array}>} The Park winter season and its consolidated Winter fee ranges.
  */
-async function addWinterFeeDatesForSeason(
-  season,
-  winterDates,
-  featureWinterTypeId,
-  featureOperatingTypeId,
-  transaction,
+async function getParkWinterDateRanges(
+  park,
+  operatingYear,
+  parkWinterTypeId,
+  transaction = null,
 ) {
-  // If the season has any Area/Feature-level winter dates already, skip it
-  const existingWinterDates = await DateRange.count({
+  const parkWinterSeason = await Season.findOne({
+    attributes: ["id", "readyToPublish"],
     where: {
-      seasonId: season.id,
+      publishableId: park.publishableId,
+      operatingYear,
+      seasonType: SEASON_TYPE.WINTER,
+    },
+    transaction,
+  });
+
+  if (!parkWinterSeason) {
+    return {
+      season: null,
+      ranges: [],
+    };
+  }
+
+  const parkWinterRanges = await DateRange.findAll({
+    where: {
+      seasonId: parkWinterSeason.id,
+      dateableId: park.dateableId,
+      dateTypeId: parkWinterTypeId,
+      startDate: {
+        [Op.ne]: null,
+      },
+      endDate: {
+        [Op.ne]: null,
+      },
+    },
+    transaction,
+  });
+
+  return {
+    season: parkWinterSeason,
+    ranges: consolidateRanges(parkWinterRanges.map((range) => range.toJSON())),
+  };
+}
+
+/**
+ * Gets the consolidated Feature-level Operation date ranges for a given year.
+ * @param {Feature} feature Feature record to inspect
+ * @param {number} operatingYear Operating year to look up
+ * @param {number} featureOperationTypeId Operation DateType ID
+ * @param {Transaction} [transaction] Optional Sequelize transaction
+ * @returns {Promise<Array>} Consolidated Operation date ranges for the Feature.
+ */
+async function getFeatureOperationRanges(
+  feature,
+  operatingYear,
+  featureOperationTypeId,
+  transaction = null,
+) {
+  const operationRanges = await DateRange.findAll({
+    attributes: ["startDate", "endDate"],
+    include: [
+      {
+        model: Season,
+        as: "season",
+        attributes: ["id"],
+        required: true,
+        where: {
+          operatingYear,
+          seasonType: SEASON_TYPE.REGULAR,
+        },
+      },
+    ],
+    where: {
+      dateableId: feature.dateableId,
+      dateTypeId: featureOperationTypeId,
+      startDate: {
+        [Op.ne]: null,
+      },
+      endDate: {
+        [Op.ne]: null,
+      },
+    },
+    transaction,
+  });
+
+  return consolidateRanges(operationRanges.map((range) => range.toJSON()));
+}
+
+
+/**
+ * Rebuilds a Feature winter season's Winter fee DateRanges from the Park-level
+ * Winter fee dates and the Feature's Operation date ranges.
+ * @param {Feature} feature Feature record to recalculate
+ * @param {number} operatingYear Operating year to process
+ * @param {Array} parkWinterDates Consolidated Park-level Winter fee ranges
+ * @param {number} featureWinterTypeId Winter fee DateType ID
+ * @param {number} featureOperationTypeId Feature Operation DateType ID
+ * @param {boolean|null} parkWinterReadyToPublish Ready-to-publish state to copy from the Park winter season
+ * @param {Transaction} [transaction] Optional Sequelize transaction
+ * @returns {Promise<boolean>} True when the Feature winter season was updated, false when it did not exist
+ */
+async function syncFeatureWinterSeason(
+  feature,
+  operatingYear,
+  parkWinterDates,
+  featureWinterTypeId,
+  featureOperationTypeId,
+  parkWinterReadyToPublish,
+  transaction = null,
+) {
+  const winterSeason = await Season.findOne({
+    where: {
+      publishableId: feature.publishableId,
+      operatingYear,
+      seasonType: SEASON_TYPE.WINTER,
+    },
+    transaction,
+  });
+
+  if (!winterSeason) {
+    return false;
+  }
+
+  const operationRanges = await getFeatureOperationRanges(
+    feature,
+    operatingYear,
+    featureOperationTypeId,
+    transaction,
+  );
+
+  const overlaps = getOverlappingDateRanges(parkWinterDates, operationRanges);
+
+  await DateRange.destroy({
+    where: {
+      seasonId: winterSeason.id,
+      dateableId: feature.dateableId,
       dateTypeId: featureWinterTypeId,
     },
     transaction,
   });
 
-  // Skip if the season already has Area/Feature-level winter dates
-  if (existingWinterDates) return false;
-
-  // Get operating dates for the season
-  const operatingDatesResults = await DateRange.findAll({
-    where: {
-      seasonId: season.id,
-      dateTypeId: featureOperatingTypeId,
-    },
-    transaction,
-  });
-
-  // Skip if the season has no Operating dates
-  if (!operatingDatesResults.length) return false;
-
-  // Group operating dates by dateableId
-  const groupedOperatingDates = _.groupBy(
-    operatingDatesResults,
-    (dateRange) => dateRange.dateableId,
-  );
-
-  const creationResults = _.map(
-    groupedOperatingDates,
-    (dateRanges, dateableId) => {
-      // Consolidate the operating date ranges for this dateableId
-      const operatingDates = consolidateRanges(
-        dateRanges.map((dateRange) => dateRange.toJSON()),
-      );
-
-      // Get an array of overlapping dates from winterDates and operatingDates
-      const overlappingDates = getOverlappingDateRanges(
-        winterDates,
-        operatingDates,
-      );
-
-      // Skip creating winter dates if there are no overlapping dates
-      if (!overlappingDates.length) return false;
-
-      // Create winter fee DateRanges for the overlapping dates for this dateableId
-      return DateRange.bulkCreate(
-        overlappingDates.map((dateRange) => ({
-          seasonId: season.id,
-          dateableId,
-          dateTypeId: featureWinterTypeId,
-          startDate: dateRange.startDate,
-          endDate: dateRange.endDate,
-        })),
-        { transaction },
-      );
-    },
-  );
-
-  return Promise.all(creationResults);
-}
-
-/**
- * Processes the Area and Feature Seasons to add winter fee dates, if applicable.
- * @param {Object} allSeasons object containing seasons organized by level (from `getAllFrontcountrySeasons`)
- * @param {Park} park Park record for the Seasons
- * @param {Transaction} [transaction] Optional Sequelize transaction
- * @returns {Promise<Array>} Array of query results from calling `addWinterFeeDatesForSeason` for each Season
- * @throws {Error} If the Winter fee DateType or Operating DateType is not found
- */
-async function processAreaAndFeatureSeasons(
-  allSeasons,
-  park,
-  transaction = null,
-) {
-  const areaAndFeatureSeasons = [...allSeasons.parkArea, ...allSeasons.feature];
-
-  // Get the IDs for the DateTypes we need in the queries
-
-  // Park-level winter fees
-  const parkLevelWinterFeeType = await DateType.findOne({
-    attributes: ["id"],
-    where: { name: PARK_WINTER_FEE_DATE_TYPE_NAME, parkLevel: true },
-    transaction,
-  });
-
-  // Throw an error if the DateType isn't in the DB
-  if (!parkLevelWinterFeeType) {
-    throw new Error("Park-level Winter fee DateType not found.");
-  }
-
-  // Area/Feature-level winter fees
-  const featureLevelWinterFeeType = await DateType.findOne({
-    attributes: ["id"],
-    where: { name: FEATURE_WINTER_FEE_DATE_TYPE_NAME, featureLevel: true },
-    transaction,
-  });
-
-  if (!featureLevelWinterFeeType) {
-    throw new Error("Feature-level Winter fee DateType not found.");
-  }
-
-  // Area/Feature-level operating dates
-  const featureLevelOperatingType = await DateType.findOne({
-    attributes: ["id"],
-    where: { name: FEATURE_OPERATING_DATE_TYPE_NAME, featureLevel: true },
-    transaction,
-  });
-
-  if (!featureLevelOperatingType) {
-    throw new Error("Operating DateType not found.");
-  }
-
-  // Get all of the winter dates for the Park level
-  const parkWinterDates = await DateRange.findAll({
-    where: {
-      dateableId: park.dateableId,
-      dateTypeId: parkLevelWinterFeeType.id,
-    },
-    transaction,
-  });
-
-  // Consolidate Winter fee dates (sort & remove duplicates)
-  const consolidatedWinterDates = consolidateRanges(
-    parkWinterDates.map((dateRange) => dateRange.toJSON()),
-  );
-
-  if (!consolidatedWinterDates.length) return false;
-
-  // Loop through each Area and Feature Season and add winter fee dates
-  const addedDates = [];
-
-  for (const season of areaAndFeatureSeasons) {
-    const result = await addWinterFeeDatesForSeason(
-      season,
-      consolidatedWinterDates,
-      featureLevelWinterFeeType.id,
-      featureLevelOperatingType.id,
-      transaction,
+  if (overlaps.length > 0) {
+    await DateRange.bulkCreate(
+      overlaps.map((range) => ({
+        seasonId: winterSeason.id,
+        dateableId: feature.dateableId,
+        dateTypeId: featureWinterTypeId,
+        startDate: range.startDate,
+        endDate: range.endDate,
+      })),
+      { transaction },
     );
-
-    addedDates.push(result);
   }
 
-  return addedDates;
+  if (
+    parkWinterReadyToPublish !== null &&
+    typeof parkWinterReadyToPublish !== "undefined"
+  ) {
+    winterSeason.readyToPublish = parkWinterReadyToPublish;
+  }
+
+  // Feature-level Winter seasons are re-approval outputs and should remain publishable.
+  winterSeason.status = APPROVED;
+  winterSeason.updatedAt = new Date();
+  await winterSeason.save({ transaction });
+
+  return true;
 }
 
 /**
- * Propagates winter fee dates from the Park level down to Area and Feature Seasons.
- * This happens if the park supports winter fee dates and all Frontcountry camping Seasons are approved.
- * @param {number} seasonId The ID of the Season being approved
+ * Recalculates Feature-level Winter fee dates for a park + operating year.
+ * Trigger this on approved saves (including edit-published flows).
+ * @param {number} seasonId The season being approved/saved
  * @param {Transaction} [transaction] Optional Sequelize transaction
- * @returns {Promise<boolean | Array>} Returns false if no winter fee dates are added,
+ * @returns {Promise<boolean | Array>} Number of Feature winter seasons updated and skipped.
  */
 export default async function propagateWinterFeeDates(
   seasonId,
   transaction = null,
 ) {
-  // Get details for the provided Season that was just approved, along with its Park details
-  // We'll use it to check all the other seasons for the Park and operatingYear
-  const season = await Season.findByPk(seasonId, {
-    include: [
-      // Park details, if it's a Park season
-      {
-        model: Park,
-        as: "park",
-      },
+  const sourceSeason = await getSeasonWithOwner(seasonId, transaction);
 
-      // Area details, if it's an Area season
-      {
-        model: ParkArea,
-        as: "parkArea",
-      },
+  if (!sourceSeason) {
+    throw new Error(`Season ${seasonId} not found for Winter fee propagation.`);
+  }
 
-      // Feature details, if it's a Feature season (including Features within Areas)
-      {
-        model: Feature,
-        as: "feature",
-      },
-    ],
+  const park = await getSeasonPark(sourceSeason, transaction);
+
+  if (
+    !park ||
+    !park.hasWinterFeeDates ||
+    !park.publishableId ||
+    !park.dateableId
+  ) {
+    return { updatedFeatures: 0, skippedFeatures: 0 };
+  }
+
+  const operatingYear = sourceSeason.operatingYear;
+
+  const { parkWinterTypeId, featureWinterTypeId, featureOperationTypeId } =
+    await getDateTypeIds(transaction);
+
+  const parkWinter = await getParkWinterDateRanges(
+    park,
+    operatingYear,
+    parkWinterTypeId,
+    transaction,
+  );
+
+  // If there is no Park-level Winter season, or it has no complete dates, clear derived Feature winter ranges.
+  const winterDates = parkWinter.ranges || [];
+
+  const features = await Feature.findAll({
+    attributes: ["id", "name", "publishableId", "dateableId"],
+    where: {
+      parkId: park.id,
+      hasWinterFeeDates: true,
+      active: true,
+    },
     transaction,
   });
 
-  // Get the Park details
-  const park = await getSeasonPark(season, transaction);
-  const operatingYear = season.operatingYear;
+  if (!features.length) {
+    return { updatedFeatures: 0, skippedFeatures: 0 };
+  }
 
-  // If the Park doesn't have winter fee dates, return false
-  if (!park.hasWinterFeeDates) return false;
+  let updatedFeatures = 0;
+  let skippedFeatures = 0;
 
-  // Get all Frontcountry camping Seasons in the Park (Park/Area/Feature) for the operating year
-  const allFrontcountrySeasons = await getAllFrontcountrySeasons(
-    park,
-    operatingYear,
-    transaction,
-  );
+  for (const feature of features) {
+    if (!feature.publishableId || !feature.dateableId) {
+      skippedFeatures++;
+      continue;
+    }
 
-  const combinedFrontcountrySeasons = [
-    ...allFrontcountrySeasons.park,
-    ...allFrontcountrySeasons.parkArea,
-    ...allFrontcountrySeasons.feature,
-  ];
+    const updated = await syncFeatureWinterSeason(
+      feature,
+      operatingYear,
+      winterDates,
+      featureWinterTypeId,
+      featureOperationTypeId,
+      parkWinter.season?.readyToPublish,
+      transaction,
+    );
 
-  // If no Frontcountry camping Seasons are found, there's nothing to do, so return false
-  if (!combinedFrontcountrySeasons.length) return false;
+    if (updated) {
+      updatedFeatures++;
+    } else {
+      skippedFeatures++;
+    }
+  }
 
-  // Check if all of the frontcountry camping seasons are approved
-  const allApproved = combinedFrontcountrySeasons.every(
-    (frontcountrySeason) => frontcountrySeason.status === APPROVED,
-  );
-
-  // If any of the seasons are still unapproved, return false
-  // Winter fee dates should only be propagated when all seasons are approved
-  if (!allApproved) return false;
-
-  // All seasons are approved, so add winter fee dates to the Feature and Area seasons
-  return processAreaAndFeatureSeasons(
-    allFrontcountrySeasons,
-    park,
-    transaction,
-  );
+  return {
+    updatedFeatures,
+    skippedFeatures,
+  };
 }

--- a/backend/utils/propagateWinterFeeDates.js
+++ b/backend/utils/propagateWinterFeeDates.js
@@ -198,15 +198,13 @@ async function getFeatureOperationRanges(
   return consolidateRanges(operationRanges.map((range) => range.toJSON()));
 }
 
-
 /**
  * Rebuilds a Feature winter season's Winter fee DateRanges from the Park-level
  * Winter fee dates and the Feature's Operation date ranges.
  * @param {Feature} feature Feature record to recalculate
  * @param {number} operatingYear Operating year to process
- * @param {Array} parkWinterDates Consolidated Park-level Winter fee ranges
+ * @param {Array} overlaps Consolidated Winter fee overlap ranges for this Feature
  * @param {number} featureWinterTypeId Winter fee DateType ID
- * @param {number} featureOperationTypeId Feature Operation DateType ID
  * @param {boolean|null} parkWinterReadyToPublish Ready-to-publish state to copy from the Park winter season
  * @param {Transaction} [transaction] Optional Sequelize transaction
  * @returns {Promise<boolean>} True when the Feature winter season was updated, false when it did not exist
@@ -214,9 +212,8 @@ async function getFeatureOperationRanges(
 async function syncFeatureWinterSeason(
   feature,
   operatingYear,
-  parkWinterDates,
+  overlaps,
   featureWinterTypeId,
-  featureOperationTypeId,
   parkWinterReadyToPublish,
   transaction = null,
 ) {
@@ -232,15 +229,6 @@ async function syncFeatureWinterSeason(
   if (!winterSeason) {
     return false;
   }
-
-  const operationRanges = await getFeatureOperationRanges(
-    feature,
-    operatingYear,
-    featureOperationTypeId,
-    transaction,
-  );
-
-  const overlaps = getOverlappingDateRanges(parkWinterDates, operationRanges);
 
   await DateRange.destroy({
     where: {
@@ -280,6 +268,89 @@ async function syncFeatureWinterSeason(
 }
 
 /**
+ * Writes Feature winter fee DateRanges into the parent ParkArea winter season.
+ * This is used for Features that belong to a ParkArea.
+ * @param {Feature} feature Feature record to recalculate
+ * @param {number} parkAreaPublishableId Parent ParkArea Publishable ID
+ * @param {number} parkAreaDateableId Parent ParkArea Dateable ID
+ * @param {number} operatingYear Operating year to process
+ * @param {Array} overlaps Consolidated Winter fee overlap ranges for this Feature
+ * @param {number} featureWinterTypeId Winter fee DateType ID
+ * @param {boolean|null} parkWinterReadyToPublish Ready-to-publish state to copy from the Park winter season
+ * @param {Transaction} [transaction] Optional Sequelize transaction
+ * @returns {Promise<boolean>} True when the parent ParkArea winter season was updated, false when it did not exist
+ */
+async function syncFeatureWinterDatesOnParkAreaSeason(
+  feature,
+  parkAreaPublishableId,
+  parkAreaDateableId,
+  operatingYear,
+  overlaps,
+  featureWinterTypeId,
+  parkWinterReadyToPublish,
+  transaction = null,
+) {
+  const winterSeason = await Season.findOne({
+    where: {
+      publishableId: parkAreaPublishableId,
+      operatingYear,
+      seasonType: SEASON_TYPE.WINTER,
+    },
+    transaction,
+  });
+
+  if (!winterSeason) {
+    return false;
+  }
+
+  await DateRange.destroy({
+    where: {
+      seasonId: winterSeason.id,
+      dateableId: feature.dateableId,
+      dateTypeId: featureWinterTypeId,
+    },
+    transaction,
+  });
+
+  if (parkAreaDateableId) {
+    await DateRange.destroy({
+      where: {
+        seasonId: winterSeason.id,
+        dateableId: parkAreaDateableId,
+        dateTypeId: featureWinterTypeId,
+      },
+      transaction,
+    });
+  }
+
+  if (overlaps.length > 0) {
+    await DateRange.bulkCreate(
+      overlaps.map((range) => ({
+        seasonId: winterSeason.id,
+        dateableId: feature.dateableId,
+        dateTypeId: featureWinterTypeId,
+        startDate: range.startDate,
+        endDate: range.endDate,
+      })),
+      { transaction },
+    );
+  }
+
+  if (
+    parkWinterReadyToPublish !== null &&
+    typeof parkWinterReadyToPublish !== "undefined"
+  ) {
+    winterSeason.readyToPublish = parkWinterReadyToPublish;
+  }
+
+  winterSeason.status = APPROVED;
+  winterSeason.updatedAt = new Date();
+  await winterSeason.save({ transaction });
+
+  return true;
+}
+
+/**
  * Recalculates Feature-level Winter fee dates for a park + operating year.
  * Trigger this on approved saves (including edit-published flows).
  * @param {number} seasonId The season being approved/saved
@@ -298,13 +369,13 @@ export default async function propagateWinterFeeDates(
 
   const park = await getSeasonPark(sourceSeason, transaction);
 
-  if (
-    !park ||
-    !park.hasWinterFeeDates ||
-    !park.publishableId ||
-    !park.dateableId
-  ) {
-    return { updatedFeatures: 0, skippedFeatures: 0 };
+  if (!park) {
+    return {
+      updatedFeatures: 0,
+      skippedFeatures: 0,
+      updatedParkAreas: 0,
+      skippedParkAreas: 0,
+    };
   }
 
   const operatingYear = sourceSeason.operatingYear;
@@ -323,21 +394,36 @@ export default async function propagateWinterFeeDates(
   const winterDates = parkWinter.ranges || [];
 
   const features = await Feature.findAll({
-    attributes: ["id", "name", "publishableId", "dateableId"],
+    attributes: ["id", "name", "publishableId", "dateableId", "parkAreaId"],
     where: {
       parkId: park.id,
       hasWinterFeeDates: true,
       active: true,
     },
+    include: [
+      {
+        model: ParkArea,
+        as: "parkArea",
+        attributes: ["id", "publishableId", "dateableId"],
+        required: false,
+      },
+    ],
     transaction,
   });
 
   if (!features.length) {
-    return { updatedFeatures: 0, skippedFeatures: 0 };
+    return {
+      updatedFeatures: 0,
+      skippedFeatures: 0,
+      updatedParkAreas: 0,
+      skippedParkAreas: 0,
+    };
   }
 
   let updatedFeatures = 0;
   let skippedFeatures = 0;
+  const updatedParkAreas = 0;
+  const skippedParkAreas = 0;
 
   for (const feature of features) {
     if (!feature.publishableId || !feature.dateableId) {
@@ -345,15 +431,34 @@ export default async function propagateWinterFeeDates(
       continue;
     }
 
-    const updated = await syncFeatureWinterSeason(
+    const operationRanges = await getFeatureOperationRanges(
       feature,
       operatingYear,
-      winterDates,
-      featureWinterTypeId,
       featureOperationTypeId,
-      parkWinter.season?.readyToPublish,
       transaction,
     );
+
+    const overlaps = getOverlappingDateRanges(winterDates, operationRanges);
+
+    const updated = feature.parkArea
+      ? await syncFeatureWinterDatesOnParkAreaSeason(
+          feature,
+          feature.parkArea.publishableId,
+          feature.parkArea.dateableId,
+          operatingYear,
+          overlaps,
+          featureWinterTypeId,
+          parkWinter.season?.readyToPublish,
+          transaction,
+        )
+      : await syncFeatureWinterSeason(
+          feature,
+          operatingYear,
+          overlaps,
+          featureWinterTypeId,
+          parkWinter.season?.readyToPublish,
+          transaction,
+        );
 
     if (updated) {
       updatedFeatures++;
@@ -365,5 +470,7 @@ export default async function propagateWinterFeeDates(
   return {
     updatedFeatures,
     skippedFeatures,
+    updatedParkAreas,
+    skippedParkAreas,
   };
 }

--- a/backend/utils/propagateWinterFeeDates.js
+++ b/backend/utils/propagateWinterFeeDates.js
@@ -1,5 +1,5 @@
 // Recalculate Feature-level Winter fee dates from Park-level Winter fee dates.
-// This runs on approved saves so updates to Winter fee or Operation dates are reflected.
+// This runs on Winter fee or Operation date saves so derived Winter ranges stay current.
 
 import { Op } from "sequelize";
 
@@ -199,6 +199,77 @@ async function getFeatureOperationRanges(
 }
 
 /**
+ * Replaces Winter fee DateRanges for a season/dateable pair.
+ * @param {Object} params Replacement parameters
+ * @param {number} params.seasonId Season ID to update
+ * @param {number} params.dateableId Dateable ID to update
+ * @param {number} params.dateTypeId Winter fee DateType ID
+ * @param {Array} params.ranges New date ranges to insert
+ * @param {boolean} [params.createPlaceholderWhenEmpty=false] Whether to insert a single empty placeholder when ranges is empty
+ * @param {Transaction} [params.transaction] Optional Sequelize transaction
+ * @returns {Promise<void>}
+ */
+async function rebuildWinterDateRanges({
+  seasonId,
+  dateableId,
+  dateTypeId,
+  ranges,
+  createPlaceholderWhenEmpty = false,
+  transaction = null,
+}) {
+  await DateRange.destroy({
+    where: {
+      seasonId,
+      dateableId,
+      dateTypeId,
+    },
+    transaction,
+  });
+
+  if (!ranges.length && !createPlaceholderWhenEmpty) {
+    return;
+  }
+
+  await DateRange.bulkCreate(
+    (ranges.length ? ranges : [{ startDate: null, endDate: null }]).map(
+      (range) => ({
+        seasonId,
+        dateableId,
+        dateTypeId,
+        startDate: range.startDate,
+        endDate: range.endDate,
+      }),
+    ),
+    { transaction },
+  );
+}
+
+/**
+ * Synchronizes derived Winter season publishable state.
+ * @param {Object} params State sync parameters
+ * @param {Season} params.winterSeason Winter Season to update
+ * @param {boolean|null|undefined} params.parkWinterReadyToPublish Ready-to-publish value to copy
+ * @param {Transaction} [params.transaction] Optional Sequelize transaction
+ * @returns {Promise<void>}
+ */
+async function syncWinterSeasonState({
+  winterSeason,
+  parkWinterReadyToPublish,
+  transaction = null,
+}) {
+  if (
+    parkWinterReadyToPublish !== null &&
+    typeof parkWinterReadyToPublish !== "undefined"
+  ) {
+    winterSeason.readyToPublish = parkWinterReadyToPublish;
+  }
+
+  winterSeason.status = APPROVED;
+  winterSeason.updatedAt = new Date();
+  await winterSeason.save({ transaction });
+}
+
+/**
  * Rebuilds a Feature winter season's Winter fee DateRanges from the Park-level
  * Winter fee dates and the Feature's Operation date ranges.
  * @param {Feature} feature Feature record to recalculate
@@ -230,39 +301,20 @@ async function syncFeatureWinterSeason(
     return false;
   }
 
-  await DateRange.destroy({
-    where: {
-      seasonId: winterSeason.id,
-      dateableId: feature.dateableId,
-      dateTypeId: featureWinterTypeId,
-    },
+  await rebuildWinterDateRanges({
+    seasonId: winterSeason.id,
+    dateableId: feature.dateableId,
+    dateTypeId: featureWinterTypeId,
+    ranges: overlaps,
+    createPlaceholderWhenEmpty: true,
     transaction,
   });
 
-  if (overlaps.length > 0) {
-    await DateRange.bulkCreate(
-      overlaps.map((range) => ({
-        seasonId: winterSeason.id,
-        dateableId: feature.dateableId,
-        dateTypeId: featureWinterTypeId,
-        startDate: range.startDate,
-        endDate: range.endDate,
-      })),
-      { transaction },
-    );
-  }
-
-  if (
-    parkWinterReadyToPublish !== null &&
-    typeof parkWinterReadyToPublish !== "undefined"
-  ) {
-    winterSeason.readyToPublish = parkWinterReadyToPublish;
-  }
-
-  // Feature-level Winter seasons are re-approval outputs and should remain publishable.
-  winterSeason.status = APPROVED;
-  winterSeason.updatedAt = new Date();
-  await winterSeason.save({ transaction });
+  await syncWinterSeasonState({
+    winterSeason,
+    parkWinterReadyToPublish,
+    transaction,
+  });
 
   return true;
 }
@@ -303,12 +355,12 @@ async function syncFeatureWinterDatesOnParkAreaSeason(
     return false;
   }
 
-  await DateRange.destroy({
-    where: {
-      seasonId: winterSeason.id,
-      dateableId: feature.dateableId,
-      dateTypeId: featureWinterTypeId,
-    },
+  await rebuildWinterDateRanges({
+    seasonId: winterSeason.id,
+    dateableId: feature.dateableId,
+    dateTypeId: featureWinterTypeId,
+    ranges: overlaps,
+    createPlaceholderWhenEmpty: true,
     transaction,
   });
 
@@ -323,36 +375,18 @@ async function syncFeatureWinterDatesOnParkAreaSeason(
     });
   }
 
-  if (overlaps.length > 0) {
-    await DateRange.bulkCreate(
-      overlaps.map((range) => ({
-        seasonId: winterSeason.id,
-        dateableId: feature.dateableId,
-        dateTypeId: featureWinterTypeId,
-        startDate: range.startDate,
-        endDate: range.endDate,
-      })),
-      { transaction },
-    );
-  }
-
-  if (
-    parkWinterReadyToPublish !== null &&
-    typeof parkWinterReadyToPublish !== "undefined"
-  ) {
-    winterSeason.readyToPublish = parkWinterReadyToPublish;
-  }
-
-  winterSeason.status = APPROVED;
-  winterSeason.updatedAt = new Date();
-  await winterSeason.save({ transaction });
+  await syncWinterSeasonState({
+    winterSeason,
+    parkWinterReadyToPublish,
+    transaction,
+  });
 
   return true;
 }
 
 /**
  * Recalculates Feature-level Winter fee dates for a park + operating year.
- * Trigger this on approved saves (including edit-published flows).
+ * Trigger this on Winter fee or Operation date saves.
  * @param {number} seasonId The season being approved/saved
  * @param {Transaction} [transaction] Optional Sequelize transaction
  * @returns {Promise<boolean | Array>} Number of Feature winter seasons updated and skipped.
@@ -422,11 +456,27 @@ export default async function propagateWinterFeeDates(
 
   let updatedFeatures = 0;
   let skippedFeatures = 0;
-  const updatedParkAreas = 0;
-  const skippedParkAreas = 0;
+  const updatedParkAreaIds = new Set();
+  const skippedParkAreaIds = new Set();
 
   for (const feature of features) {
-    if (!feature.publishableId || !feature.dateableId) {
+    if (!feature.dateableId) {
+      if (feature.parkAreaId) {
+        skippedParkAreaIds.add(feature.parkAreaId);
+      }
+      skippedFeatures++;
+      continue;
+    }
+
+    const featureHasParentParkArea = Boolean(feature.parkArea);
+
+    if (!featureHasParentParkArea && !feature.publishableId) {
+      skippedFeatures++;
+      continue;
+    }
+
+    if (featureHasParentParkArea && !feature.parkArea.publishableId) {
+      skippedParkAreaIds.add(feature.parkArea.id);
       skippedFeatures++;
       continue;
     }
@@ -440,7 +490,7 @@ export default async function propagateWinterFeeDates(
 
     const overlaps = getOverlappingDateRanges(winterDates, operationRanges);
 
-    const updated = feature.parkArea
+    const updated = featureHasParentParkArea
       ? await syncFeatureWinterDatesOnParkAreaSeason(
           feature,
           feature.parkArea.publishableId,
@@ -462,15 +512,24 @@ export default async function propagateWinterFeeDates(
 
     if (updated) {
       updatedFeatures++;
+
+      if (featureHasParentParkArea) {
+        updatedParkAreaIds.add(feature.parkArea.id);
+        skippedParkAreaIds.delete(feature.parkArea.id);
+      }
     } else {
       skippedFeatures++;
+
+      if (featureHasParentParkArea) {
+        skippedParkAreaIds.add(feature.parkArea.id);
+      }
     }
   }
 
   return {
     updatedFeatures,
     skippedFeatures,
-    updatedParkAreas,
-    skippedParkAreas,
+    updatedParkAreas: updatedParkAreaIds.size,
+    skippedParkAreas: skippedParkAreaIds.size,
   };
 }

--- a/frontend/src/router/pages/PublishPage.jsx
+++ b/frontend/src/router/pages/PublishPage.jsx
@@ -8,10 +8,11 @@ import FlashMessage from "@/components/FlashMessage";
 import LoadingBar from "@/components/LoadingBar";
 import NotReadyFlag from "@/components/NotReadyFlag";
 import PaginationControls from "@/components/PaginationControls";
+import * as SEASON_TYPE from "@/constants/seasonType";
 import "./PublishPage.scss";
 
 function formatSeasonType(seasonType, publishableType) {
-  if (seasonType !== "winter") {
+  if (seasonType !== SEASON_TYPE.WINTER) {
     return "";
   }
 

--- a/frontend/src/router/pages/PublishPage.jsx
+++ b/frontend/src/router/pages/PublishPage.jsx
@@ -10,6 +10,16 @@ import NotReadyFlag from "@/components/NotReadyFlag";
 import PaginationControls from "@/components/PaginationControls";
 import "./PublishPage.scss";
 
+function formatSeasonType(seasonType, publishableType) {
+  if (seasonType !== "winter") {
+    return "";
+  }
+
+  return publishableType === "feature" || publishableType === "parkArea"
+    ? "Winter fee (calculated)"
+    : "";
+}
+
 function PublishPage() {
   // table pagination
   const [page, setPage] = useState(1);
@@ -169,7 +179,11 @@ function PublishPage() {
                     </ul>
                   </td>
                   <td>
-                    {season.displayOperatingYear}
+                    {season.displayOperatingYear}{" "}
+                    {formatSeasonType(
+                      season.seasonType,
+                      season.publishableType,
+                    )}
                     <NotReadyFlag show={!season.readyToPublish} />
                   </td>
                 </tr>


### PR DESCRIPTION
### Jira Ticket

CMS-1297

### Description
<!-- What did you change, and why? -->
- Updated `create-winter-season.js`
  - Create winter seasons at park/area/feature level based on `park.hasWinterFeeDates`/`feature.hasWinterFeeDates`
  - Create empty date ranges with "Winter fee" date type for park/feature
  - Create dateRangeAnnual for park level winter fee dates
- Updated `propagateWinterFeeDates.js`
  - Calculate feature level winter fee dates based on park level winter fee dates and feature operating dates 
  - Re-calculate when  ark level winter fee dates and feature operating dates are updated
- For testing:
  - Run `node tasks/create-winter-seasons/create-winter-seasons.js 2025` and `node tasks/create-winter-seasons/create-winter-seasons.js 2026`