### PR TITLE
CMS-1837: Fix dates spanning 2 years option bug

### DIFF
--- a/backend/routes/api/parks.js
+++ b/backend/routes/api/parks.js
@@ -462,11 +462,12 @@ router.get(
     const requestedOperatingYear = Number.parseInt(req.query.operatingYear, 10);
     const minAllowedOperatingYear = currentYear - 1;
 
-    // Use currentYear in the Submit page
+    // Use the previous operating year in the Submit page
+    // so we include both the prior season and the current season
     // Use requestedOperatingYear in the Edit published page
     // Clamp to a safe lower bound
     const operatingYear = Number.isNaN(requestedOperatingYear)
-      ? currentYear
+      ? minAllowedOperatingYear
       : Math.max(requestedOperatingYear, minAllowedOperatingYear);
     const seasonStatus =
       typeof req.query.seasonStatus === "string"

--- a/backend/routes/api/parks.js
+++ b/backend/routes/api/parks.js
@@ -462,10 +462,8 @@ router.get(
     const requestedOperatingYear = Number.parseInt(req.query.operatingYear, 10);
     const minAllowedOperatingYear = currentYear - 1;
 
-    // Use the previous operating year in the Submit page
-    // so we include both the prior season and the current season
-    // Use requestedOperatingYear in the Edit published page
-    // Clamp to a safe lower bound
+    // Default to the previous operating year so the response includes both the prior and current seasons.
+    // If an operatingYear is explicitly requested, clamp to a safe lower bound.
     const operatingYear = Number.isNaN(requestedOperatingYear)
       ? minAllowedOperatingYear
       : Math.max(requestedOperatingYear, minAllowedOperatingYear);

--- a/frontend/src/components/OperatingYearSelect.jsx
+++ b/frontend/src/components/OperatingYearSelect.jsx
@@ -9,11 +9,20 @@ export default function OperatingYearSelect({
   loadingSeasonOptions = false,
   onSeasonChange,
 }) {
+  const currentYear = new Date().getFullYear();
+
+  // Filter out seasons that are in the future and hide the current operating year in Edit Published.
+  // e.g. if current year is 2026, exclude operatingYear >= 2026.
+  const editableSeasonOptions = useMemo(
+    () => seasonOptions.filter((option) => option.operatingYear < currentYear),
+    [seasonOptions, currentYear],
+  );
+
   const showOperatingYearRange = useMemo(
     () =>
       season?.seasonType === SEASON_TYPE.WINTER ||
-      Boolean(season?.feature?.datesCanSpan2Years),
-    [season?.seasonType, season?.feature?.datesCanSpan2Years],
+      Boolean(season?.datesCanSpan2Years),
+    [season?.seasonType, season?.datesCanSpan2Years],
   );
 
   const formatOperatingYearLabel = useCallback(
@@ -37,9 +46,9 @@ export default function OperatingYearSelect({
           onSeasonChange(nextSeasonId);
         }}
         className="ms-0 ms-sm-3 mb-2"
-        disabled={loadingSeasonOptions || seasonOptions.length === 0}
+        disabled={loadingSeasonOptions || editableSeasonOptions.length === 0}
       >
-        {seasonOptions.map((option) => (
+        {editableSeasonOptions.map((option) => (
           <option key={option.id} value={option.id}>
             {formatOperatingYearLabel(option.operatingYear)}
           </option>
@@ -53,9 +62,7 @@ OperatingYearSelect.propTypes = {
   season: PropTypes.shape({
     id: PropTypes.number,
     seasonType: PropTypes.string,
-    feature: PropTypes.shape({
-      datesCanSpan2Years: PropTypes.bool,
-    }),
+    datesCanSpan2Years: PropTypes.bool,
   }),
   seasonOptions: PropTypes.arrayOf(
     PropTypes.shape({


### PR DESCRIPTION
### Jira Ticket

CMS-1837

### Description
<!-- What did you change, and why? -->
- For the first bug
  - Display the 2 years spanning as a option in the dropdown
- For the second bug
  - Limit the operating year option within the past (operatingYear < 2026.)
- For the third bug
  - The bug made it look like random data was being populated in the past season form, even though the Submit table showed "Not provided." However, that behavior was actually a bug. The form should display the previous season's dates when they are available, and those dates should also be populated in the past season form.
  - Updated the operating year at `/parks` endpoint