### PR TITLE
CMS-1878: Include sourceDateRangeId in publish payload

### DIFF
--- a/backend/routes/api/publish.js
+++ b/backend/routes/api/publish.js
@@ -370,7 +370,7 @@ function formatDate(date) {
 async function formatDateRanges(entity, season) {
   // Fetch all date ranges for this season
   const dateRangesRows = await DateRange.findAll({
-    attributes: ["startDate", "endDate", "dateTypeId"],
+    attributes: ["id", "startDate", "endDate", "dateTypeId"],
 
     where: {
       seasonId: season.id,
@@ -440,6 +440,7 @@ async function formatDateRanges(entity, season) {
     }
 
     return {
+      id: dateRange.id,
       isActive: true, // Must be true if the entity has dates being published
       isDateAnnual,
       startDate: formatDate(dateRange.startDate),


### PR DESCRIPTION
### Jira Ticket

CMS-1878

### Description
This change is to include DateRange.id in the JSON data sent to the Strapi scheduler. 

A related PR has been created in the bcparks.ca repo for the rest of the change: https://github.com/bcgov/bcparks.ca/pull/1905
