### PR TITLE
CMS-1836: QA fixes to the "Edit published" results table

### DIFF
--- a/backend/routes/api/edit-published.js
+++ b/backend/routes/api/edit-published.js
@@ -1,4 +1,5 @@
 import { Router } from "express";
+import asyncHandler from "express-async-handler";
 import { Season } from "../../models/index.js";
 import * as USER_ROLES from "../../constants/userRoles.js";
 import { checkPermissions } from "../../middleware/permissions.js";
@@ -11,7 +12,7 @@ const router = Router();
 router.get(
   "/",
   checkPermissions([USER_ROLES.APPROVER]),
-  async (req, res, next) => {
+  asyncHandler(async (req, res, next) => {
     // get the max season (latest operating year) from the db
     const maxSeason = await Season.findOne({
       order: [["operatingYear", "DESC"]],
@@ -30,8 +31,9 @@ router.get(
       operatingYear: previousDateCollectionYear,
     };
 
-    parkRoutes.handle(req, res, next);
-  },
+    return next();
+  }),
+  parkRoutes,
 );
 
 export default router;

--- a/backend/routes/api/edit-published.js
+++ b/backend/routes/api/edit-published.js
@@ -1,23 +1,37 @@
 import { Router } from "express";
-import * as SEASON_STATUS from "../../constants/seasonStatus.js";
+import { Season } from "../../models/index.js";
 import * as USER_ROLES from "../../constants/userRoles.js";
 import { checkPermissions } from "../../middleware/permissions.js";
 import parkRoutes from "./parks.js";
 
 const router = Router();
 
-// Reuse parkRoutes for the Edit published page
-// Get all parks with published seasons for the previous year
-router.get("/", checkPermissions([USER_ROLES.APPROVER]), (req, res, next) => {
-  const minOperatingYear = new Date().getFullYear() - 1;
+// Reuse parkRoutes for the previous-year edit page.
+// Get all parks with seasons for the previous year, regardless of status or seasonType.
+router.get(
+  "/",
+  checkPermissions([USER_ROLES.APPROVER]),
+  async (req, res, next) => {
+    // get the max season (latest operating year) from the db
+    const maxSeason = await Season.findOne({
+      order: [["operatingYear", "DESC"]],
+    });
 
-  req.query = {
-    ...req.query,
-    seasonStatus: SEASON_STATUS.PUBLISHED,
-    operatingYear: minOperatingYear,
-  };
+    // Group site and picnic shelter dates are collected a year before campsite dates
+    // because they open for reservations 12 months in advance. As a result, the highest
+    // operatingYear in the database is one year ahead of the active camping season.
+    const campingDateCollectionYear = maxSeason?.operatingYear
+      ? maxSeason.operatingYear - 1
+      : new Date().getFullYear();
+    const previousDateCollectionYear = campingDateCollectionYear - 1;
 
-  parkRoutes.handle(req, res, next);
-});
+    req.query = {
+      ...req.query,
+      operatingYear: previousDateCollectionYear,
+    };
+
+    parkRoutes.handle(req, res, next);
+  },
+);
 
 export default router;

--- a/frontend/src/components/IconButton.jsx
+++ b/frontend/src/components/IconButton.jsx
@@ -5,18 +5,18 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 export default function IconButton({
   icon,
   label,
-  onClick,
-  textColor,
+  extraClassName,
   loading = false,
   disabled = false,
+  ...props
 }) {
   const isDisabled = disabled || loading;
 
   return (
     <button
+      {...props}
       type="button"
-      onClick={onClick}
-      className={classNames("btn btn-text text-link", textColor)}
+      className={classNames("btn btn-text text-link", extraClassName)}
       disabled={isDisabled}
     >
       {loading ? (
@@ -33,7 +33,7 @@ IconButton.propTypes = {
   icon: PropTypes.object.isRequired,
   label: PropTypes.string.isRequired,
   onClick: PropTypes.func,
-  textColor: PropTypes.string,
+  extraClassName: PropTypes.string,
   loading: PropTypes.bool,
   disabled: PropTypes.bool,
 };

--- a/frontend/src/components/SubmitPageTable.jsx
+++ b/frontend/src/components/SubmitPageTable.jsx
@@ -175,7 +175,7 @@ function getDisplayGroupedDateRanges(groupedDateRanges, showWinterFeeDates) {
   );
 }
 
-function ApproveButton({ seasonId, status, color = "", onApprove }) {
+function ApproveButton({ seasonId, status, onApprove }) {
   // disable the approve button if a season is already approved, published, or requested by HQ
   const isDisabled = status !== "pending review";
   const { refreshTable } = useContext(RefreshTableContext);
@@ -203,7 +203,6 @@ function ApproveButton({ seasonId, status, color = "", onApprove }) {
     <IconButton
       icon={faCheck}
       label="Approve"
-      textColor={color}
       onClick={approveSeason}
       loading={sendingSave}
       disabled={isDisabled}
@@ -214,7 +213,6 @@ function ApproveButton({ seasonId, status, color = "", onApprove }) {
 ApproveButton.propTypes = {
   seasonId: PropTypes.number.isRequired,
   status: PropTypes.string.isRequired,
-  color: PropTypes.string,
   onApprove: PropTypes.func.isRequired,
 };
 
@@ -226,7 +224,6 @@ function StatusTableRow({
   typeName,
   season,
   formPanelHandler,
-  color,
 }) {
   const flashMessage = useContext(globalFlashMessageContext);
   const isWinterSeason = season.seasonType === SEASON_TYPE.WINTER;
@@ -285,14 +282,12 @@ function StatusTableRow({
             icon={faPen}
             label="Edit"
             onClick={formPanelHandler}
-            textColor={color}
           />
 
           {approver && (
             <ApproveButton
               seasonId={season.id}
               status={season.status}
-              color={color}
               onApprove={onApprove}
             />
           )}
@@ -315,7 +310,6 @@ StatusTableRow.propTypes = {
   typeName: PropTypes.string,
   season: PropTypes.object,
   formPanelHandler: PropTypes.func,
-  color: PropTypes.string,
 };
 
 function FeaturesByFeatureTypeWithAreas({

--- a/frontend/src/router/pages/EditPublishedPage.jsx
+++ b/frontend/src/router/pages/EditPublishedPage.jsx
@@ -40,7 +40,9 @@ export default function EditPublishedPage() {
     if (!selectedPark) return [];
 
     const items = [];
-    const targetOperatingYear = new Date().getFullYear() - 1;
+    const targetOperatingYear = Math.min(
+      ...selectedPark.seasons.map((s) => s.operatingYear),
+    );
 
     // Find a season by year and type
     function getSeasonByYear(seasons = [], seasonType = SEASON_TYPE.REGULAR) {

--- a/frontend/src/router/pages/EditPublishedPage.jsx
+++ b/frontend/src/router/pages/EditPublishedPage.jsx
@@ -169,7 +169,20 @@ export default function EditPublishedPage() {
                   </thead>
                   <tbody>
                     {parkItems.map((item) => (
-                      <tr key={item.id} className={`table-row--${item.level}`}>
+                      <tr
+                        key={item.id}
+                        className="table-row--clickable"
+                        onClick={() => handleOpenFormPanel(item)}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter" || e.key === " ") {
+                            e.preventDefault();
+                            handleOpenFormPanel(item);
+                          }
+                        }}
+                        tabIndex={0}
+                        role="button"
+                        aria-label={`Edit ${item.name}`}
+                      >
                         <th className="align-middle">
                           {item.name}
                           {item.typeName && (
@@ -179,11 +192,7 @@ export default function EditPublishedPage() {
                           )}
                         </th>
                         <td className="align-middle text-end">
-                          <IconButton
-                            icon={faPen}
-                            label="Edit"
-                            onClick={() => handleOpenFormPanel(item)}
-                          />
+                          <IconButton icon={faPen} label="Edit" tabIndex={-1} />
                         </td>
                       </tr>
                     ))}

--- a/frontend/src/router/pages/EditPublishedPage.scss
+++ b/frontend/src/router/pages/EditPublishedPage.scss
@@ -1,19 +1,30 @@
 .page.edit-published {
   table {
-    tr.table-row {
-      &--park {
-        th,
-        td {
-          background-color: var(--surface-color-secondary-button-hover);
-        }
+    tr.table-row--clickable {
+      cursor: pointer;
+
+      th,
+      td {
+        border-bottom: 1px solid var(--surface-color-border-default);
       }
-      &--park-area,
-      &--park-area-feature,
-      &--feature {
-        th,
-        td {
-          background-color: var(--bs-table-bg);
-        }
+
+      &:active th,
+      &:active td {
+        background-color: var(--surface-color-secondary-pressed);
+      }
+
+      &:hover th,
+      &:hover td,
+      &:focus-visible th,
+      &:focus-visible td {
+        background-color: var(--surface-color-secondary-button-hover);
+      }
+    }
+
+    tr.table-row {
+      th,
+      td {
+        background-color: var(--bs-table-bg);
       }
     }
   }


### PR DESCRIPTION
### Jira Ticket

CMS-1836

### Description

This PR addresses issues reported by QA:

1. Updated table rows to look and behave like BCGov secondary buttons.
2. Removed the default grey background from the "Tiers and Gate" row. The Figma design was showing a hover state rather than the intended default state.
3. Refined backend filtering for the "Edit Published" screen. The screen is intended to display all parks, park-areas and features with entries from the previous date collection period regardless of publishing status. The year calculation was also problematic because the "current date collection year" is arbitrarily determined by when the `tasks/create-seasons/create-seasons.js` script is run; it cannot be determined from the current calendar year alone.
4. Refactored IconButton so it would accept a `tabIndex={-1}` prop via a spread operator. Also removed an unused `textColor` prop from IconButton and a corresponding `color` prop from ApproveButton and StatusTableRow.  This prop wasn't being used and it was actually expecting a classname rather than a color string. It was replaced with extraClassName in IconButton which is less confusing. 