### PR TITLE
CMS-1963: Prevent form revalidation while the panel is closing

### DIFF
--- a/frontend/src/components/FormPanel.jsx
+++ b/frontend/src/components/FormPanel.jsx
@@ -502,13 +502,8 @@ function SeasonForm({
       );
     }
 
-    // Clone the payload
-    const payload = { ...changesPayload };
-
-    // Override status if provided
-    if (status) {
-      payload.status = status;
-    }
+    // Clone the payload, and override the status with the provided value.
+    const payload = { ...changesPayload, status };
 
     // Update isDateRangeAnnual for "Park gate open" date if gateDetail.hasGate is false
     if (

--- a/frontend/src/components/FormPanel.jsx
+++ b/frontend/src/components/FormPanel.jsx
@@ -472,16 +472,12 @@ function SeasonForm({
 
   /**
    * Saves the form data to the DB.
-   * @param {boolean} close closes the form panel
    * @param {boolean} allowInvalid allows saving even if the form has validation errors
-   * @param {string} status optional status to set for the season
+   * @param {string} status status to set for the season
+   * @param {boolean} [resetDataAfterSave=true] reset the form data after saving
    * @returns {Promise<void>}
    */
-  async function saveForm(
-    close = true,
-    allowInvalid = false,
-    status = STATUS.REQUESTED.value,
-  ) {
+  async function saveForm(allowInvalid, status, resetDataAfterSave = true) {
     // saveForm is called on any kind of form submission, so validation happens here
     // If the form is submitted by some other means, call the validation function there too
     setSubmitted(true);
@@ -559,9 +555,7 @@ function SeasonForm({
       setDeletedDateRangeIds([]);
       setSubmitWithErrors(false);
 
-      if (close) {
-        closePanel();
-      } else {
+      if (resetDataAfterSave) {
         resetData();
       }
     } catch (saveError) {
@@ -573,7 +567,7 @@ function SeasonForm({
 
   // If the season is not "requested" (e.g. it is submitted, approved, or published),
   // prompt the user to confirm moving back to draft.
-  async function promptAndSave(close = true) {
+  async function promptAndSave() {
     if (season.status !== STATUS.REQUESTED.value) {
       const proceed = await modal.open(
         "Move back to draft?",
@@ -592,7 +586,7 @@ If dates have already been published, they will not be updated until new dates a
 
     try {
       // Save draft, and allow saving with validation errors
-      await saveForm(close, true, STATUS.REQUESTED.value);
+      await saveForm(true, STATUS.REQUESTED.value);
 
       flashMessage.open(
         "Dates saved as draft",
@@ -606,7 +600,8 @@ If dates have already been published, they will not be updated until new dates a
   async function onApprove() {
     try {
       // Save and update status, bypassing validation errors if the user has checked the "Submit with errors" checkbox
-      await saveForm(false, allowSubmitWithErrors, STATUS.APPROVED.value); // Don't close the form after saving
+      // Don't reset the form data after saving, because the panel will close
+      await saveForm(allowSubmitWithErrors, STATUS.APPROVED.value, false);
 
       // Start refreshing the main page data from the API
       onDataUpdate();
@@ -625,7 +620,8 @@ If dates have already been published, they will not be updated until new dates a
   async function onSubmit() {
     try {
       // Save and update status, bypassing validation errors if the user has checked the "Submit with errors" checkbox
-      await saveForm(false, allowSubmitWithErrors, STATUS.PENDING_REVIEW.value); // Don't close the form after saving
+      // Don't reset the form data after saving, because the panel will close
+      await saveForm(allowSubmitWithErrors, STATUS.PENDING_REVIEW.value, false);
 
       // Start refreshing the main page data from the API
       onDataUpdate();
@@ -818,7 +814,7 @@ If dates have already been published, they will not be updated until new dates a
             approver={approver}
             submitter={submitter}
             onApprove={onApprove}
-            onSave={() => promptAndSave(false)}
+            onSave={promptAndSave}
             onSubmit={onSubmit}
             loading={sendingSave}
             disableDraftButton={disableDraftButton}

--- a/frontend/src/components/FormPanel.jsx
+++ b/frontend/src/components/FormPanel.jsx
@@ -603,9 +603,6 @@ If dates have already been published, they will not be updated until new dates a
       // Don't reset the form data after saving, because the panel will close
       await saveForm(allowSubmitWithErrors, STATUS.APPROVED.value, false);
 
-      // Start refreshing the main page data from the API
-      onDataUpdate();
-
       flashMessage.open(
         "Dates approved",
         `${seasonTitle} ${season.operatingYear} dates marked as approved`,
@@ -622,9 +619,6 @@ If dates have already been published, they will not be updated until new dates a
       // Save and update status, bypassing validation errors if the user has checked the "Submit with errors" checkbox
       // Don't reset the form data after saving, because the panel will close
       await saveForm(allowSubmitWithErrors, STATUS.PENDING_REVIEW.value, false);
-
-      // Start refreshing the main page data from the API
-      onDataUpdate();
 
       flashMessage.open(
         "Dates submitted to HQ",


### PR DESCRIPTION
### Jira Ticket

CMS-1963

### Description
<!-- What did you change, and why? -->

QA noticed a visual issue with the approval process in the form. After the POST request, the form data would update and validation would re-run. The data would now have the "approved" status, so this message would show while the form was closing (during the animation)
> The dates you are editing have already been approved or published. Please provide a note explaining the reason for this update.

When the user clicks "Submit" or "Approve," the form will close anyway, so there's no need to refresh the data or re-validate it.

Changes:
- Changed the parameters for `saveForm`: `close` was always false so I removed it, and added `resetDataAfterSave`.
- The other optional params for `saveForm` were always being passed so I made them required.
- `promptAndSave` was also passing a `close` parameter (always false) so I removed that too.
- `onApprove` and `onSubmit` now pass `resetDataAfterSave=false` because they call `closePanel` after saving so they don't need to reset.
- `onApprove` and `onSubmit` also called `onDataUpdate` after saving, but it automatically gets called every time in `saveForm` so I removed the duplicated calls.