### PR TITLE
CMS-1870: Import dates modified in Strapi back into DOOT

### DIFF
--- a/backend/tasks/import-2026-strapi-dates/PSQL.md
+++ b/backend/tasks/import-2026-strapi-dates/PSQL.md
@@ -1,0 +1,81 @@
+## Strapi data extraction
+
+Data is extracted from Strapi via SQL queries because the REST API does not expose `created_by_id` and `updated_by_id`. When data is added to Strapi through API calls, these fields are always `null`. Therefore, if records were added or edited by a human, these fields will be non-null.
+
+Connect to one of the `crunchy-postgres-ha` pods in prod and run the following commands. The commands below assume you are connecting to `crunchy-postgres-ha-pmhw`.
+
+`psql -d cms`
+
+```sql
+\pset tuples_only on
+\pset format unaligned
+\o /tmp/feature-dates.json
+
+SELECT json_agg(row_to_json(t))
+FROM (
+    SELECT distinct
+        pdt.date_type_id,
+        pf.orcs_feature_number,
+        pd.is_date_annual,
+        pd.operating_year,
+        pd.start_date,
+        pd.end_date
+    FROM park_dates pd
+    INNER JOIN park_dates_park_date_type_lnk pdpdtl
+        ON pdpdtl.park_date_id = pd.id
+    INNER JOIN park_date_types pdt
+        ON pdt.id = pdpdtl.park_date_type_id
+    INNER JOIN park_dates_park_feature_lnk pdpfl
+        ON pdpfl.park_date_id = pd.id
+    INNER JOIN park_features pf
+        ON pf.id = pdpfl.park_feature_id
+    WHERE pd.operating_year >= 2026
+      AND (pd.created_by_id IS NOT NULL OR pd.updated_by_id IS NOT NULL)
+      AND pd.is_active = TRUE
+      AND pd.published_at IS NOT NULL
+    ORDER BY pf.orcs_feature_number, pdt.date_type_id, pd.start_date
+) t;
+
+
+\o /tmp/protected-area-dates.json
+
+SELECT json_agg(row_to_json(t))
+FROM (
+    SELECT distinct
+        pdt.date_type_id,
+        pa.orcs,
+        pd.is_date_annual,
+        pd.operating_year,
+        pd.start_date,
+        pd.end_date
+    FROM park_dates pd
+    INNER JOIN park_dates_park_date_type_lnk pdpdtl
+        ON pdpdtl.park_date_id = pd.id
+    INNER JOIN park_date_types pdt
+        ON pdt.id = pdpdtl.park_date_type_id
+    INNER JOIN park_dates_protected_area_lnk pdpal
+        ON pdpal.park_date_id = pd.id
+    INNER JOIN protected_areas pa
+        ON pa.id = pdpal.protected_area_id
+    WHERE pd.operating_year >= 2026
+      AND (pd.created_by_id IS NOT NULL OR pd.updated_by_id IS NOT NULL)
+      AND pd.is_active = TRUE
+      AND pd.published_at IS NOT NULL
+    ORDER BY pa.orcs, pdt.date_type_id, pd.start_date
+) t;
+
+\o
+```
+
+Now log in to the `oc` console locally and run the following commands (update the `cd` path for your workstation):
+
+```bash
+oc project c1643c-prod
+
+cd ~/Work/bcparks-staff-portal/backend/tasks/import-2026-strapi-dates
+
+oc cp crunchy-postgres-ha-pmhw-0:/tmp/feature-dates.json ./feature-dates.json
+oc cp crunchy-postgres-ha-pmhw-0:/tmp/protected-area-dates.json ./protected-area-dates.json
+```
+
+Save the files in VS Code to apply prettier formatting.

