### PR TITLE
CMS-1838: Update past seasons option for group camping feature

### DIFF
--- a/backend/routes/api/seasons.js
+++ b/backend/routes/api/seasons.js
@@ -154,6 +154,7 @@ router.get(
       dateTypes: orderedDateTypes,
       icon: seasonModel.feature.featureType.icon,
       featureTypeName: seasonModel.feature.featureType.name,
+      featureTypeNumber: seasonModel.feature.featureType.featureTypeNumber,
       name: seasonModel.feature.name,
       parkName: seasonModel.feature.park.name,
       parkWinterDates,
@@ -252,6 +253,7 @@ router.get(
 
     let icon = null;
     let featureTypeName = null;
+    let featureTypeNumber = null;
 
     // If there are features in the Park Area, use the first feature's type
     if (seasonModel.parkArea.features.length > 0) {
@@ -259,6 +261,7 @@ router.get(
 
       icon = firstFeature.featureType.icon;
       featureTypeName = firstFeature.featureType.name;
+      featureTypeNumber = firstFeature.featureType.featureTypeNumber;
     }
 
     // Get DateRangeAnnuals and GateDetail
@@ -295,6 +298,7 @@ router.get(
       featureDateTypesByFeatureId,
       icon,
       featureTypeName,
+      featureTypeNumber,
       name: seasonModel.parkArea.name,
       parkName: seasonModel.parkArea.park.name,
       parkWinterDates,
@@ -454,6 +458,7 @@ router.get(
       dateTypes: orderedDateTypes,
       icon: null,
       featureTypeName: null,
+      featureTypeNumber: null,
       name: seasonModel.park.name,
       frontcountryFeatureReservationDates:
         await frontcountryFeatureReservationDates,

--- a/backend/routes/api/seasons.js
+++ b/backend/routes/api/seasons.js
@@ -468,6 +468,7 @@ router.get(
   "/options/:seasonId",
   asyncHandler(async (req, res) => {
     const seasonId = Number(req.params.seasonId);
+    const currentYear = new Date().getFullYear();
 
     const currentSeason = await Season.findByPk(seasonId, {
       attributes: ["id", "publishableId", "seasonType"],
@@ -481,7 +482,7 @@ router.get(
       where: {
         publishableId: currentSeason.publishableId,
         seasonType: currentSeason.seasonType,
-        status: STATUS.PUBLISHED,
+        [Op.or]: [{ status: STATUS.PUBLISHED }, { operatingYear: currentYear }],
       },
       order: [["operatingYear", "DESC"]],
     });

--- a/frontend/src/components/FormPanel.jsx
+++ b/frontend/src/components/FormPanel.jsx
@@ -674,7 +674,7 @@ If dates have already been published, they will not be updated until new dates a
               <OperatingYearSelect
                 season={season}
                 seasonOptions={seasonOptions}
-                featureTypeName={seasonMetadata.featureTypeName}
+                featureTypeNumber={seasonMetadata.featureTypeNumber}
                 loadingSeasonOptions={loadingSeasonOptions}
                 onSeasonChange={onSeasonChange}
               />

--- a/frontend/src/components/FormPanel.jsx
+++ b/frontend/src/components/FormPanel.jsx
@@ -674,6 +674,7 @@ If dates have already been published, they will not be updated until new dates a
               <OperatingYearSelect
                 season={season}
                 seasonOptions={seasonOptions}
+                featureTypeName={seasonMetadata.featureTypeName}
                 loadingSeasonOptions={loadingSeasonOptions}
                 onSeasonChange={onSeasonChange}
               />

--- a/frontend/src/components/OperatingYearSelect.jsx
+++ b/frontend/src/components/OperatingYearSelect.jsx
@@ -2,18 +2,20 @@ import { useCallback, useMemo } from "react";
 import Form from "react-bootstrap/Form";
 import PropTypes from "prop-types";
 import * as SEASON_TYPE from "@/constants/seasonType";
+import * as FEATURE_TYPE from "@/constants/featureType";
 
 export default function OperatingYearSelect({
   season = null,
   seasonOptions,
-  featureTypeName = null,
+  featureTypeNumber = null,
   loadingSeasonOptions = false,
   onSeasonChange,
 }) {
   const currentYear = new Date().getFullYear();
+  const normalizedFeatureTypeNumber = Number(featureTypeNumber);
   const allowCurrentYear =
-    featureTypeName === "Group campground" ||
-    featureTypeName === "Picnic shelter";
+    normalizedFeatureTypeNumber === FEATURE_TYPE.GROUP_CAMPGROUND ||
+    normalizedFeatureTypeNumber === FEATURE_TYPE.PICNIC_SHELTER;
 
   // Filter out seasons that are in the future and hide the current operating year in Edit Published.
   // Group campground and Picnic shelter always carry one extra season ahead,
@@ -80,7 +82,7 @@ OperatingYearSelect.propTypes = {
       operatingYear: PropTypes.number.isRequired,
     }),
   ).isRequired,
-  featureTypeName: PropTypes.string,
+  featureTypeNumber: PropTypes.number,
   loadingSeasonOptions: PropTypes.bool,
   onSeasonChange: PropTypes.func.isRequired,
 };

--- a/frontend/src/components/OperatingYearSelect.jsx
+++ b/frontend/src/components/OperatingYearSelect.jsx
@@ -6,16 +6,26 @@ import * as SEASON_TYPE from "@/constants/seasonType";
 export default function OperatingYearSelect({
   season = null,
   seasonOptions,
+  featureTypeName = null,
   loadingSeasonOptions = false,
   onSeasonChange,
 }) {
   const currentYear = new Date().getFullYear();
+  const allowCurrentYear =
+    featureTypeName === "Group campground" ||
+    featureTypeName === "Picnic shelter";
 
   // Filter out seasons that are in the future and hide the current operating year in Edit Published.
-  // e.g. if current year is 2026, exclude operatingYear >= 2026.
+  // Group campground and Picnic shelter always carry one extra season ahead,
+  // so allow the current operating year for those feature types.
   const editableSeasonOptions = useMemo(
-    () => seasonOptions.filter((option) => option.operatingYear < currentYear),
-    [seasonOptions, currentYear],
+    () =>
+      seasonOptions.filter((option) =>
+        allowCurrentYear
+          ? option.operatingYear <= currentYear
+          : option.operatingYear < currentYear,
+      ),
+    [allowCurrentYear, seasonOptions, currentYear],
   );
 
   const showOperatingYearRange = useMemo(
@@ -70,6 +80,7 @@ OperatingYearSelect.propTypes = {
       operatingYear: PropTypes.number.isRequired,
     }),
   ).isRequired,
+  featureTypeName: PropTypes.string,
   loadingSeasonOptions: PropTypes.bool,
   onSeasonChange: PropTypes.func.isRequired,
 };


### PR DESCRIPTION
### Jira Ticket

CMS-1838

### Description
<!-- What did you change, and why? -->
- In the Edit published, added the current operating year option for those feature types (Group campground and Picnic shelter) as they always carry one extra season ahead
