### PR TITLE
CMS-1844: Await fetch before opening notes panel

### DIFF
--- a/frontend/src/components/InternalNotesRow.jsx
+++ b/frontend/src/components/InternalNotesRow.jsx
@@ -33,18 +33,20 @@ export default function InternalNotesRow({ seasonId }) {
 
   // Toggles the open state and fetches notes if opening for the first time
   async function toggleOpen() {
-    const openingRow = !isOpen;
-
-    setIsOpen(openingRow);
-
-    if (openingRow && !hasRequestedNotes) {
+    if (!isOpen && !hasRequestedNotes) {
+      // If the notes data isn't loaded yet, load it and then open the notes
       try {
         await fetchData();
         setHasRequestedNotes(true);
+        setIsOpen(true);
       } catch {
         // Keep this false so collapsing and reopening retries the request.
         setHasRequestedNotes(false);
+        console.error("Failed to fetch internal notes for season", seasonId);
       }
+    } else {
+      // If the notes data is already loaded, just toggle the open state
+      setIsOpen((prev) => !prev);
     }
   }
 
@@ -60,15 +62,7 @@ export default function InternalNotesRow({ seasonId }) {
             eventKey="internal-notes"
           >
             <>
-              {loading && <p className="mb-0 text-muted">Loading notes...</p>}
-
-              {!loading && error && (
-                <p className="mb-0 text-danger">
-                  Unable to load internal notes.
-                </p>
-              )}
-
-              {!loading && !error && visibleNotes.length > 0 && (
+              {visibleNotes.length > 0 && (
                 <ul className="list-unstyled">
                   {visibleNotes.map((note) => (
                     <li key={note.id}>
@@ -81,16 +75,17 @@ export default function InternalNotesRow({ seasonId }) {
                 </ul>
               )}
 
-              {!loading &&
-                !error &&
-                hasRequestedNotes &&
-                visibleNotes.length === 0 && (
-                  <p className="mb-0 text-muted">
-                    No internal notes found for this season.
-                  </p>
-                )}
+              {!error && hasRequestedNotes && visibleNotes.length === 0 && (
+                <p className="mb-0 text-muted">
+                  No internal notes found for this season.
+                </p>
+              )}
             </>
           </Accordion.Collapse>
+
+          {!loading && error && (
+            <p className="mb-0 text-danger">Unable to load internal notes.</p>
+          )}
 
           <button
             type="button"
@@ -98,12 +93,26 @@ export default function InternalNotesRow({ seasonId }) {
             onClick={toggleOpen}
             aria-expanded={isOpen}
             aria-controls={`internal-notes-${seasonId}`}
+            disabled={loading}
           >
-            {isOpen ? "Hide internal notes" : "Show internal notes"}
-            <FontAwesomeIcon
-              icon={isOpen ? faChevronUp : faChevronDown}
-              className="ms-2"
-            />
+            {loading ? (
+              <>
+                Loading internal notes...
+                <span
+                  className="spinner-border spinner-border-sm ms-2"
+                  role="status"
+                  aria-hidden="true"
+                />
+              </>
+            ) : (
+              <>
+                {isOpen ? "Hide internal notes" : "Show internal notes"}
+                <FontAwesomeIcon
+                  icon={isOpen ? faChevronUp : faChevronDown}
+                  className="ms-2"
+                />
+              </>
+            )}
           </button>
         </Accordion>
       </td>

--- a/frontend/src/components/InternalNotesRow.jsx
+++ b/frontend/src/components/InternalNotesRow.jsx
@@ -100,7 +100,6 @@ export default function InternalNotesRow({ seasonId }) {
                 Loading internal notes...
                 <span
                   className="spinner-border spinner-border-sm ms-2"
-                  role="status"
                   aria-hidden="true"
                 />
               </>

--- a/frontend/src/components/InternalNotesRow.jsx
+++ b/frontend/src/components/InternalNotesRow.jsx
@@ -39,10 +39,11 @@ export default function InternalNotesRow({ seasonId }) {
         await fetchData();
         setHasRequestedNotes(true);
         setIsOpen(true);
-      } catch {
+      } catch (apiError) {
         // Keep this false so collapsing and reopening retries the request.
         setHasRequestedNotes(false);
         console.error("Failed to fetch internal notes for season", seasonId);
+        console.error(apiError);
       }
     } else {
       // If the notes data is already loaded, just toggle the open state


### PR DESCRIPTION
### Jira Ticket

CMS-1844

### Description
<!-- What did you change, and why? -->

Small change on the main table:

The "Show internal notes" panel was opening immediately on click, before the content loaded in. The height of the accordion changed when the content loaded during the transition, and the animation looked odd. I updated the logic a bit to await the data before opening the panel.

Now the accordion panel won't open until the data is loaded, so I moved the error message and loading message out of the panel.

There's still no guarantee that the content will be loaded into the DOM before the animation starts, but I think it should be fine. If it's still causing problems anywhere, we can try a `useLayoutEffect` 🤔 