### PR TITLE
CMS-1878: Hide winter fee dates when feature.hasWinterFeeDates is false

### DIFF
--- a/backend/routes/api/parks.js
+++ b/backend/routes/api/parks.js
@@ -1,4 +1,4 @@
-import { Op } from "sequelize";
+import { Op, col, where as sqlWhere } from "sequelize";
 import { Router } from "express";
 import _ from "lodash";
 import sequelize from "../../db/connection.js";
@@ -76,6 +76,30 @@ function seasonModel(minYear, required = true, seasonStatus = null) {
 }
 
 /**
+ * Builds Season include config for Feature relations.
+ * Excludes winter seasons when the parent Feature hasWinterFeeDates is false.
+ * @param {number} minYear Minimum operating year to filter seasons by (inclusive)
+ * @param {string|null} [seasonStatus=null] Optional status filter
+ * @returns {Object} Sequelize include config for Feature -> Season
+ */
+function featureSeasonModel(minYear, seasonStatus = null) {
+  return {
+    ...seasonModel(minYear, true, seasonStatus),
+    where: {
+      operatingYear: {
+        [Op.gte]: minYear,
+      },
+      ...(seasonStatus ? { status: seasonStatus } : {}),
+      // SQL-level guard: if a feature has no winter fee dates, exclude winter seasons.
+      [Op.or]: [
+        { seasonType: { [Op.ne]: SEASON_TYPE.WINTER } },
+        sqlWhere(col("features.hasWinterFeeDates"), true),
+      ],
+    },
+  };
+}
+
+/**
  * Builds Sequelize include configuration for Feature model with type and seasons.
  * @param {number} minYear Minimum operating year to filter seasons by (inclusive)
  * @param {Object} [where={}] Additional Sequelize WHERE conditions for features
@@ -108,7 +132,7 @@ function featureModel(minYear, where = {}, seasonStatus = null) {
         attributes: ["id", "featureTypeNumber", "name"],
       },
       // Publishable Seasons for the Feature
-      seasonModel(minYear, false, seasonStatus),
+      featureSeasonModel(minYear, seasonStatus),
     ],
   };
 }

--- a/frontend/src/components/SubmitPageTable.jsx
+++ b/frontend/src/components/SubmitPageTable.jsx
@@ -118,7 +118,6 @@ function DateTableRow({
   groupedDateRanges,
   currentYear,
   showCalculatedDateTypeLabels = false,
-  hasWinterFeeDates = false,
 }) {
   if (!currentYear || !groupedDateRanges) return null;
 
@@ -131,15 +130,6 @@ function DateTableRow({
 
   return sortedDateTypes.map(([dateTypeName, yearsObj]) => {
     const dateTypeNumber = getDateTypeNumber(yearsObj);
-
-    // hasWinterFeeDates flag overrides db dateRange existence
-    if (
-      hasWinterFeeDates === false &&
-      dateTypeNumber === DATE_TYPE.WINTER_FEE
-    ) {
-      return null;
-    }
-
     const showCalculatedDateTypeLabel =
       showCalculatedDateTypeLabels && dateTypeNumber === DATE_TYPE.WINTER_FEE;
 
@@ -167,7 +157,6 @@ DateTableRow.propTypes = {
   groupedDateRanges: PropTypes.object,
   currentYear: PropTypes.number,
   showCalculatedDateTypeLabels: PropTypes.bool,
-  hasWinterFeeDates: PropTypes.bool,
 };
 
 function getDisplayGroupedDateRanges(groupedDateRanges, showWinterFeeDates) {
@@ -382,7 +371,6 @@ function FeaturesByFeatureTypeWithAreas({
                       groupedDateRanges={displayGroupedDateRanges}
                       currentYear={regularSeason.operatingYear}
                       showCalculatedDateTypeLabels={true}
-                      hasWinterFeeDates={parkFeature.hasWinterFeeDates}
                     />
                     {isApprover && regularSeason.hasNotes && (
                       <InternalNotesRow seasonId={regularSeason.id} />
@@ -444,7 +432,6 @@ function FeaturesByFeatureTypeNoAreas({
               groupedDateRanges={displayGroupedDateRanges}
               currentYear={regularSeason.operatingYear}
               showCalculatedDateTypeLabels={true}
-              hasWinterFeeDates={feature.hasWinterFeeDates}
             />
             {isApprover && regularSeason.hasNotes && (
               <InternalNotesRow seasonId={regularSeason.id} />

--- a/frontend/src/components/SubmitPageTable.jsx
+++ b/frontend/src/components/SubmitPageTable.jsx
@@ -118,6 +118,7 @@ function DateTableRow({
   groupedDateRanges,
   currentYear,
   showCalculatedDateTypeLabels = false,
+  hasWinterFeeDates = false,
 }) {
   if (!currentYear || !groupedDateRanges) return null;
 
@@ -130,6 +131,12 @@ function DateTableRow({
 
   return sortedDateTypes.map(([dateTypeName, yearsObj]) => {
     const dateTypeNumber = getDateTypeNumber(yearsObj);
+
+    // hasWinterFeeDates flag overrides db dateRange existence
+    if (!hasWinterFeeDates && dateTypeNumber === DATE_TYPE.WINTER_FEE) {
+      return null;
+    }
+
     const showCalculatedDateTypeLabel =
       showCalculatedDateTypeLabels && dateTypeNumber === DATE_TYPE.WINTER_FEE;
 
@@ -157,6 +164,7 @@ DateTableRow.propTypes = {
   groupedDateRanges: PropTypes.object,
   currentYear: PropTypes.number,
   showCalculatedDateTypeLabels: PropTypes.bool,
+  hasWinterFeeDates: PropTypes.bool,
 };
 
 function getDisplayGroupedDateRanges(groupedDateRanges, showWinterFeeDates) {
@@ -371,6 +379,7 @@ function FeaturesByFeatureTypeWithAreas({
                       groupedDateRanges={displayGroupedDateRanges}
                       currentYear={regularSeason.operatingYear}
                       showCalculatedDateTypeLabels={true}
+                      hasWinterFeeDates={parkFeature.hasWinterFeeDates}
                     />
                     {isApprover && regularSeason.hasNotes && (
                       <InternalNotesRow seasonId={regularSeason.id} />

--- a/frontend/src/components/SubmitPageTable.jsx
+++ b/frontend/src/components/SubmitPageTable.jsx
@@ -133,7 +133,10 @@ function DateTableRow({
     const dateTypeNumber = getDateTypeNumber(yearsObj);
 
     // hasWinterFeeDates flag overrides db dateRange existence
-    if (!hasWinterFeeDates && dateTypeNumber === DATE_TYPE.WINTER_FEE) {
+    if (
+      hasWinterFeeDates === false &&
+      dateTypeNumber === DATE_TYPE.WINTER_FEE
+    ) {
       return null;
     }
 
@@ -441,6 +444,7 @@ function FeaturesByFeatureTypeNoAreas({
               groupedDateRanges={displayGroupedDateRanges}
               currentYear={regularSeason.operatingYear}
               showCalculatedDateTypeLabels={true}
+              hasWinterFeeDates={feature.hasWinterFeeDates}
             />
             {isApprover && regularSeason.hasNotes && (
               <InternalNotesRow seasonId={regularSeason.id} />


### PR DESCRIPTION
### Jira Ticket

CMS-1878

### Description
This change hides the calculated winter fee date row from the table when `feature.hasWinterFeeDates`. The existence of this row is confusing because it is essentially hardcoded in these scenarios with no way to force recalculation.
This scenario typically arises from data that was originally imported from Strapi. 