--- a/backend/tasks/import-2026-strapi-dates/PSQL.md
+++ b/backend/tasks/import-2026-strapi-dates/PSQL.md
@@ -17,7 +17,7 @@ FROM (
         pdt.date_type_id,
         pf.orcs_feature_number,
         pd.is_date_annual,
-        pd.operating_year,
+        EXTRACT(YEAR FROM pd.start_date)::int AS operating_year,
         pd.start_date,
         pd.end_date
     FROM park_dates pd
@@ -29,7 +29,7 @@ FROM (
         ON pdpfl.park_date_id = pd.id
     INNER JOIN park_features pf
         ON pf.id = pdpfl.park_feature_id
-    WHERE pd.operating_year >= 2026
+    WHERE pd.start_date >= '2026-01-01'
       AND (pd.created_by_id IS NOT NULL OR pd.updated_by_id IS NOT NULL)
       AND pd.is_active = TRUE
       AND pd.published_at IS NOT NULL
@@ -45,7 +45,7 @@ FROM (
         pdt.date_type_id,
         pa.orcs,
         pd.is_date_annual,
-        pd.operating_year,
+        EXTRACT(YEAR FROM pd.start_date)::int AS operating_year,
         pd.start_date,
         pd.end_date
     FROM park_dates pd
@@ -57,7 +57,7 @@ FROM (
         ON pdpal.park_date_id = pd.id
     INNER JOIN protected_areas pa
         ON pa.id = pdpal.protected_area_id
-    WHERE pd.operating_year >= 2026
+    WHERE pd.start_date >= '2026-01-01'
       AND (pd.created_by_id IS NOT NULL OR pd.updated_by_id IS NOT NULL)
       AND pd.is_active = TRUE
       AND pd.published_at IS NOT NULL

--- a/backend/tasks/import-2026-strapi-dates/PSQL.md
+++ b/backend/tasks/import-2026-strapi-dates/PSQL.md
@@ -16,6 +16,7 @@ FROM (
     SELECT distinct
         pdt.date_type_id,
         pf.orcs_feature_number,
+        pd.name,
         pd.is_date_annual,
         EXTRACT(YEAR FROM pd.start_date)::int AS operating_year,
         pd.start_date,
@@ -44,6 +45,7 @@ FROM (
     SELECT distinct
         pdt.date_type_id,
         pa.orcs,
+        pd.name,
         pd.is_date_annual,
         EXTRACT(YEAR FROM pd.start_date)::int AS operating_year,
         pd.start_date,

--- a/backend/tasks/import-2026-strapi-dates/README.md
+++ b/backend/tasks/import-2026-strapi-dates/README.md
@@ -1,0 +1,47 @@
+# Import 2026+ Strapi Dates
+
+Reverse syncs operating year 2026+ dates that were modified in Strapi back into DOOT. Intended as a one-time operation in late August or early September 2026, before 2027 date collection begins.
+
+## Files
+
+Two scripts handle different entity types:
+
+- `import-2026-strapi-feature-dates.js` - Syncs feature-level date ranges
+- `import-2026-strapi-protected-area-dates.js` - Syncs park-level date ranges
+
+## Prerequisites
+
+This folder contains required data files:
+
+- `feature-dates.json`
+- `protected-area-dates.json`
+
+These should be refreshed before running on production. Unlike other task scripts, these are included as JSON files because the Strapi REST API does not expose `created_by_id` and `updated_by_id`, which are central to the sync logic. See [PSQL.md](./PSQL.md) for regeneration instructions.
+
+## Running
+
+```bash
+# Feature dates
+node tasks/import-2026-strapi-dates/import-2026-strapi-feature-dates.js
+
+# Protected area dates
+node tasks/import-2026-strapi-dates/import-2026-strapi-protected-area-dates.js
+```
+
+## Dry Run
+
+Set `const dryRun = true;` at the top of the script you are running to preview changes without writing to the database.
+
+## What It Does
+
+- Creates `Publishable` and `Dateable` records if missing
+- Creates `Season` records for the operating year if they don't exist
+- Creates new `DateRange` records from JSON data
+- Deletes `DateRange` records not present in JSON data
+- Creates or updates `DateRangeAnnual` records based on `is_date_annual` flag
+
+Changes are wrapped in a transaction and rolled back on error.
+
+## Expected Output
+
+On the first run, expect non-zero counts for created and deleted records. On subsequent runs, all counters should report zero unless the JSON data files have changed. This indicates the database is in sync with the source data.

--- a/backend/tasks/import-2026-strapi-dates/feature-dates.json
+++ b/backend/tasks/import-2026-strapi-dates/feature-dates.json
@@ -1,0 +1,794 @@
+[
+  {
+    "date_type_id": 4,
+    "orcs_feature_number": "104-1",
+    "is_date_annual": null,
+    "operating_year": 2026,
+    "start_date": "2025-11-01",
+    "end_date": "2026-03-14"
+  },
+  {
+    "date_type_id": 6,
+    "orcs_feature_number": "1-12",
+    "is_date_annual": null,
+    "operating_year": 2026,
+    "start_date": "2026-05-09",
+    "end_date": "2026-09-30"
+  },
+  {
+    "date_type_id": 7,
+    "orcs_feature_number": "1-12",
+    "is_date_annual": null,
+    "operating_year": 2026,
+    "start_date": "2026-05-09",
+    "end_date": "2026-09-29"
+  },
+  {
+    "date_type_id": 4,
+    "orcs_feature_number": "117-1",
+    "is_date_annual": null,
+    "operating_year": 2026,
+    "start_date": "2025-11-01",
+    "end_date": "2026-03-31"
+  },
+  {
+    "date_type_id": 4,
+    "orcs_feature_number": "117-1",
+    "is_date_annual": null,
+    "operating_year": 2026,
+    "start_date": "2026-11-01",
+    "end_date": "2027-03-31"
+  },
+  {
+    "date_type_id": 4,
+    "orcs_feature_number": "122-1",
+    "is_date_annual": null,
+    "operating_year": 2026,
+    "start_date": "2025-10-16",
+    "end_date": "2026-03-26"
+  },
+  {
+    "date_type_id": 1,
+    "orcs_feature_number": "15-2",
+    "is_date_annual": false,
+    "operating_year": 2026,
+    "start_date": "2026-01-01",
+    "end_date": "2026-12-31"
+  },
+  {
+    "date_type_id": 6,
+    "orcs_feature_number": "15-2",
+    "is_date_annual": false,
+    "operating_year": 2026,
+    "start_date": "2026-01-01",
+    "end_date": "2026-12-31"
+  },
+  {
+    "date_type_id": 7,
+    "orcs_feature_number": "15-2",
+    "is_date_annual": false,
+    "operating_year": 2026,
+    "start_date": "2026-01-01",
+    "end_date": "2026-12-31"
+  },
+  {
+    "date_type_id": 6,
+    "orcs_feature_number": "1-6",
+    "is_date_annual": null,
+    "operating_year": 2026,
+    "start_date": "2026-06-26",
+    "end_date": "2026-09-30"
+  },
+  {
+    "date_type_id": 7,
+    "orcs_feature_number": "1-6",
+    "is_date_annual": null,
+    "operating_year": 2026,
+    "start_date": "2026-06-26",
+    "end_date": "2026-09-29"
+  },
+  {
+    "date_type_id": 6,
+    "orcs_feature_number": "1-7",
+    "is_date_annual": null,
+    "operating_year": 2026,
+    "start_date": "2026-05-09",
+    "end_date": "2026-09-30"
+  },
+  {
+    "date_type_id": 7,
+    "orcs_feature_number": "1-7",
+    "is_date_annual": null,
+    "operating_year": 2026,
+    "start_date": "2026-05-09",
+    "end_date": "2026-09-29"
+  },
+  {
+    "date_type_id": 4,
+    "orcs_feature_number": "182-1",
+    "is_date_annual": null,
+    "operating_year": 2026,
+    "start_date": "2025-10-16",
+    "end_date": "2026-04-10"
+  },
+  {
+    "date_type_id": 4,
+    "orcs_feature_number": "190-1",
+    "is_date_annual": null,
+    "operating_year": 2026,
+    "start_date": "2025-10-14",
+    "end_date": "2026-04-29"
+  },
+  {
+    "date_type_id": 4,
+    "orcs_feature_number": "193-1",
+    "is_date_annual": null,
+    "operating_year": 2026,
+    "start_date": "2025-10-26",
+    "end_date": "2026-03-13"
+  },
+  {
+    "date_type_id": 4,
+    "orcs_feature_number": "193-2",
+    "is_date_annual": null,
+    "operating_year": 2026,
+    "start_date": "2025-10-26",
+    "end_date": "2026-03-13"
+  },
+  {
+    "date_type_id": 6,
+    "orcs_feature_number": "20-1",
+    "is_date_annual": false,
+    "operating_year": 2026,
+    "start_date": "2026-05-01",
+    "end_date": "2026-09-27"
+  },
+  {
+    "date_type_id": 6,
+    "orcs_feature_number": "20-2",
+    "is_date_annual": null,
+    "operating_year": 2026,
+    "start_date": "2026-05-01",
+    "end_date": "2026-09-27"
+  },
+  {
+    "date_type_id": 4,
+    "orcs_feature_number": "210-1",
+    "is_date_annual": false,
+    "operating_year": 2026,
+    "start_date": "2025-11-01",
+    "end_date": "2026-03-31"
+  },
+  {
+    "date_type_id": 6,
+    "orcs_feature_number": "2-14",
+    "is_date_annual": null,
+    "operating_year": 2026,
+    "start_date": "2026-05-15",
+    "end_date": "2026-09-30"
+  },
+  {
+    "date_type_id": 7,
+    "orcs_feature_number": "2-14",
+    "is_date_annual": null,
+    "operating_year": 2026,
+    "start_date": "2026-05-15",
+    "end_date": "2026-09-29"
+  },
+  {
+    "date_type_id": 6,
+    "orcs_feature_number": "255-3",
+    "is_date_annual": true,
+    "operating_year": 2026,
+    "start_date": "2026-06-01",
+    "end_date": "2026-09-30"
+  },
+  {
+    "date_type_id": 4,
+    "orcs_feature_number": "262-1",
+    "is_date_annual": null,
+    "operating_year": 2026,
+    "start_date": "2025-10-26",
+    "end_date": "2026-03-12"
+  },
+  {
+    "date_type_id": 4,
+    "orcs_feature_number": "267-1",
+    "is_date_annual": null,
+    "operating_year": 2026,
+    "start_date": "2025-11-01",
+    "end_date": "2026-03-14"
+  },
+  {
+    "date_type_id": 6,
+    "orcs_feature_number": "267-3",
+    "is_date_annual": null,
+    "operating_year": 2026,
+    "start_date": "2026-03-13",
+    "end_date": "2026-10-31"
+  },
+  {
+    "date_type_id": 7,
+    "orcs_feature_number": "267-3",
+    "is_date_annual": null,
+    "operating_year": 2026,
+    "start_date": "2026-03-13",
+    "end_date": "2026-10-30"
+  },
+  {
+    "date_type_id": 6,
+    "orcs_feature_number": "273-8",
+    "is_date_annual": null,
+    "operating_year": 2026,
+    "start_date": "2026-05-15",
+    "end_date": "2026-09-30"
+  },
+  {
+    "date_type_id": 7,
+    "orcs_feature_number": "273-8",
+    "is_date_annual": false,
+    "operating_year": 2026,
+    "start_date": "2026-05-15",
+    "end_date": "2026-09-29"
+  },
+  {
+    "date_type_id": 4,
+    "orcs_feature_number": "28-2",
+    "is_date_annual": null,
+    "operating_year": 2026,
+    "start_date": "2025-11-01",
+    "end_date": "2026-03-19"
+  },
+  {
+    "date_type_id": 4,
+    "orcs_feature_number": "28-3",
+    "is_date_annual": null,
+    "operating_year": 2026,
+    "start_date": "2025-11-01",
+    "end_date": "2026-03-19"
+  },
+  {
+    "date_type_id": 4,
+    "orcs_feature_number": "28-4",
+    "is_date_annual": null,
+    "operating_year": 2026,
+    "start_date": "2025-11-01",
+    "end_date": "2026-03-19"
+  },
+  {
+    "date_type_id": 6,
+    "orcs_feature_number": "292-1",
+    "is_date_annual": null,
+    "operating_year": 2026,
+    "start_date": "2026-06-10",
+    "end_date": "2026-10-13"
+  },
+  {
+    "date_type_id": 7,
+    "orcs_feature_number": "292-1",
+    "is_date_annual": false,
+    "operating_year": 2026,
+    "start_date": "2026-06-10",
+    "end_date": "2026-10-12"
+  },
+  {
+    "date_type_id": 6,
+    "orcs_feature_number": "292-2",
+    "is_date_annual": null,
+    "operating_year": 2026,
+    "start_date": "2026-06-10",
+    "end_date": "2026-10-13"
+  },
+  {
+    "date_type_id": 7,
+    "orcs_feature_number": "292-2",
+    "is_date_annual": null,
+    "operating_year": 2026,
+    "start_date": "2026-06-10",
+    "end_date": "2026-10-12"
+  },
+  {
+    "date_type_id": 4,
+    "orcs_feature_number": "31-1",
+    "is_date_annual": null,
+    "operating_year": 2026,
+    "start_date": "2025-11-16",
+    "end_date": "2026-03-31"
+  },
+  {
+    "date_type_id": 4,
+    "orcs_feature_number": "314-4",
+    "is_date_annual": null,
+    "operating_year": 2026,
+    "start_date": "2025-11-12",
+    "end_date": "2026-02-28"
+  },
+  {
+    "date_type_id": 4,
+    "orcs_feature_number": "314-6",
+    "is_date_annual": null,
+    "operating_year": 2026,
+    "start_date": "2025-11-12",
+    "end_date": "2026-02-28"
+  },
+  {
+    "date_type_id": 4,
+    "orcs_feature_number": "33-11",
+    "is_date_annual": null,
+    "operating_year": 2026,
+    "start_date": "2025-10-18",
+    "end_date": "2026-05-15"
+  },
+  {
+    "date_type_id": 6,
+    "orcs_feature_number": "33-11",
+    "is_date_annual": false,
+    "operating_year": 2026,
+    "start_date": "2025-10-18",
+    "end_date": "2026-05-14"
+  },
+  {
+    "date_type_id": 6,
+    "orcs_feature_number": "33-13",
+    "is_date_annual": null,
+    "operating_year": 2026,
+    "start_date": "2026-05-01",
+    "end_date": "2026-10-14"
+  },
+  {
+    "date_type_id": 7,
+    "orcs_feature_number": "33-13",
+    "is_date_annual": null,
+    "operating_year": 2026,
+    "start_date": "2026-05-01",
+    "end_date": "2026-10-13"
+  },
+  {
+    "date_type_id": 6,
+    "orcs_feature_number": "33-14",
+    "is_date_annual": null,
+    "operating_year": 2026,
+    "start_date": "2026-01-01",
+    "end_date": "2026-12-31"
+  },
+  {
+    "date_type_id": 7,
+    "orcs_feature_number": "33-14",
+    "is_date_annual": null,
+    "operating_year": 2026,
+    "start_date": "2026-01-01",
+    "end_date": "2026-12-31"
+  },
+  {
+    "date_type_id": 6,
+    "orcs_feature_number": "33-3",
+    "is_date_annual": false,
+    "operating_year": 2026,
+    "start_date": "2025-12-01",
+    "end_date": "2026-03-31"
+  },
+  {
+    "date_type_id": 6,
+    "orcs_feature_number": "33-3",
+    "is_date_annual": null,
+    "operating_year": 2026,
+    "start_date": "2026-12-01",
+    "end_date": "2027-03-31"
+  },
+  {
+    "date_type_id": 7,
+    "orcs_feature_number": "33-3",
+    "is_date_annual": false,
+    "operating_year": 2026,
+    "start_date": "2025-12-01",
+    "end_date": "2026-03-30"
+  },
+  {
+    "date_type_id": 7,
+    "orcs_feature_number": "33-3",
+    "is_date_annual": null,
+    "operating_year": 2026,
+    "start_date": "2026-12-01",
+    "end_date": "2027-03-30"
+  },
+  {
+    "date_type_id": 7,
+    "orcs_feature_number": "408-1",
+    "is_date_annual": null,
+    "operating_year": 2026,
+    "start_date": "2026-05-08",
+    "end_date": "2026-10-11"
+  },
+  {
+    "date_type_id": 6,
+    "orcs_feature_number": "409-1",
+    "is_date_annual": true,
+    "operating_year": 2026,
+    "start_date": "2025-11-01",
+    "end_date": "2026-08-31"
+  },
+  {
+    "date_type_id": 6,
+    "orcs_feature_number": "409-1",
+    "is_date_annual": true,
+    "operating_year": 2026,
+    "start_date": "2026-11-01",
+    "end_date": "2027-08-31"
+  },
+  {
+    "date_type_id": 6,
+    "orcs_feature_number": "41-11",
+    "is_date_annual": false,
+    "operating_year": 2026,
+    "start_date": "2026-03-06",
+    "end_date": "2027-01-03"
+  },
+  {
+    "date_type_id": 4,
+    "orcs_feature_number": "41-2",
+    "is_date_annual": null,
+    "operating_year": 2026,
+    "start_date": "2025-11-16",
+    "end_date": "2026-03-26"
+  },
+  {
+    "date_type_id": 6,
+    "orcs_feature_number": "41-4",
+    "is_date_annual": null,
+    "operating_year": 2026,
+    "start_date": "2026-03-27",
+    "end_date": "2026-10-18"
+  },
+  {
+    "date_type_id": 7,
+    "orcs_feature_number": "41-4",
+    "is_date_annual": null,
+    "operating_year": 2026,
+    "start_date": "2026-03-27",
+    "end_date": "2026-10-17"
+  },
+  {
+    "date_type_id": 6,
+    "orcs_feature_number": "41-5",
+    "is_date_annual": null,
+    "operating_year": 2026,
+    "start_date": "2026-03-27",
+    "end_date": "2026-10-18"
+  },
+  {
+    "date_type_id": 7,
+    "orcs_feature_number": "41-5",
+    "is_date_annual": null,
+    "operating_year": 2026,
+    "start_date": "2026-03-27",
+    "end_date": "2026-10-17"
+  },
+  {
+    "date_type_id": 6,
+    "orcs_feature_number": "41-8",
+    "is_date_annual": false,
+    "operating_year": 2026,
+    "start_date": "2026-03-06",
+    "end_date": "2027-01-03"
+  },
+  {
+    "date_type_id": 7,
+    "orcs_feature_number": "41-8",
+    "is_date_annual": false,
+    "operating_year": 2026,
+    "start_date": "2026-03-06",
+    "end_date": "2027-01-02"
+  },
+  {
+    "date_type_id": 4,
+    "orcs_feature_number": "45-4",
+    "is_date_annual": null,
+    "operating_year": 2026,
+    "start_date": "2025-11-01",
+    "end_date": "2025-11-30"
+  },
+  {
+    "date_type_id": 4,
+    "orcs_feature_number": "45-4",
+    "is_date_annual": null,
+    "operating_year": 2026,
+    "start_date": "2026-03-01",
+    "end_date": "2026-03-19"
+  },
+  {
+    "date_type_id": 4,
+    "orcs_feature_number": "45-5",
+    "is_date_annual": null,
+    "operating_year": 2026,
+    "start_date": "2026-03-01",
+    "end_date": "2026-03-19"
+  },
+  {
+    "date_type_id": 4,
+    "orcs_feature_number": "45-7",
+    "is_date_annual": null,
+    "operating_year": 2026,
+    "start_date": "2026-03-01",
+    "end_date": "2026-03-19"
+  },
+  {
+    "date_type_id": 4,
+    "orcs_feature_number": "48-1",
+    "is_date_annual": null,
+    "operating_year": 2026,
+    "start_date": "2025-11-01",
+    "end_date": "2026-03-19"
+  },
+  {
+    "date_type_id": 8,
+    "orcs_feature_number": "5-1",
+    "is_date_annual": false,
+    "operating_year": 2026,
+    "start_date": "2025-10-01",
+    "end_date": "2026-06-20"
+  },
+  {
+    "date_type_id": 8,
+    "orcs_feature_number": "5-1",
+    "is_date_annual": false,
+    "operating_year": 2026,
+    "start_date": "2026-10-01",
+    "end_date": "2027-06-20"
+  },
+  {
+    "date_type_id": 6,
+    "orcs_feature_number": "52-6",
+    "is_date_annual": false,
+    "operating_year": 2026,
+    "start_date": "2026-05-01",
+    "end_date": "2026-06-27"
+  },
+  {
+    "date_type_id": 6,
+    "orcs_feature_number": "52-6",
+    "is_date_annual": false,
+    "operating_year": 2026,
+    "start_date": "2026-09-07",
+    "end_date": "2026-09-28"
+  },
+  {
+    "date_type_id": 6,
+    "orcs_feature_number": "5-3",
+    "is_date_annual": false,
+    "operating_year": 2026,
+    "start_date": "2026-06-26",
+    "end_date": "2026-09-30"
+  },
+  {
+    "date_type_id": 7,
+    "orcs_feature_number": "5-3",
+    "is_date_annual": null,
+    "operating_year": 2026,
+    "start_date": "2026-06-26",
+    "end_date": "2026-09-30"
+  },
+  {
+    "date_type_id": 8,
+    "orcs_feature_number": "5-5",
+    "is_date_annual": false,
+    "operating_year": 2026,
+    "start_date": "2025-10-01",
+    "end_date": "2026-06-20"
+  },
+  {
+    "date_type_id": 8,
+    "orcs_feature_number": "5-5",
+    "is_date_annual": false,
+    "operating_year": 2026,
+    "start_date": "2026-10-01",
+    "end_date": "2027-06-20"
+  },
+  {
+    "date_type_id": 8,
+    "orcs_feature_number": "5-7",
+    "is_date_annual": false,
+    "operating_year": 2026,
+    "start_date": "2025-10-01",
+    "end_date": "2026-06-20"
+  },
+  {
+    "date_type_id": 8,
+    "orcs_feature_number": "5-7",
+    "is_date_annual": false,
+    "operating_year": 2026,
+    "start_date": "2026-10-01",
+    "end_date": "2027-06-20"
+  },
+  {
+    "date_type_id": 6,
+    "orcs_feature_number": "6161-1",
+    "is_date_annual": null,
+    "operating_year": 2026,
+    "start_date": "2026-04-01",
+    "end_date": "2026-10-31"
+  },
+  {
+    "date_type_id": 7,
+    "orcs_feature_number": "6161-1",
+    "is_date_annual": null,
+    "operating_year": 2026,
+    "start_date": "2026-04-01",
+    "end_date": "2026-10-30"
+  },
+  {
+    "date_type_id": 4,
+    "orcs_feature_number": "6161-2",
+    "is_date_annual": false,
+    "operating_year": 2026,
+    "start_date": "2025-11-01",
+    "end_date": "2026-03-31"
+  },
+  {
+    "date_type_id": 6,
+    "orcs_feature_number": "6161-2",
+    "is_date_annual": null,
+    "operating_year": 2026,
+    "start_date": "2026-04-01",
+    "end_date": "2026-10-31"
+  },
+  {
+    "date_type_id": 7,
+    "orcs_feature_number": "6161-2",
+    "is_date_annual": false,
+    "operating_year": 2026,
+    "start_date": "2026-05-08",
+    "end_date": "2026-09-06"
+  },
+  {
+    "date_type_id": 6,
+    "orcs_feature_number": "6161-3",
+    "is_date_annual": false,
+    "operating_year": 2026,
+    "start_date": "2026-04-01",
+    "end_date": "2026-10-31"
+  },
+  {
+    "date_type_id": 7,
+    "orcs_feature_number": "6161-3",
+    "is_date_annual": null,
+    "operating_year": 2026,
+    "start_date": "2026-04-01",
+    "end_date": "2026-10-30"
+  },
+  {
+    "date_type_id": 6,
+    "orcs_feature_number": "6878-4",
+    "is_date_annual": null,
+    "operating_year": 2026,
+    "start_date": "2026-04-10",
+    "end_date": "2026-10-12"
+  },
+  {
+    "date_type_id": 1,
+    "orcs_feature_number": "70-3",
+    "is_date_annual": null,
+    "operating_year": 2026,
+    "start_date": "2026-05-01",
+    "end_date": "2026-09-28"
+  },
+  {
+    "date_type_id": 6,
+    "orcs_feature_number": "70-3",
+    "is_date_annual": null,
+    "operating_year": 2026,
+    "start_date": "2026-05-01",
+    "end_date": "2026-09-28"
+  },
+  {
+    "date_type_id": 7,
+    "orcs_feature_number": "70-3",
+    "is_date_annual": null,
+    "operating_year": 2026,
+    "start_date": "2026-05-01",
+    "end_date": "2026-09-27"
+  },
+  {
+    "date_type_id": 6,
+    "orcs_feature_number": "7-12",
+    "is_date_annual": null,
+    "operating_year": 2027,
+    "start_date": "2026-11-01",
+    "end_date": "2027-08-31"
+  },
+  {
+    "date_type_id": 7,
+    "orcs_feature_number": "7-12",
+    "is_date_annual": null,
+    "operating_year": 2027,
+    "start_date": "2026-11-01",
+    "end_date": "2027-08-30"
+  },
+  {
+    "date_type_id": 7,
+    "orcs_feature_number": "75-1",
+    "is_date_annual": null,
+    "operating_year": 2026,
+    "start_date": "2026-05-08",
+    "end_date": "2026-09-29"
+  },
+  {
+    "date_type_id": 6,
+    "orcs_feature_number": "8-10",
+    "is_date_annual": true,
+    "operating_year": 2026,
+    "start_date": "2026-01-01",
+    "end_date": "2026-12-31"
+  },
+  {
+    "date_type_id": 6,
+    "orcs_feature_number": "8-11",
+    "is_date_annual": true,
+    "operating_year": 2026,
+    "start_date": "2026-01-01",
+    "end_date": "2026-12-31"
+  },
+  {
+    "date_type_id": 7,
+    "orcs_feature_number": "8-11",
+    "is_date_annual": true,
+    "operating_year": 2026,
+    "start_date": "2026-05-15",
+    "end_date": "2026-12-31"
+  },
+  {
+    "date_type_id": 8,
+    "orcs_feature_number": "8-11",
+    "is_date_annual": null,
+    "operating_year": 2026,
+    "start_date": "2026-01-01",
+    "end_date": "2026-05-14"
+  },
+  {
+    "date_type_id": 4,
+    "orcs_feature_number": "8-3",
+    "is_date_annual": null,
+    "operating_year": 2026,
+    "start_date": "2025-10-16",
+    "end_date": "2026-03-26"
+  },
+  {
+    "date_type_id": 7,
+    "orcs_feature_number": "8-4",
+    "is_date_annual": true,
+    "operating_year": 2026,
+    "start_date": "2026-05-15",
+    "end_date": "2026-12-31"
+  },
+  {
+    "date_type_id": 8,
+    "orcs_feature_number": "8-4",
+    "is_date_annual": true,
+    "operating_year": 2026,
+    "start_date": "2026-01-01",
+    "end_date": "2026-05-14"
+  },
+  {
+    "date_type_id": 4,
+    "orcs_feature_number": "92-3",
+    "is_date_annual": null,
+    "operating_year": 2026,
+    "start_date": "2025-10-14",
+    "end_date": "2026-03-31"
+  },
+  {
+    "date_type_id": 6,
+    "orcs_feature_number": "9451-1",
+    "is_date_annual": null,
+    "operating_year": 2026,
+    "start_date": "2026-06-01",
+    "end_date": "2026-10-31"
+  },
+  {
+    "date_type_id": 4,
+    "orcs_feature_number": "96-2",
+    "is_date_annual": null,
+    "operating_year": 2026,
+    "start_date": "2025-10-26",
+    "end_date": "2026-03-12"
+  }
+]

--- a/backend/tasks/import-2026-strapi-dates/feature-dates.json
+++ b/backend/tasks/import-2026-strapi-dates/feature-dates.json
@@ -1,13 +1,5 @@
 [
   {
-    "date_type_id": 4,
-    "orcs_feature_number": "104-1",
-    "is_date_annual": null,
-    "operating_year": 2026,
-    "start_date": "2025-11-01",
-    "end_date": "2026-03-14"
-  },
-  {
     "date_type_id": 6,
     "orcs_feature_number": "1-12",
     "is_date_annual": null,
@@ -28,24 +20,8 @@
     "orcs_feature_number": "117-1",
     "is_date_annual": null,
     "operating_year": 2026,
-    "start_date": "2025-11-01",
-    "end_date": "2026-03-31"
-  },
-  {
-    "date_type_id": 4,
-    "orcs_feature_number": "117-1",
-    "is_date_annual": null,
-    "operating_year": 2026,
     "start_date": "2026-11-01",
     "end_date": "2027-03-31"
-  },
-  {
-    "date_type_id": 4,
-    "orcs_feature_number": "122-1",
-    "is_date_annual": null,
-    "operating_year": 2026,
-    "start_date": "2025-10-16",
-    "end_date": "2026-03-26"
   },
   {
     "date_type_id": 1,
@@ -104,38 +80,6 @@
     "end_date": "2026-09-29"
   },
   {
-    "date_type_id": 4,
-    "orcs_feature_number": "182-1",
-    "is_date_annual": null,
-    "operating_year": 2026,
-    "start_date": "2025-10-16",
-    "end_date": "2026-04-10"
-  },
-  {
-    "date_type_id": 4,
-    "orcs_feature_number": "190-1",
-    "is_date_annual": null,
-    "operating_year": 2026,
-    "start_date": "2025-10-14",
-    "end_date": "2026-04-29"
-  },
-  {
-    "date_type_id": 4,
-    "orcs_feature_number": "193-1",
-    "is_date_annual": null,
-    "operating_year": 2026,
-    "start_date": "2025-10-26",
-    "end_date": "2026-03-13"
-  },
-  {
-    "date_type_id": 4,
-    "orcs_feature_number": "193-2",
-    "is_date_annual": null,
-    "operating_year": 2026,
-    "start_date": "2025-10-26",
-    "end_date": "2026-03-13"
-  },
-  {
     "date_type_id": 6,
     "orcs_feature_number": "20-1",
     "is_date_annual": false,
@@ -150,14 +94,6 @@
     "operating_year": 2026,
     "start_date": "2026-05-01",
     "end_date": "2026-09-27"
-  },
-  {
-    "date_type_id": 4,
-    "orcs_feature_number": "210-1",
-    "is_date_annual": false,
-    "operating_year": 2026,
-    "start_date": "2025-11-01",
-    "end_date": "2026-03-31"
   },
   {
     "date_type_id": 6,
@@ -182,22 +118,6 @@
     "operating_year": 2026,
     "start_date": "2026-06-01",
     "end_date": "2026-09-30"
-  },
-  {
-    "date_type_id": 4,
-    "orcs_feature_number": "262-1",
-    "is_date_annual": null,
-    "operating_year": 2026,
-    "start_date": "2025-10-26",
-    "end_date": "2026-03-12"
-  },
-  {
-    "date_type_id": 4,
-    "orcs_feature_number": "267-1",
-    "is_date_annual": null,
-    "operating_year": 2026,
-    "start_date": "2025-11-01",
-    "end_date": "2026-03-14"
   },
   {
     "date_type_id": 6,
@@ -232,30 +152,6 @@
     "end_date": "2026-09-29"
   },
   {
-    "date_type_id": 4,
-    "orcs_feature_number": "28-2",
-    "is_date_annual": null,
-    "operating_year": 2026,
-    "start_date": "2025-11-01",
-    "end_date": "2026-03-19"
-  },
-  {
-    "date_type_id": 4,
-    "orcs_feature_number": "28-3",
-    "is_date_annual": null,
-    "operating_year": 2026,
-    "start_date": "2025-11-01",
-    "end_date": "2026-03-19"
-  },
-  {
-    "date_type_id": 4,
-    "orcs_feature_number": "28-4",
-    "is_date_annual": null,
-    "operating_year": 2026,
-    "start_date": "2025-11-01",
-    "end_date": "2026-03-19"
-  },
-  {
     "date_type_id": 6,
     "orcs_feature_number": "292-1",
     "is_date_annual": null,
@@ -286,46 +182,6 @@
     "operating_year": 2026,
     "start_date": "2026-06-10",
     "end_date": "2026-10-12"
-  },
-  {
-    "date_type_id": 4,
-    "orcs_feature_number": "31-1",
-    "is_date_annual": null,
-    "operating_year": 2026,
-    "start_date": "2025-11-16",
-    "end_date": "2026-03-31"
-  },
-  {
-    "date_type_id": 4,
-    "orcs_feature_number": "314-4",
-    "is_date_annual": null,
-    "operating_year": 2026,
-    "start_date": "2025-11-12",
-    "end_date": "2026-02-28"
-  },
-  {
-    "date_type_id": 4,
-    "orcs_feature_number": "314-6",
-    "is_date_annual": null,
-    "operating_year": 2026,
-    "start_date": "2025-11-12",
-    "end_date": "2026-02-28"
-  },
-  {
-    "date_type_id": 4,
-    "orcs_feature_number": "33-11",
-    "is_date_annual": null,
-    "operating_year": 2026,
-    "start_date": "2025-10-18",
-    "end_date": "2026-05-15"
-  },
-  {
-    "date_type_id": 6,
-    "orcs_feature_number": "33-11",
-    "is_date_annual": false,
-    "operating_year": 2026,
-    "start_date": "2025-10-18",
-    "end_date": "2026-05-14"
   },
   {
     "date_type_id": 6,
@@ -362,26 +218,10 @@
   {
     "date_type_id": 6,
     "orcs_feature_number": "33-3",
-    "is_date_annual": false,
-    "operating_year": 2026,
-    "start_date": "2025-12-01",
-    "end_date": "2026-03-31"
-  },
-  {
-    "date_type_id": 6,
-    "orcs_feature_number": "33-3",
     "is_date_annual": null,
     "operating_year": 2026,
     "start_date": "2026-12-01",
     "end_date": "2027-03-31"
-  },
-  {
-    "date_type_id": 7,
-    "orcs_feature_number": "33-3",
-    "is_date_annual": false,
-    "operating_year": 2026,
-    "start_date": "2025-12-01",
-    "end_date": "2026-03-30"
   },
   {
     "date_type_id": 7,
@@ -404,14 +244,6 @@
     "orcs_feature_number": "409-1",
     "is_date_annual": true,
     "operating_year": 2026,
-    "start_date": "2025-11-01",
-    "end_date": "2026-08-31"
-  },
-  {
-    "date_type_id": 6,
-    "orcs_feature_number": "409-1",
-    "is_date_annual": true,
-    "operating_year": 2026,
     "start_date": "2026-11-01",
     "end_date": "2027-08-31"
   },
@@ -422,14 +254,6 @@
     "operating_year": 2026,
     "start_date": "2026-03-06",
     "end_date": "2027-01-03"
-  },
-  {
-    "date_type_id": 4,
-    "orcs_feature_number": "41-2",
-    "is_date_annual": null,
-    "operating_year": 2026,
-    "start_date": "2025-11-16",
-    "end_date": "2026-03-26"
   },
   {
     "date_type_id": 6,
@@ -484,14 +308,6 @@
     "orcs_feature_number": "45-4",
     "is_date_annual": null,
     "operating_year": 2026,
-    "start_date": "2025-11-01",
-    "end_date": "2025-11-30"
-  },
-  {
-    "date_type_id": 4,
-    "orcs_feature_number": "45-4",
-    "is_date_annual": null,
-    "operating_year": 2026,
     "start_date": "2026-03-01",
     "end_date": "2026-03-19"
   },
@@ -510,22 +326,6 @@
     "operating_year": 2026,
     "start_date": "2026-03-01",
     "end_date": "2026-03-19"
-  },
-  {
-    "date_type_id": 4,
-    "orcs_feature_number": "48-1",
-    "is_date_annual": null,
-    "operating_year": 2026,
-    "start_date": "2025-11-01",
-    "end_date": "2026-03-19"
-  },
-  {
-    "date_type_id": 8,
-    "orcs_feature_number": "5-1",
-    "is_date_annual": false,
-    "operating_year": 2026,
-    "start_date": "2025-10-01",
-    "end_date": "2026-06-20"
   },
   {
     "date_type_id": 8,
@@ -572,24 +372,8 @@
     "orcs_feature_number": "5-5",
     "is_date_annual": false,
     "operating_year": 2026,
-    "start_date": "2025-10-01",
-    "end_date": "2026-06-20"
-  },
-  {
-    "date_type_id": 8,
-    "orcs_feature_number": "5-5",
-    "is_date_annual": false,
-    "operating_year": 2026,
     "start_date": "2026-10-01",
     "end_date": "2027-06-20"
-  },
-  {
-    "date_type_id": 8,
-    "orcs_feature_number": "5-7",
-    "is_date_annual": false,
-    "operating_year": 2026,
-    "start_date": "2025-10-01",
-    "end_date": "2026-06-20"
   },
   {
     "date_type_id": 8,
@@ -614,14 +398,6 @@
     "operating_year": 2026,
     "start_date": "2026-04-01",
     "end_date": "2026-10-30"
-  },
-  {
-    "date_type_id": 4,
-    "orcs_feature_number": "6161-2",
-    "is_date_annual": false,
-    "operating_year": 2026,
-    "start_date": "2025-11-01",
-    "end_date": "2026-03-31"
   },
   {
     "date_type_id": 6,
@@ -691,7 +467,7 @@
     "date_type_id": 6,
     "orcs_feature_number": "7-12",
     "is_date_annual": null,
-    "operating_year": 2027,
+    "operating_year": 2026,
     "start_date": "2026-11-01",
     "end_date": "2027-08-31"
   },
@@ -699,7 +475,7 @@
     "date_type_id": 7,
     "orcs_feature_number": "7-12",
     "is_date_annual": null,
-    "operating_year": 2027,
+    "operating_year": 2026,
     "start_date": "2026-11-01",
     "end_date": "2027-08-30"
   },
@@ -744,14 +520,6 @@
     "end_date": "2026-05-14"
   },
   {
-    "date_type_id": 4,
-    "orcs_feature_number": "8-3",
-    "is_date_annual": null,
-    "operating_year": 2026,
-    "start_date": "2025-10-16",
-    "end_date": "2026-03-26"
-  },
-  {
     "date_type_id": 7,
     "orcs_feature_number": "8-4",
     "is_date_annual": true,
@@ -768,27 +536,11 @@
     "end_date": "2026-05-14"
   },
   {
-    "date_type_id": 4,
-    "orcs_feature_number": "92-3",
-    "is_date_annual": null,
-    "operating_year": 2026,
-    "start_date": "2025-10-14",
-    "end_date": "2026-03-31"
-  },
-  {
     "date_type_id": 6,
     "orcs_feature_number": "9451-1",
     "is_date_annual": null,
     "operating_year": 2026,
     "start_date": "2026-06-01",
     "end_date": "2026-10-31"
-  },
-  {
-    "date_type_id": 4,
-    "orcs_feature_number": "96-2",
-    "is_date_annual": null,
-    "operating_year": 2026,
-    "start_date": "2025-10-26",
-    "end_date": "2026-03-12"
   }
 ]

--- a/backend/tasks/import-2026-strapi-dates/feature-dates.json
+++ b/backend/tasks/import-2026-strapi-dates/feature-dates.json
@@ -2,6 +2,7 @@
   {
     "date_type_id": 6,
     "orcs_feature_number": "1-12",
+    "name": "1: 2026 - Operation",
     "is_date_annual": null,
     "operating_year": 2026,
     "start_date": "2026-05-09",
@@ -10,6 +11,7 @@
   {
     "date_type_id": 7,
     "orcs_feature_number": "1-12",
+    "name": "1: 2026 - Reservation",
     "is_date_annual": null,
     "operating_year": 2026,
     "start_date": "2026-05-09",
@@ -18,6 +20,7 @@
   {
     "date_type_id": 4,
     "orcs_feature_number": "117-1",
+    "name": "F-117-1: 2026 - Winter fee",
     "is_date_annual": null,
     "operating_year": 2026,
     "start_date": "2026-11-01",
@@ -26,6 +29,7 @@
   {
     "date_type_id": 1,
     "orcs_feature_number": "15-2",
+    "name": "F-15-2: 2026 - Gate",
     "is_date_annual": false,
     "operating_year": 2026,
     "start_date": "2026-01-01",
@@ -34,6 +38,7 @@
   {
     "date_type_id": 6,
     "orcs_feature_number": "15-2",
+    "name": "F-15-2: 2026 - Operation",
     "is_date_annual": false,
     "operating_year": 2026,
     "start_date": "2026-01-01",
@@ -42,6 +47,7 @@
   {
     "date_type_id": 7,
     "orcs_feature_number": "15-2",
+    "name": "F-15-2: 2026 - Reservation",
     "is_date_annual": false,
     "operating_year": 2026,
     "start_date": "2026-01-01",
@@ -50,6 +56,7 @@
   {
     "date_type_id": 6,
     "orcs_feature_number": "1-6",
+    "name": "1: 2026 - Operation",
     "is_date_annual": null,
     "operating_year": 2026,
     "start_date": "2026-06-26",
@@ -58,6 +65,7 @@
   {
     "date_type_id": 7,
     "orcs_feature_number": "1-6",
+    "name": "1: 2026 - Reservation",
     "is_date_annual": null,
     "operating_year": 2026,
     "start_date": "2026-06-26",
@@ -66,6 +74,7 @@
   {
     "date_type_id": 6,
     "orcs_feature_number": "1-7",
+    "name": "1: 2026 - Operation",
     "is_date_annual": null,
     "operating_year": 2026,
     "start_date": "2026-05-09",
@@ -74,6 +83,7 @@
   {
     "date_type_id": 7,
     "orcs_feature_number": "1-7",
+    "name": "1: 2026 - Reservation",
     "is_date_annual": null,
     "operating_year": 2026,
     "start_date": "2026-05-09",
@@ -82,6 +92,7 @@
   {
     "date_type_id": 6,
     "orcs_feature_number": "20-1",
+    "name": "F-20-1: 2026 - Operation",
     "is_date_annual": false,
     "operating_year": 2026,
     "start_date": "2026-05-01",
@@ -90,6 +101,7 @@
   {
     "date_type_id": 6,
     "orcs_feature_number": "20-2",
+    "name": "F-20-2: 2026 - Operation",
     "is_date_annual": null,
     "operating_year": 2026,
     "start_date": "2026-05-01",
@@ -98,6 +110,7 @@
   {
     "date_type_id": 6,
     "orcs_feature_number": "2-14",
+    "name": "F-2-14: 2026 - Operation",
     "is_date_annual": null,
     "operating_year": 2026,
     "start_date": "2026-05-15",
@@ -106,6 +119,7 @@
   {
     "date_type_id": 7,
     "orcs_feature_number": "2-14",
+    "name": "F-2-14: 2026 - Reservation",
     "is_date_annual": null,
     "operating_year": 2026,
     "start_date": "2026-05-15",
@@ -114,6 +128,7 @@
   {
     "date_type_id": 6,
     "orcs_feature_number": "255-3",
+    "name": "F-255-3: 2026 - Operation",
     "is_date_annual": true,
     "operating_year": 2026,
     "start_date": "2026-06-01",
@@ -122,6 +137,7 @@
   {
     "date_type_id": 6,
     "orcs_feature_number": "267-3",
+    "name": "F-267-3: 2026 - Operation",
     "is_date_annual": null,
     "operating_year": 2026,
     "start_date": "2026-03-13",
@@ -130,6 +146,7 @@
   {
     "date_type_id": 7,
     "orcs_feature_number": "267-3",
+    "name": "F-267-3: 2026 - Reservation",
     "is_date_annual": null,
     "operating_year": 2026,
     "start_date": "2026-03-13",
@@ -138,6 +155,7 @@
   {
     "date_type_id": 6,
     "orcs_feature_number": "273-8",
+    "name": "F-273-8: 2026 - Operation",
     "is_date_annual": null,
     "operating_year": 2026,
     "start_date": "2026-05-15",
@@ -146,6 +164,7 @@
   {
     "date_type_id": 7,
     "orcs_feature_number": "273-8",
+    "name": "F-273-8: 2026 - Reservation",
     "is_date_annual": false,
     "operating_year": 2026,
     "start_date": "2026-05-15",
@@ -154,6 +173,7 @@
   {
     "date_type_id": 6,
     "orcs_feature_number": "292-1",
+    "name": "F-292-1: 2026 - Operation",
     "is_date_annual": null,
     "operating_year": 2026,
     "start_date": "2026-06-10",
@@ -162,6 +182,7 @@
   {
     "date_type_id": 7,
     "orcs_feature_number": "292-1",
+    "name": "F-292-1: 2026 - Reservation",
     "is_date_annual": false,
     "operating_year": 2026,
     "start_date": "2026-06-10",
@@ -170,6 +191,7 @@
   {
     "date_type_id": 6,
     "orcs_feature_number": "292-2",
+    "name": "F-292-2: 2026 - Operation",
     "is_date_annual": null,
     "operating_year": 2026,
     "start_date": "2026-06-10",
@@ -178,6 +200,7 @@
   {
     "date_type_id": 7,
     "orcs_feature_number": "292-2",
+    "name": "292: 2026 - Reservation",
     "is_date_annual": null,
     "operating_year": 2026,
     "start_date": "2026-06-10",
@@ -186,6 +209,7 @@
   {
     "date_type_id": 6,
     "orcs_feature_number": "33-13",
+    "name": "F-33-13: 2026 - Operation",
     "is_date_annual": null,
     "operating_year": 2026,
     "start_date": "2026-05-01",
@@ -194,6 +218,7 @@
   {
     "date_type_id": 7,
     "orcs_feature_number": "33-13",
+    "name": "F-33-13: 2026 - Reservation",
     "is_date_annual": null,
     "operating_year": 2026,
     "start_date": "2026-05-01",
@@ -202,6 +227,7 @@
   {
     "date_type_id": 6,
     "orcs_feature_number": "33-14",
+    "name": "F-33-14: 2026 - Operation",
     "is_date_annual": null,
     "operating_year": 2026,
     "start_date": "2026-01-01",
@@ -210,6 +236,7 @@
   {
     "date_type_id": 7,
     "orcs_feature_number": "33-14",
+    "name": "F-33-14: 2026 - Reservation",
     "is_date_annual": null,
     "operating_year": 2026,
     "start_date": "2026-01-01",
@@ -218,6 +245,7 @@
   {
     "date_type_id": 6,
     "orcs_feature_number": "33-3",
+    "name": "F-33-3: 2026 - Operation",
     "is_date_annual": null,
     "operating_year": 2026,
     "start_date": "2026-12-01",
@@ -226,6 +254,7 @@
   {
     "date_type_id": 7,
     "orcs_feature_number": "33-3",
+    "name": "F-33-3: 2026 - Reservation",
     "is_date_annual": null,
     "operating_year": 2026,
     "start_date": "2026-12-01",
@@ -234,6 +263,7 @@
   {
     "date_type_id": 7,
     "orcs_feature_number": "408-1",
+    "name": "F-408-1: 2026 - Reservation",
     "is_date_annual": null,
     "operating_year": 2026,
     "start_date": "2026-05-08",
@@ -242,6 +272,7 @@
   {
     "date_type_id": 6,
     "orcs_feature_number": "409-1",
+    "name": "F-409-1: 2026 - Operation",
     "is_date_annual": true,
     "operating_year": 2026,
     "start_date": "2026-11-01",
@@ -250,6 +281,7 @@
   {
     "date_type_id": 6,
     "orcs_feature_number": "41-11",
+    "name": "F-41-11: 2026 - Operation",
     "is_date_annual": false,
     "operating_year": 2026,
     "start_date": "2026-03-06",
@@ -258,6 +290,7 @@
   {
     "date_type_id": 6,
     "orcs_feature_number": "41-4",
+    "name": "F-41-4: 2026 - Operation",
     "is_date_annual": null,
     "operating_year": 2026,
     "start_date": "2026-03-27",
@@ -266,6 +299,7 @@
   {
     "date_type_id": 7,
     "orcs_feature_number": "41-4",
+    "name": "F-41-4: 2026 - Reservation",
     "is_date_annual": null,
     "operating_year": 2026,
     "start_date": "2026-03-27",
@@ -274,6 +308,7 @@
   {
     "date_type_id": 6,
     "orcs_feature_number": "41-5",
+    "name": "F-41-5: 2026 - Operation",
     "is_date_annual": null,
     "operating_year": 2026,
     "start_date": "2026-03-27",
@@ -282,6 +317,7 @@
   {
     "date_type_id": 7,
     "orcs_feature_number": "41-5",
+    "name": "F-41-5: 2026 - Reservation",
     "is_date_annual": null,
     "operating_year": 2026,
     "start_date": "2026-03-27",
@@ -290,6 +326,7 @@
   {
     "date_type_id": 6,
     "orcs_feature_number": "41-8",
+    "name": "F-41-8: 2026 - Operation",
     "is_date_annual": false,
     "operating_year": 2026,
     "start_date": "2026-03-06",
@@ -298,6 +335,7 @@
   {
     "date_type_id": 7,
     "orcs_feature_number": "41-8",
+    "name": "F-41-8: 2026 - Reservation",
     "is_date_annual": false,
     "operating_year": 2026,
     "start_date": "2026-03-06",
@@ -306,6 +344,7 @@
   {
     "date_type_id": 4,
     "orcs_feature_number": "45-4",
+    "name": "F-45-4: 2026 - Winter fee",
     "is_date_annual": null,
     "operating_year": 2026,
     "start_date": "2026-03-01",
@@ -314,6 +353,7 @@
   {
     "date_type_id": 4,
     "orcs_feature_number": "45-5",
+    "name": "F-45-5: 2026 - Winter fee",
     "is_date_annual": null,
     "operating_year": 2026,
     "start_date": "2026-03-01",
@@ -322,6 +362,7 @@
   {
     "date_type_id": 4,
     "orcs_feature_number": "45-7",
+    "name": "F-45-7: 2026 - Winter fee",
     "is_date_annual": null,
     "operating_year": 2026,
     "start_date": "2026-03-01",
@@ -330,6 +371,7 @@
   {
     "date_type_id": 8,
     "orcs_feature_number": "5-1",
+    "name": "F-5-1: 2026 - Backcountry registration",
     "is_date_annual": false,
     "operating_year": 2026,
     "start_date": "2026-10-01",
@@ -338,6 +380,7 @@
   {
     "date_type_id": 6,
     "orcs_feature_number": "52-6",
+    "name": "F-52-6: 2026 - Operation",
     "is_date_annual": false,
     "operating_year": 2026,
     "start_date": "2026-05-01",
@@ -346,6 +389,7 @@
   {
     "date_type_id": 6,
     "orcs_feature_number": "52-6",
+    "name": "F-52-6: 2026 - Operation",
     "is_date_annual": false,
     "operating_year": 2026,
     "start_date": "2026-09-07",
@@ -354,6 +398,7 @@
   {
     "date_type_id": 6,
     "orcs_feature_number": "5-3",
+    "name": "F-5-3: 2026 - Operation",
     "is_date_annual": false,
     "operating_year": 2026,
     "start_date": "2026-06-26",
@@ -362,6 +407,7 @@
   {
     "date_type_id": 7,
     "orcs_feature_number": "5-3",
+    "name": "F-5-3: 2026 - Reservation",
     "is_date_annual": null,
     "operating_year": 2026,
     "start_date": "2026-06-26",
@@ -370,6 +416,7 @@
   {
     "date_type_id": 8,
     "orcs_feature_number": "5-5",
+    "name": "F-5-5: 2026 - Backcountry registration",
     "is_date_annual": false,
     "operating_year": 2026,
     "start_date": "2026-10-01",
@@ -378,6 +425,7 @@
   {
     "date_type_id": 8,
     "orcs_feature_number": "5-7",
+    "name": "F-5-7: 2026 - Backcountry registration",
     "is_date_annual": false,
     "operating_year": 2026,
     "start_date": "2026-10-01",
@@ -386,6 +434,7 @@
   {
     "date_type_id": 6,
     "orcs_feature_number": "6161-1",
+    "name": "F-6161-1: 2026 - Operation",
     "is_date_annual": null,
     "operating_year": 2026,
     "start_date": "2026-04-01",
@@ -394,6 +443,7 @@
   {
     "date_type_id": 7,
     "orcs_feature_number": "6161-1",
+    "name": "F-6161-1: 2026 - Reservation",
     "is_date_annual": null,
     "operating_year": 2026,
     "start_date": "2026-04-01",
@@ -402,6 +452,7 @@
   {
     "date_type_id": 6,
     "orcs_feature_number": "6161-2",
+    "name": "F-6161-2: 2026 - Operation",
     "is_date_annual": null,
     "operating_year": 2026,
     "start_date": "2026-04-01",
@@ -410,6 +461,7 @@
   {
     "date_type_id": 7,
     "orcs_feature_number": "6161-2",
+    "name": "F-6161-2: 2026 - Reservation",
     "is_date_annual": false,
     "operating_year": 2026,
     "start_date": "2026-05-08",
@@ -418,6 +470,7 @@
   {
     "date_type_id": 6,
     "orcs_feature_number": "6161-3",
+    "name": "F-6161-3: 2026 - Operation",
     "is_date_annual": false,
     "operating_year": 2026,
     "start_date": "2026-04-01",
@@ -426,6 +479,7 @@
   {
     "date_type_id": 7,
     "orcs_feature_number": "6161-3",
+    "name": "F-6161-3: 2026 - Reservation",
     "is_date_annual": null,
     "operating_year": 2026,
     "start_date": "2026-04-01",
@@ -434,6 +488,7 @@
   {
     "date_type_id": 6,
     "orcs_feature_number": "6878-4",
+    "name": "F-6878-4: 2026 - Operation",
     "is_date_annual": null,
     "operating_year": 2026,
     "start_date": "2026-04-10",
@@ -442,6 +497,7 @@
   {
     "date_type_id": 1,
     "orcs_feature_number": "70-3",
+    "name": "F-70-3: 2026 - Gate",
     "is_date_annual": null,
     "operating_year": 2026,
     "start_date": "2026-05-01",
@@ -450,6 +506,7 @@
   {
     "date_type_id": 6,
     "orcs_feature_number": "70-3",
+    "name": "F-70-3: 2026 - Operation",
     "is_date_annual": null,
     "operating_year": 2026,
     "start_date": "2026-05-01",
@@ -458,6 +515,7 @@
   {
     "date_type_id": 7,
     "orcs_feature_number": "70-3",
+    "name": "F-70-3: 2026 - Reservation",
     "is_date_annual": null,
     "operating_year": 2026,
     "start_date": "2026-05-01",
@@ -466,6 +524,7 @@
   {
     "date_type_id": 6,
     "orcs_feature_number": "7-12",
+    "name": "F-7-12: 2027 - Operation",
     "is_date_annual": null,
     "operating_year": 2026,
     "start_date": "2026-11-01",
@@ -474,6 +533,7 @@
   {
     "date_type_id": 7,
     "orcs_feature_number": "7-12",
+    "name": "F-7-12: 2027 - Reservation",
     "is_date_annual": null,
     "operating_year": 2026,
     "start_date": "2026-11-01",
@@ -482,6 +542,7 @@
   {
     "date_type_id": 7,
     "orcs_feature_number": "75-1",
+    "name": "F-75-1: 2026 - Reservation",
     "is_date_annual": null,
     "operating_year": 2026,
     "start_date": "2026-05-08",
@@ -490,6 +551,7 @@
   {
     "date_type_id": 6,
     "orcs_feature_number": "8-10",
+    "name": "F-8-10: 2026 - Operation",
     "is_date_annual": true,
     "operating_year": 2026,
     "start_date": "2026-01-01",
@@ -498,6 +560,7 @@
   {
     "date_type_id": 6,
     "orcs_feature_number": "8-11",
+    "name": "F-8-11: 2026 - Operation",
     "is_date_annual": true,
     "operating_year": 2026,
     "start_date": "2026-01-01",
@@ -506,6 +569,7 @@
   {
     "date_type_id": 7,
     "orcs_feature_number": "8-11",
+    "name": "F-8-11: 2026 - Reservation",
     "is_date_annual": true,
     "operating_year": 2026,
     "start_date": "2026-05-15",
@@ -514,6 +578,7 @@
   {
     "date_type_id": 8,
     "orcs_feature_number": "8-11",
+    "name": "",
     "is_date_annual": null,
     "operating_year": 2026,
     "start_date": "2026-01-01",
@@ -522,6 +587,7 @@
   {
     "date_type_id": 7,
     "orcs_feature_number": "8-4",
+    "name": "F-8-4: 2026 - Reservation",
     "is_date_annual": true,
     "operating_year": 2026,
     "start_date": "2026-05-15",
@@ -530,6 +596,7 @@
   {
     "date_type_id": 8,
     "orcs_feature_number": "8-4",
+    "name": "F-8-4: 2026 - Backcountry registration",
     "is_date_annual": true,
     "operating_year": 2026,
     "start_date": "2026-01-01",
@@ -538,6 +605,7 @@
   {
     "date_type_id": 6,
     "orcs_feature_number": "9451-1",
+    "name": "F-9451-1: 2026 - Operation",
     "is_date_annual": null,
     "operating_year": 2026,
     "start_date": "2026-06-01",

--- a/backend/tasks/import-2026-strapi-dates/import-2026-strapi-feature-dates.js
+++ b/backend/tasks/import-2026-strapi-dates/import-2026-strapi-feature-dates.js
@@ -112,21 +112,28 @@ try {
       );
     }
 
-    let publishableId = parkArea?.publishableId
+    let publishableId = parkArea
       ? parkArea.publishableId
       : feature.publishableId;
 
-    // If publishableId is still null, create one for the feature
+    // If publishableId is still null, create one for the parkArea or feature
     if (!publishableId) {
       const publishable = await Publishable.create({}, { transaction });
 
       publishableId = publishable.id;
-      feature.publishableId = publishableId;
-      await feature.save({ transaction });
-
-      console.log(
-        `${dryRun ? "[DRY RUN] Would create" : "Created"} publishableId for feature ${orcsFeatureNumber}: ${publishableId}`,
-      );
+      if (parkArea) {
+        parkArea.publishableId = publishableId;
+        await parkArea.save({ transaction });
+        console.log(
+          `${dryRun ? "[DRY RUN] Would create" : "Created"} publishableId for park area ${parkArea.id}: ${publishableId}`,
+        );
+      } else {
+        feature.publishableId = publishableId;
+        await feature.save({ transaction });
+        console.log(
+          `${dryRun ? "[DRY RUN] Would create" : "Created"} publishableId for feature ${orcsFeatureNumber}: ${publishableId}`,
+        );
+      }
     }
 
     const seasonType =

--- a/backend/tasks/import-2026-strapi-dates/import-2026-strapi-feature-dates.js
+++ b/backend/tasks/import-2026-strapi-dates/import-2026-strapi-feature-dates.js
@@ -1,0 +1,303 @@
+import "../../env.js";
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  DateType,
+  Feature,
+  ParkArea,
+  Season,
+  DateRange,
+  DateRangeAnnual,
+  Publishable,
+  Dateable,
+} from "../../models/index.js";
+import * as SEASON_TYPE from "../../constants/seasonType.js";
+import * as DATE_TYPE from "../../constants/dateType.js";
+import * as SEASON_STATUS from "../../constants/seasonStatus.js";
+
+const filename = fileURLToPath(import.meta.url);
+const dirname = path.dirname(filename);
+
+// Set to true to preview changes without writing to the database
+const dryRun = false;
+
+const featureDates = JSON.parse(
+  fs.readFileSync(path.join(dirname, "feature-dates.json"), "utf8"),
+);
+
+// get a list of unique orcs_feature_number, date_type_id and operating_year combos from the featureDates data
+const uniqueFeatureDateKeys = [
+  ...new Map(
+    featureDates.map((item) => [
+      `${item.orcs_feature_number}-${item.date_type_id}-${item.operating_year}`,
+      {
+        orcsFeatureNumber: item.orcs_feature_number,
+        dateTypeNumber: item.date_type_id,
+        operatingYear: item.operating_year,
+      },
+    ]),
+  ).values(),
+];
+
+let seasonsAdded = 0;
+let dateRangesAdded = 0;
+let dateRangesDeleted = 0;
+let dateRangeAnnualsAdded = 0;
+let dateRangeAnnualsUpdated = 0;
+
+const transaction = await Season.sequelize.transaction();
+
+try {
+  // for each key in uniqueFeatureDateKeys, find the list of corresponding DateRange records in the database and check if they match the JSON data.
+  for (const key of uniqueFeatureDateKeys) {
+    const { orcsFeatureNumber, dateTypeNumber, operatingYear } = key;
+
+    // find the corresponding DateType record in the database
+    const dateType = await DateType.findOne({
+      where: { dateTypeNumber },
+      transaction,
+    });
+
+    if (!dateType) {
+      console.error(
+        `No DateType found for date_type_id ${dateTypeNumber}. Skipping...`,
+      );
+      continue;
+    }
+
+    // find the corresponding Feature record in the database
+    const feature = await Feature.findOne({
+      where: { orcsFeatureNumber },
+      transaction,
+    });
+
+    if (!feature) {
+      console.error(
+        `No Feature found for orcs_feature_number ${orcsFeatureNumber}. Skipping...`,
+      );
+      continue;
+    }
+
+    // if the feature has a parkAreaId then get the parkArea
+    let parkArea = null;
+
+    if (feature.parkAreaId) {
+      parkArea = await ParkArea.findOne({
+        where: { id: feature.parkAreaId },
+        transaction,
+      });
+
+      if (!parkArea) {
+        console.error(
+          `No Park Area found for parkAreaId ${feature.parkAreaId}. Skipping...`,
+        );
+        continue;
+      }
+    }
+
+    let dateableId = feature.dateableId;
+
+    // If dateableId is null, create one for the feature
+    if (!dateableId) {
+      const dateable = await Dateable.create({}, { transaction });
+
+      dateableId = dateable.id;
+      feature.dateableId = dateableId;
+      await feature.save({ transaction });
+
+      console.log(
+        `${dryRun ? "[DRY RUN] Would create" : "Created"} dateableId for feature ${orcsFeatureNumber}: ${dateableId}`,
+      );
+    }
+
+    let publishableId = parkArea?.publishableId
+      ? parkArea.publishableId
+      : feature.publishableId;
+
+    // If publishableId is still null, create one for the feature
+    if (!publishableId) {
+      const publishable = await Publishable.create({}, { transaction });
+
+      publishableId = publishable.id;
+      feature.publishableId = publishableId;
+      await feature.save({ transaction });
+
+      console.log(
+        `${dryRun ? "[DRY RUN] Would create" : "Created"} publishableId for feature ${orcsFeatureNumber}: ${publishableId}`,
+      );
+    }
+
+    const seasonType =
+      dateTypeNumber === DATE_TYPE.WINTER_FEE
+        ? SEASON_TYPE.WINTER
+        : SEASON_TYPE.REGULAR;
+
+    // get the season for the publishableId, operatingYear and seasonType
+    let season = await Season.findOne({
+      where: {
+        publishableId,
+        operatingYear,
+        seasonType,
+      },
+      transaction,
+    });
+
+    if (!season) {
+      // create the Season record if it doesn't exist
+      season = await Season.create(
+        {
+          publishableId,
+          operatingYear,
+          seasonType,
+          status: SEASON_STATUS.PUBLISHED,
+          readyToPublish: true,
+        },
+        { transaction },
+      );
+
+      seasonsAdded++;
+
+      console.log(
+        `${dryRun ? "[DRY RUN] Would create" : "Created"} new Season for publishableId ${publishableId}, operatingYear ${operatingYear}, seasonType ${seasonType}`,
+      );
+    }
+
+    // filter featureDates to find all records that match the current key
+    const matchingFeatureDates = featureDates.filter(
+      (item) =>
+        item.orcs_feature_number === orcsFeatureNumber &&
+        item.date_type_id === dateTypeNumber &&
+        item.operating_year === operatingYear,
+    );
+
+    // for each matchingFeatureDate, check if a DateRange record exists in the database
+    for (const featureDate of matchingFeatureDates) {
+      const { start_date: startDate, end_date: endDate } = featureDate;
+
+      // find the corresponding DateRange record in the database
+      const dateRange = await DateRange.findOne({
+        where: {
+          dateableId,
+          dateTypeId: dateType.id,
+          seasonId: season.id,
+          startDate,
+          endDate,
+        },
+        transaction,
+      });
+
+      if (!dateRange) {
+        // create the DateRange record if it doesn't exist
+        await DateRange.create(
+          {
+            dateableId,
+            dateTypeId: dateType.id,
+            seasonId: season.id,
+            startDate,
+            endDate,
+          },
+          { transaction },
+        );
+
+        dateRangesAdded++;
+
+        console.log(
+          `${dryRun ? "[DRY RUN] Would create" : "Created"} new DateRange for dateableId ${dateableId}, dateTypeId ${dateType.id}, startDate ${startDate}, endDate ${endDate}`,
+        );
+      }
+    }
+
+    // delete any DateRange records that exist in the database for this dateableId, seasonId and dateTypeId
+    // that are not in the matchingFeatureDates
+    const existingDateRanges = await DateRange.findAll({
+      where: {
+        dateableId,
+        seasonId: season.id,
+        dateTypeId: dateType.id,
+      },
+      transaction,
+    });
+
+    for (const existingDateRange of existingDateRanges) {
+      const existsInFeatureDates = matchingFeatureDates.some(
+        (item) =>
+          item.start_date === existingDateRange.startDate &&
+          item.end_date === existingDateRange.endDate,
+      );
+
+      if (!existsInFeatureDates) {
+        await existingDateRange.destroy({ transaction });
+
+        dateRangesDeleted++;
+
+        console.log(
+          `${dryRun ? "[DRY RUN] Would delete" : "Deleted"} DateRange for dateableId ${dateableId}, dateTypeId ${dateType.id}, startDate ${existingDateRange.startDate}, endDate ${existingDateRange.endDate}`,
+        );
+      }
+    }
+
+    // Update DateRangeAnnual records based on the is_date_annual field in the matchingFeatureDates
+    const isDateAnnual = matchingFeatureDates[0]?.is_date_annual ?? false;
+
+    const dateRangeAnnual = await DateRangeAnnual.findOne({
+      where: {
+        publishableId,
+        dateableId,
+        dateTypeId: dateType.id,
+      },
+      transaction,
+    });
+
+    if (isDateAnnual !== dateRangeAnnual?.isDateRangeAnnual) {
+      if (!dateRangeAnnual) {
+        // create the DateRangeAnnual record if it doesn't exist
+        await DateRangeAnnual.create(
+          {
+            publishableId,
+            dateableId,
+            dateTypeId: dateType.id,
+            isDateRangeAnnual: isDateAnnual,
+          },
+          { transaction },
+        );
+
+        dateRangeAnnualsAdded++;
+
+        console.log(
+          `${dryRun ? "[DRY RUN] Would create" : "Created"} new DateRangeAnnual for publishableId ${publishableId}, dateableId ${dateableId}, dateTypeId ${dateType.id}, isDateRangeAnnual ${isDateAnnual}`,
+        );
+      } else {
+        // update the DateRangeAnnual record if it exists
+        dateRangeAnnual.isDateRangeAnnual = isDateAnnual;
+        await dateRangeAnnual.save({ transaction });
+
+        dateRangeAnnualsUpdated++;
+
+        console.log(
+          `${dryRun ? "[DRY RUN] Would update" : "Updated"} DateRangeAnnual for publishableId ${publishableId}, dateableId ${dateableId}, dateTypeId ${dateType.id}, isDateRangeAnnual ${isDateAnnual}`,
+        );
+      }
+    }
+  }
+
+  if (dryRun) {
+    await transaction.rollback();
+    console.log("\n[DRY RUN] Changes rolled back.");
+  } else {
+    await transaction.commit();
+  }
+
+  console.log(`\n${dryRun ? "[DRY RUN] " : ""}Strapi feature date import complete!
+
+Seasons added:            ${seasonsAdded}
+DateRanges added:         ${dateRangesAdded}
+DateRanges deleted:       ${dateRangesDeleted}
+DateRangeAnnuals added:   ${dateRangeAnnualsAdded}
+DateRangeAnnuals updated: ${dateRangeAnnualsUpdated}`);
+} catch (error) {
+  await transaction.rollback();
+  console.error("Import failed:", error);
+  throw error;
+}

--- a/backend/tasks/import-2026-strapi-dates/import-2026-strapi-protected-area-dates.js
+++ b/backend/tasks/import-2026-strapi-dates/import-2026-strapi-protected-area-dates.js
@@ -1,0 +1,286 @@
+// This script is used to overwrite the existing DateRange and DateRangeAnnual data
+// in the db with the data from Strapi for the operatingYears 2026 and onward. It is
+// intended to be run as a one-time operation to update the database with records that
+// were manually edited in Strapi after they were published to Strapi from DOOT.
+
+import "../../env.js";
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  DateType,
+  Park,
+  Season,
+  DateRange,
+  DateRangeAnnual,
+  Publishable,
+  Dateable,
+} from "../../models/index.js";
+import * as SEASON_TYPE from "../../constants/seasonType.js";
+import * as DATE_TYPE from "../../constants/dateType.js";
+import * as SEASON_STATUS from "../../constants/seasonStatus.js";
+
+const filename = fileURLToPath(import.meta.url);
+const dirname = path.dirname(filename);
+
+// Set to true to preview changes without writing to the database
+const dryRun = false;
+
+const protectedAreaDates = JSON.parse(
+  fs.readFileSync(path.join(dirname, "protected-area-dates.json"), "utf8"),
+);
+
+// get a list of unique orcs, date_type_id and operating_year combos from the protectedArea data
+const uniqueProtectedAreaDateKeys = [
+  ...new Map(
+    protectedAreaDates.map((item) => [
+      `${item.orcs}-${item.date_type_id}-${item.operating_year}`,
+      {
+        orcs: String(item.orcs),
+        dateTypeNumber: item.date_type_id,
+        operatingYear: item.operating_year,
+      },
+    ]),
+  ).values(),
+];
+
+let seasonsAdded = 0;
+let dateRangesAdded = 0;
+let dateRangesDeleted = 0;
+let dateRangeAnnualsAdded = 0;
+let dateRangeAnnualsUpdated = 0;
+
+const transaction = await Season.sequelize.transaction();
+
+try {
+  // for each key in uniqueProtectedAreaDateKeys, find the list of corresponding DateRange records in the database and check if they match the JSON data.
+  for (const key of uniqueProtectedAreaDateKeys) {
+    const { orcs, dateTypeNumber, operatingYear } = key;
+
+    // find the corresponding DateType record in the database
+    const dateType = await DateType.findOne({
+      where: { dateTypeNumber },
+      transaction,
+    });
+
+    if (!dateType) {
+      console.error(
+        `No DateType found for date_type_id ${dateTypeNumber}. Skipping...`,
+      );
+      continue;
+    }
+
+    // find the corresponding Park record in the database
+    const park = await Park.findOne({
+      where: { orcs },
+      transaction,
+    });
+
+    if (!park) {
+      console.error(`No Park found for orcs ${orcs}. Skipping...`);
+      continue;
+    }
+
+    let dateableId = park.dateableId;
+
+    // If dateableId is null, create one for the park
+    if (!dateableId) {
+      const dateable = await Dateable.create({}, { transaction });
+
+      dateableId = dateable.id;
+      park.dateableId = dateableId;
+      await park.save({ transaction });
+
+      console.log(
+        `${dryRun ? "[DRY RUN] Would create" : "Created"} dateableId for park ${orcs}: ${dateableId}`,
+      );
+    }
+
+    let publishableId = park.publishableId;
+
+    // If publishableId is null, create one for the park
+    if (!publishableId) {
+      const publishable = await Publishable.create({}, { transaction });
+
+      publishableId = publishable.id;
+      park.publishableId = publishableId;
+      await park.save({ transaction });
+
+      console.log(
+        `${dryRun ? "[DRY RUN] Would create" : "Created"} publishableId for park ${orcs}: ${publishableId}`,
+      );
+    }
+
+    const seasonType =
+      dateTypeNumber === DATE_TYPE.WINTER_FEE
+        ? SEASON_TYPE.WINTER
+        : SEASON_TYPE.REGULAR;
+
+    // get the season for the publishableId, operatingYear and seasonType
+    let season = await Season.findOne({
+      where: {
+        publishableId,
+        operatingYear,
+        seasonType,
+      },
+      transaction,
+    });
+
+    if (!season) {
+      // create the Season record if it doesn't exist
+      season = await Season.create(
+        {
+          publishableId,
+          operatingYear,
+          seasonType,
+          status: SEASON_STATUS.PUBLISHED,
+          readyToPublish: true,
+        },
+        { transaction },
+      );
+
+      seasonsAdded++;
+
+      console.log(
+        `${dryRun ? "[DRY RUN] Would create" : "Created"} new Season for publishableId ${publishableId}, operatingYear ${operatingYear}, seasonType ${seasonType}`,
+      );
+    }
+
+    // filter protectedAreaDates to find all records that match the current key
+    const matchingProtectedAreaDates = protectedAreaDates.filter(
+      (item) =>
+        String(item.orcs) === orcs &&
+        item.date_type_id === dateTypeNumber &&
+        item.operating_year === operatingYear,
+    );
+
+    // for each matchingProtectedAreaDate, check if a DateRange record exists in the database
+    for (const protectedAreaDate of matchingProtectedAreaDates) {
+      const { start_date: startDate, end_date: endDate } = protectedAreaDate;
+
+      // find the corresponding DateRange record in the database
+      const dateRange = await DateRange.findOne({
+        where: {
+          dateableId,
+          dateTypeId: dateType.id,
+          seasonId: season.id,
+          startDate,
+          endDate,
+        },
+        transaction,
+      });
+
+      if (!dateRange) {
+        // create the DateRange record if it doesn't exist
+        await DateRange.create(
+          {
+            dateableId,
+            dateTypeId: dateType.id,
+            seasonId: season.id,
+            startDate,
+            endDate,
+          },
+          { transaction },
+        );
+
+        dateRangesAdded++;
+
+        console.log(
+          `${dryRun ? "[DRY RUN] Would create" : "Created"} new DateRange for dateableId ${dateableId}, dateTypeId ${dateType.id}, startDate ${startDate}, endDate ${endDate}`,
+        );
+      }
+    }
+
+    // delete any DateRange records that exist in the database for this dateableId, seasonId and dateTypeId
+    // that are not in the matchingProtectedAreaDates
+    const existingDateRanges = await DateRange.findAll({
+      where: {
+        dateableId,
+        seasonId: season.id,
+        dateTypeId: dateType.id,
+      },
+      transaction,
+    });
+
+    for (const existingDateRange of existingDateRanges) {
+      const existsInProtectedAreaDates = matchingProtectedAreaDates.some(
+        (item) =>
+          item.start_date === existingDateRange.startDate &&
+          item.end_date === existingDateRange.endDate,
+      );
+
+      if (!existsInProtectedAreaDates) {
+        await existingDateRange.destroy({ transaction });
+
+        dateRangesDeleted++;
+
+        console.log(
+          `${dryRun ? "[DRY RUN] Would delete" : "Deleted"} DateRange for dateableId ${dateableId}, dateTypeId ${dateType.id}, startDate ${existingDateRange.startDate}, endDate ${existingDateRange.endDate}`,
+        );
+      }
+    }
+
+    // Update DateRangeAnnual records based on the is_date_annual field in the matchingProtectedAreaDates
+    const isDateAnnual = matchingProtectedAreaDates[0]?.is_date_annual ?? false;
+
+    const dateRangeAnnual = await DateRangeAnnual.findOne({
+      where: {
+        publishableId,
+        dateableId,
+        dateTypeId: dateType.id,
+      },
+      transaction,
+    });
+
+    if (isDateAnnual !== dateRangeAnnual?.isDateRangeAnnual) {
+      if (!dateRangeAnnual) {
+        // create the DateRangeAnnual record if it doesn't exist
+        await DateRangeAnnual.create(
+          {
+            publishableId,
+            dateableId,
+            dateTypeId: dateType.id,
+            isDateRangeAnnual: isDateAnnual,
+          },
+          { transaction },
+        );
+
+        dateRangeAnnualsAdded++;
+
+        console.log(
+          `${dryRun ? "[DRY RUN] Would create" : "Created"} new DateRangeAnnual for publishableId ${publishableId}, dateableId ${dateableId}, dateTypeId ${dateType.id}, isDateRangeAnnual ${isDateAnnual}`,
+        );
+      } else {
+        // update the DateRangeAnnual record if it exists
+        dateRangeAnnual.isDateRangeAnnual = isDateAnnual;
+        await dateRangeAnnual.save({ transaction });
+
+        dateRangeAnnualsUpdated++;
+
+        console.log(
+          `${dryRun ? "[DRY RUN] Would update" : "Updated"} DateRangeAnnual for publishableId ${publishableId}, dateableId ${dateableId}, dateTypeId ${dateType.id}, isDateRangeAnnual ${isDateAnnual}`,
+        );
+      }
+    }
+  }
+
+  if (dryRun) {
+    await transaction.rollback();
+    console.log("\n[DRY RUN] Changes rolled back.");
+  } else {
+    await transaction.commit();
+  }
+
+  console.log(`\n${dryRun ? "[DRY RUN] " : ""}Strapi protected-area date import complete!
+
+Seasons added:            ${seasonsAdded}
+DateRanges added:         ${dateRangesAdded}
+DateRanges deleted:       ${dateRangesDeleted}
+DateRangeAnnuals added:   ${dateRangeAnnualsAdded}
+DateRangeAnnuals updated: ${dateRangeAnnualsUpdated}`);
+} catch (error) {
+  await transaction.rollback();
+  console.error("Import failed:", error);
+  throw error;
+}

--- a/backend/tasks/import-2026-strapi-dates/protected-area-dates.json
+++ b/backend/tasks/import-2026-strapi-dates/protected-area-dates.json
@@ -1,0 +1,42 @@
+[
+  {
+    "date_type_id": 1,
+    "orcs": 96,
+    "is_date_annual": true,
+    "operating_year": 2026,
+    "start_date": "2026-01-01",
+    "end_date": "2026-12-31"
+  },
+  {
+    "date_type_id": 1,
+    "orcs": 211,
+    "is_date_annual": true,
+    "operating_year": 2026,
+    "start_date": "2026-01-01",
+    "end_date": "2026-12-31"
+  },
+  {
+    "date_type_id": 1,
+    "orcs": 263,
+    "is_date_annual": true,
+    "operating_year": 2026,
+    "start_date": "2026-01-01",
+    "end_date": "2026-12-31"
+  },
+  {
+    "date_type_id": 1,
+    "orcs": 292,
+    "is_date_annual": true,
+    "operating_year": 2026,
+    "start_date": "2026-01-01",
+    "end_date": "2026-12-31"
+  },
+  {
+    "date_type_id": 1,
+    "orcs": 530,
+    "is_date_annual": true,
+    "operating_year": 2026,
+    "start_date": "2026-01-01",
+    "end_date": "2026-12-31"
+  }
+]

--- a/backend/tasks/import-2026-strapi-dates/protected-area-dates.json
+++ b/backend/tasks/import-2026-strapi-dates/protected-area-dates.json
@@ -2,6 +2,7 @@
   {
     "date_type_id": 1,
     "orcs": 96,
+    "name": "96: 2026 - Gate",
     "is_date_annual": true,
     "operating_year": 2026,
     "start_date": "2026-01-01",
@@ -10,6 +11,7 @@
   {
     "date_type_id": 1,
     "orcs": 211,
+    "name": "211: 2026 - Gate",
     "is_date_annual": true,
     "operating_year": 2026,
     "start_date": "2026-01-01",
@@ -18,6 +20,7 @@
   {
     "date_type_id": 1,
     "orcs": 263,
+    "name": "263: 2026 - Gate",
     "is_date_annual": true,
     "operating_year": 2026,
     "start_date": "2026-01-01",
@@ -26,6 +29,7 @@
   {
     "date_type_id": 1,
     "orcs": 292,
+    "name": "292: 2026 - Gate",
     "is_date_annual": true,
     "operating_year": 2026,
     "start_date": "2026-01-01",
@@ -34,6 +38,7 @@
   {
     "date_type_id": 1,
     "orcs": 530,
+    "name": "530: 2026 - Gate",
     "is_date_annual": true,
     "operating_year": 2026,
     "start_date": "2026-01-01",


### PR DESCRIPTION
### Jira Tickets

CMS-1870
CMS-1858

### Description
Reverse syncs operating year 2026+ dates that were modified in Strapi back into DOOT. Intended as a one-time operation in late August or early September 2026, before 2027 date collection begins.

Two scripts handle different entity types: `import-2026-strapi-feature-dates.js` syncs feature-level date ranges, and `import-2026-strapi-protected-area-dates.js` syncs park-level date ranges.

The scripts create `Publishable` and `Dateable` records if missing, create missing `Season` records for the operating year, sync `DateRange` record from JSON data by creating new records and deleting orphaned ones, and create or update `DateRangeAnnual` records based on the `is_date_annual` flag. All changes are wrapped in a transaction and rolled back on error.

Data files `feature-dates.json` and `protected-area-dates.json` are included in the task folder as JSON files rather than fetched from the Strapi REST API because the API does not expose `created_by_id` and `updated_by_id`, which are central to the sync logic.

Dry-run mode is available by setting `const dryRun = true;` at the top of either script to preview changes without writing to the database.

