### PR TITLE
CMS-1838: Disable draft button when editing previous years

### DIFF
--- a/frontend/src/components/FormPanel.jsx
+++ b/frontend/src/components/FormPanel.jsx
@@ -61,17 +61,16 @@ function Buttons({
   approver,
   submitter,
   loading = false,
-  disableButtons = false,
+  disableDraftButton = false,
+  disablePrimaryActionButton = false,
 }) {
-  const isDisabled = loading || disableButtons;
-
   return (
     <div>
       <button
         type="button"
         onClick={onSave}
         className="btn btn-outline-primary form-btn fw-bold me-3"
-        disabled={isDisabled}
+        disabled={loading || disableDraftButton}
       >
         Save draft
       </button>
@@ -82,7 +81,7 @@ function Buttons({
           type="button"
           onClick={onApprove}
           className="btn btn-primary form-btn fw-bold me-2"
-          disabled={isDisabled}
+          disabled={loading || disablePrimaryActionButton}
         >
           Mark approved
         </button>
@@ -94,7 +93,7 @@ function Buttons({
           type="button"
           onClick={onSubmit}
           className="btn btn-primary form-btn fw-bold me-2"
-          disabled={isDisabled}
+          disabled={loading || disablePrimaryActionButton}
         >
           Submit to HQ
         </button>
@@ -113,7 +112,8 @@ Buttons.propTypes = {
   approver: PropTypes.bool.isRequired,
   submitter: PropTypes.bool.isRequired,
   loading: PropTypes.bool,
-  disableButtons: PropTypes.bool,
+  disableDraftButton: PropTypes.bool,
+  disablePrimaryActionButton: PropTypes.bool,
 };
 
 function SeasonForm({
@@ -462,7 +462,8 @@ function SeasonForm({
   }, [season, changesPayload, apiData]);
 
   // In the Edit published page, buttons should only be enabled after edits are made
-  const disableButtons = showOperatingYearSelect && !dataChanged;
+  const disablePrimaryActionButton = showOperatingYearSelect && !dataChanged;
+  const disableDraftButton = showOperatingYearSelect;
 
   // Update the parent component when dataChanged is updated
   useEffect(() => {
@@ -820,7 +821,9 @@ If dates have already been published, they will not be updated until new dates a
             onSave={() => promptAndSave(false)}
             onSubmit={onSubmit}
             loading={sendingSave}
-            disableButtons={disableButtons}
+            disableDraftButton={disableDraftButton}
+            disableApproveButton={disablePrimaryActionButton}
+            disableSubmitButton={disablePrimaryActionButton}
           />
         </Offcanvas.Body>
       </ValidationContext.Provider>

--- a/frontend/src/components/FormPanel.jsx
+++ b/frontend/src/components/FormPanel.jsx
@@ -461,7 +461,7 @@ function SeasonForm({
     return changesPayload.notes.length > 0;
   }, [season, changesPayload, apiData]);
 
-  // In the Edit published page, buttons should only be enabled after edits are made
+  // When editing published dates: primary action only enabled after changes; draft button always disabled
   const disablePrimaryActionButton = showOperatingYearSelect && !dataChanged;
   const disableDraftButton = showOperatingYearSelect;
 
@@ -822,8 +822,7 @@ If dates have already been published, they will not be updated until new dates a
             onSubmit={onSubmit}
             loading={sendingSave}
             disableDraftButton={disableDraftButton}
-            disableApproveButton={disablePrimaryActionButton}
-            disableSubmitButton={disablePrimaryActionButton}
+            disablePrimaryActionButton={disablePrimaryActionButton}
           />
         </Offcanvas.Body>
       </ValidationContext.Provider>


### PR DESCRIPTION
### Jira Ticket

CMS-1838

### Description
FIX: Updated the form according to UX comments in the Jira ticket so the draft button is always disabled when a previous year is being edited.  

