### PR TITLE
CMS-1964: Add role checks back to parks table query

### DIFF
--- a/backend/routes/api/parks.js
+++ b/backend/routes/api/parks.js
@@ -529,27 +529,30 @@ router.get(
           },
           seasonStatus,
         ),
-        {
-          model: AccessGroup,
-          as: "accessGroups",
-          attributes: ["id"],
-          required: !hasAllParkAccess,
-          include: hasAllParkAccess
-            ? []
-            : [
-                {
-                  model: User,
-                  as: "users",
-                  attributes: [],
-                  where: { username: req.user?.username },
-                  through: {
-                    model: UserAccessGroup,
+        ...(hasAllParkAccess
+          ? []
+          : [
+              {
+                model: AccessGroup,
+                as: "accessGroups",
+                attributes: ["id"],
+                through: { attributes: [] },
+                required: true,
+                include: [
+                  {
+                    model: User,
+                    as: "users",
                     attributes: [],
+                    where: { username: req.user?.username },
+                    through: {
+                      model: UserAccessGroup,
+                      attributes: [],
+                    },
+                    required: true,
                   },
-                  required: true,
-                },
-              ],
-        },
+                ],
+              },
+            ]),
       ],
       order: [
         ["name", "ASC"],

--- a/backend/routes/api/parks.js
+++ b/backend/routes/api/parks.js
@@ -495,6 +495,9 @@ router.get(
       typeof req.query.seasonStatus === "string"
         ? req.query.seasonStatus
         : null;
+    const hasAllParkAccess = checkUserRoles(getRolesFromAuth(req.auth), [
+      USER_ROLES.ALL_PARK_ACCESS,
+    ]);
 
     // Main query: Fetch Parks with their Seasons
     const parks = await Park.findAll({
@@ -526,6 +529,27 @@ router.get(
           },
           seasonStatus,
         ),
+        {
+          model: AccessGroup,
+          as: "accessGroups",
+          attributes: ["id"],
+          required: !hasAllParkAccess,
+          include: hasAllParkAccess
+            ? []
+            : [
+                {
+                  model: User,
+                  as: "users",
+                  attributes: [],
+                  where: { username: req.user?.username },
+                  through: {
+                    model: UserAccessGroup,
+                    attributes: [],
+                  },
+                  required: true,
+                },
+              ],
+        },
       ],
       order: [
         ["name", "ASC"],


### PR DESCRIPTION
### Jira Ticket

CMS-1964

### Description
Added back a role check that was accidentally removed in #661.

This fixes the bug "BCP Park Operator can see all parks on DOOT dates management table".

Note: When this is merged into the alpha branch, rename `ALL_PARK_ACCESS` to `DOOT_ALL_PARK_ACCESS`

